### PR TITLE
DOT-812 Allow host to be added back in to a past event

### DIFF
--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -1064,11 +1064,10 @@ class PartyController extends Controller
     public function getGroupEmails($event_id, $object = false)
     {
         $group_user_ids = UserGroups::where('group', Party::find($event_id)->group)
-        ->where('user', '!=', Auth::user()->id)
         ->pluck('user')
         ->toArray();
 
-        // Users already associated with the event.
+        // Users already associated with the event.  Normally this would already include the host.
         // (Not including those invited but not RSVPed)
         $event_user_ids = EventsUsers::where('event', $event_id)
         ->where('user', '!=', Auth::user()->id)

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -201,4 +201,42 @@ class CreateEventTest extends TestCase
             [$coordinator], AdminModerationEvent::class
         );
     }
+
+    /** @test */
+    public function a_host_can_be_added_later()
+    {
+        // Disable discourse integration as this doesn't currently work in a test environment.  We are considering
+        // a better solution.
+        config(['restarters.features.discourse_integration' => false]);
+
+        $this->withoutExceptionHandling();
+
+        $host = factory(User::class)->states('Host')->create();
+        $this->actingAs($host);
+
+        $group = factory(Group::class)->create();
+        $group->addVolunteer($host);
+        $group->makeMemberAHost($host);
+
+        // Create the event
+        $response = $this->get('/party/create');
+        $this->get('/party/create')->assertStatus(200);
+
+        $eventAttributes = factory(Party::class)->raw(['group' => $group->idgroups, 'event_date' => '2000-01-01', 'wordpress_post_id' => '99999']);
+        $response = $this->post('/party/create/', $eventAttributes);
+
+        // Find the event id
+        $party = $group->parties()->first();
+
+        // Remove the host from the event
+        $this->post('/party/remove-volunteer/', [
+            'user_id' => $host->id,
+            'event_id' => $party->idevents
+        ])->assertStatus(200);
+
+        // Assert that we see the host in the list of volunteers to add to the event.
+        $this->get('/party/view/1')->assertSeeInOrder(['Group member', '<option value="' . $host->id . '">', '</div>']);
+
+        config(['restarters.features.discourse_integration' => true]);
+    }
 }


### PR DESCRIPTION
If an event was created, and the host removed, then they cannot be re-added after the event.  

This appeared deliberate, but has been in there since the code was added, and there's nothing in the feature about it.  Normally the host would be excluded by the later code which excludes users already associated with the event, so there's no need to do so explicitly.