### PR TITLE
Forgot password colour

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -16428,9 +16428,10 @@ table.sortable > thead th div.mozilla {
 }
 
 .alert-success {
+  color: #222;
+  border-radius: 0px;
   background-color: #fff4e4;
   border: 3px dashed #222;
-  border-radius: 15px;
   padding: 20px 45px 20px 35px;
   font-size: 16px;
   overflow: hidden;

--- a/resources/assets/sass/_alert.scss
+++ b/resources/assets/sass/_alert.scss
@@ -43,7 +43,7 @@
     }
 
     &-success {
-        background-color: $brand;
+        background-color: #fff4e4;
         border: 3px dashed #222;
         border-radius: 15px;
         padding: 20px 45px 20px 35px;

--- a/resources/assets/sass/_alert.scss
+++ b/resources/assets/sass/_alert.scss
@@ -115,7 +115,7 @@
 }
 
 .information-alert {
-    background-color: $brand;
+    background-color: #fff4e4;
     border: 3px dashed #222;
     border-radius: 15px;
   padding: 20px 45px 20px 35px;

--- a/resources/assets/sass/_alert.scss
+++ b/resources/assets/sass/_alert.scss
@@ -43,7 +43,7 @@
     }
 
     &-success {
-        background-color: #fff4e4;
+        background-color: $brand;
         border: 3px dashed #222;
         border-radius: 15px;
         padding: 20px 45px 20px 35px;
@@ -115,7 +115,7 @@
 }
 
 .information-alert {
-    background-color: #fff4e4;
+    background-color: $brand;
     border: 3px dashed #222;
     border-radius: 15px;
   padding: 20px 45px 20px 35px;

--- a/resources/assets/sass/_alert.scss
+++ b/resources/assets/sass/_alert.scss
@@ -43,9 +43,10 @@
     }
 
     &-success {
+        color: #222;
         background-color: #fff4e4;
         border: 3px dashed #222;
-        border-radius: 15px;
+        border-radius: 0px;
         padding: 20px 45px 20px 35px;
         font-size: 16px;
         overflow: hidden;

--- a/resources/views/layouts/header_plain.blade.php
+++ b/resources/views/layouts/header_plain.blade.php
@@ -26,6 +26,7 @@
         @else
           <link href="{{ asset('css/app.css') }}" rel="stylesheet">
         @endif
+        <link href="{{ asset('global/css/app.css') }}" rel="stylesheet">
 
         <!-- Cookie banner with fine-grained opt-in -->
         <script src="{{ asset('js/gdpr-cookie-notice.js') }}"></script>

--- a/resources/views/layouts/header_plain.blade.php
+++ b/resources/views/layouts/header_plain.blade.php
@@ -26,7 +26,6 @@
         @else
           <link href="{{ asset('css/app.css') }}" rel="stylesheet">
         @endif
-        <link href="{{ asset('global/css/app.css') }}" rel="stylesheet">
 
         <!-- Cookie banner with fine-grained opt-in -->
         <script src="{{ asset('js/gdpr-cookie-notice.js') }}"></script>


### PR DESCRIPTION
We've been talking as though this was device/browser specific, and that's why we needed Browserstack.  But I think it's a general problem with the alert colours, which reproduces on Chrome.

_alert.scss defines a font colour of #FFF and different background colours for the alert variants. The background colour for alert-success would be unreadable wherever it was used.  Given that alert-primary has a background colour of $brand, I've set that for alert-success too.  That gives this:

![image](https://user-images.githubusercontent.com/56696/91993043-d40a2500-ed2c-11ea-8550-3503ad385707.png)

That's a different change than James suggested, but I think it's probably better to stick to the brand colours.