### PR TITLE
Dot 1346 safari timepicker

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1724,7 +1724,8 @@ jQuery(document).ready(function () {
         'groupdescription':  require('./components/GroupDescription.vue'),
         'groupvolunteers':  require('./components/GroupVolunteers.vue'),
         'groupstats': require('./components/GroupStats.vue'),
-        'eventtimerangepicker': require('./components/EventTimeRangePicker.vue')
+        'eventtimerangepicker': require('./components/EventTimeRangePicker.vue'),
+        'eventdatepicker': require('./components/EventDatePicker.vue')
       }
     })
   })

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1723,7 +1723,8 @@ jQuery(document).ready(function () {
         'groupheading':  require('./components/GroupHeading.vue'),
         'groupdescription':  require('./components/GroupDescription.vue'),
         'groupvolunteers':  require('./components/GroupVolunteers.vue'),
-        'groupstats': require('./components/GroupStats.vue')
+        'groupstats': require('./components/GroupStats.vue'),
+        'eventtimerangepicker': require('./components/EventTimeRangePicker.vue')
       }
     })
   })

--- a/resources/assets/js/components/EventDatePicker.vue
+++ b/resources/assets/js/components/EventDatePicker.vue
@@ -1,0 +1,48 @@
+<template>
+    <div>
+        <b-form-datepicker class="datepicker" v-model="value"></b-form-datepicker>
+        <input type="hidden" name="event_date" :value="value" />
+    </div>
+</template>
+
+<script>
+export default {
+  props: {
+    'initialvalue' : {
+      required: false,
+      type: String
+    }
+  },
+  data() {
+    return {
+      value: this.initialvalue,
+    }
+  },
+}
+</script>
+
+<style scoped lang="scss">
+@import 'resources/global/css/_variables';
+
+.b-form-datepicker.form-control {
+    padding: 0 10px;
+}
+
+/deep/ .datepicker {
+    & label {
+        padding-bottom: 0;
+        border: 0;
+        margin: 0;
+        font-weight: normal;
+    }
+
+    .btn {
+        padding: 0.4rem 0.3rem !important;
+    }
+
+    .btn-primary {
+        background-color: $brand-orange !important;
+        color: $black !important;
+    }
+}
+</style>

--- a/resources/assets/js/components/EventTimeRangePicker.vue
+++ b/resources/assets/js/components/EventTimeRangePicker.vue
@@ -1,15 +1,9 @@
 <template>
-    <div>
-    <b-row class="no-gutters">
-        <b-col>
-            <b-form-timepicker id="start-time" v-model="startTime" placeholder="--:--" @input="changeEndTime" />
-            <input type="hidden" name="start" :value="startTime" />
-        </b-col>
-        <b-col>
-            <b-form-timepicker id="end-time" v-model="endTime" placeholder="--:--" />
-            <input type="hidden" name="end" :value="endTime" />
-        </b-col>
-    </b-row>
+    <div class="d-flex">
+        <b-form-timepicker id="start-time" v-model="startTime" placeholder="--:--" @input="changeEndTime" />
+        <input type="hidden" name="start" :value="startTime" />
+        <b-form-timepicker id="end-time" v-model="endTime" placeholder="--:--" />
+        <input type="hidden" name="end" :value="endTime" />
     </div>
 </template>
 

--- a/resources/assets/js/components/EventTimeRangePicker.vue
+++ b/resources/assets/js/components/EventTimeRangePicker.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="d-flex">
-        <b-form-timepicker id="start-time" v-model="startTime" placeholder="--:--" @input="changeEndTime" />
+        <b-form-timepicker class="start-time" v-model="startTime" placeholder="--:--" @input="changeEndTime" />
         <input type="hidden" name="start" :value="startTime" />
-        <b-form-timepicker id="end-time" v-model="endTime" placeholder="--:--" />
+        <b-form-timepicker class="end-time" v-model="endTime" placeholder="--:--" />
         <input type="hidden" name="end" :value="endTime" />
     </div>
 </template>
@@ -45,12 +45,36 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.b-form-timepicker.form-control {
-    padding: 0 10px;
+.b-form-timepicker {
+    &.form-control {
+        padding: 0 10px;
+    }
+
+    &:first-child {
+        border-right: 0;
+    }
 }
 
 /deep/ label {
     font-weight: normal;
+}
+
+/deep/ .start-time label,
+/deep/ .end-time label {
+    padding: 0.5rem 0 !important;
+    border: 0;
+    margin:0;
+}
+
+/deep/ .start-time .btn,
+/deep/ .end-time .btn {
+    padding: 0.5rem !important;
+    border: 0;
+    margin: 0;
+}
+
+/deep/ output {
+    justify-content: center;
 }
 
 /deep/ .b-time .form-control {
@@ -58,24 +82,5 @@ export default {
     height: 100%;
     border: 0;
     padding: 0 10px;
-}
-
-/deep/ #start-time__outer_ {
-    border-right: 0;
-}
-
-/deep/ #start-time,
-/deep/ #end-time {
-    padding: 0;
-}
-
-/deep/ #start-time__value_,
-/deep/ #end-time__value_ {
-    border: 0;
-    margin: 0;
-}
-
-/deep/ output {
-    justify-content: center;
 }
 </style>

--- a/resources/assets/js/components/EventTimeRangePicker.vue
+++ b/resources/assets/js/components/EventTimeRangePicker.vue
@@ -15,7 +15,16 @@
 
 <script>
 export default {
-  props: ['starttimeinit', 'endtimeinit'  ],
+  props: {
+    starttimeinit: {
+      required: false,
+      type: String
+    },
+    endtimeinit: {
+      required: false,
+      type: String
+    }
+  },
   data() {
     return {
       startTime: this.starttimeinit,
@@ -46,6 +55,10 @@ export default {
     padding: 0 10px;
 }
 
+/deep/ label {
+    font-weight: normal;
+}
+
 /deep/ .b-time .form-control {
     width: 100%;
     height: 100%;
@@ -53,12 +66,22 @@ export default {
     padding: 0 10px;
 }
 
-/deep/ #start-time, /deep/ #end-time {
+/deep/ #start-time__outer_ {
+    border-right: 0;
+}
+
+/deep/ #start-time,
+/deep/ #end-time {
     padding: 0;
 }
 
-/deep/ #start-time__value_, /deep/ #end-time__value_ {
+/deep/ #start-time__value_,
+/deep/ #end-time__value_ {
     border: 0;
     margin: 0;
+}
+
+/deep/ output {
+    justify-content: center;
 }
 </style>

--- a/resources/assets/js/components/EventTimeRangePicker.vue
+++ b/resources/assets/js/components/EventTimeRangePicker.vue
@@ -1,0 +1,64 @@
+<template>
+    <div>
+    <b-row class="no-gutters">
+        <b-col>
+            <b-form-timepicker id="start-time" v-model="startTime" placeholder="--:--" @input="changeEndTime" />
+            <input type="hidden" name="start" :value="startTime" />
+        </b-col>
+        <b-col>
+            <b-form-timepicker id="end-time" v-model="endTime" placeholder="--:--" />
+            <input type="hidden" name="end" :value="endTime" />
+        </b-col>
+    </b-row>
+    </div>
+</template>
+
+<script>
+export default {
+  props: ['starttimeinit', 'endtimeinit'  ],
+  data() {
+    return {
+      startTime: this.starttimeinit,
+      endTime: this.endtimeinit
+    }
+  },
+  methods: {
+    changeEndTime: function (startTime) {
+      // Replicating existing functionality.
+      // When start time changes, change end time to 3 hours hence.
+      let timeParts = startTime.split(':');
+      var hours = (parseInt(timeParts[0]) + 3).toString();
+
+      if (hours.length < 2) {
+        hours = '0' + hours;
+      }
+
+      var mins = timeParts[1];
+
+      this.endTime = hours+':'+mins
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.b-form-timepicker.form-control {
+    padding: 0 10px;
+}
+
+/deep/ .b-time .form-control {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    padding: 0 10px;
+}
+
+/deep/ #start-time, /deep/ #end-time {
+    padding: 0;
+}
+
+/deep/ #start-time__value_, /deep/ #end-time__value_ {
+    border: 0;
+    margin: 0;
+}
+</style>

--- a/resources/views/events/create.blade.php
+++ b/resources/views/events/create.blade.php
@@ -124,20 +124,25 @@
                   <div class="col-lg-7">
                     <div class="form-group">
 
-                      <label for="field_event_time">@lang('events.field_event_time'):</label>
+                        <label for="field_event_time">@lang('events.field_event_time'):</label>
+                        @if ($agent->browser() == 'Safari' && $agent->isDesktop())
+                            <div class="vue">
+                                <EventTimeRangePicker />
+                            </div>
+                        @else
+                            <div class="row">
 
-                      <div class="row">
+                                <div class="col-6">
+                                    <input type="time" id="start-time" name="start" class="form-control field" required>
+                                </div>
 
-                        <div class="col-6">
-                          <input type="time" id="start-time" name="start" class="form-control field" required>
-                        </div>
+                                <div class="col-6">
+                                    <input type="time" id="end-time" name="end" class="form-control field" required>
+                                </div>
 
-                        <div class="col-6">
-                          <label class="sr-only" for="field_event_time_2">@lang('events.field_event_time'):</label>
-                          <input type="time" id="end-time" name="end" class="form-control field" required>
-                        </div>
+                            </div>
 
-                      </div>
+                       @endif
 
                     </div>
                   </div>

--- a/resources/views/events/create.blade.php
+++ b/resources/views/events/create.blade.php
@@ -115,7 +115,13 @@
                 <div class="row">
                   <div class="col-lg-7">
                     <label for="event_date">@lang('events.field_event_date'):</label>
-                    <input type="date" id="event_date" name="event_date" class="form-control field" required>
+                    @if ($agent->browser() == 'Safari' && $agent->isDesktop())
+                        <div class="vue">
+                            <EventDatePicker />
+                        </div>
+                    @else
+                        <input type="date" id="event_date" name="event_date" class="form-control field" required>
+                    @endif
                   </div>
                 </div>
               </div>

--- a/resources/views/events/edit.blade.php
+++ b/resources/views/events/edit.blade.php
@@ -122,18 +122,30 @@
                       <div class="col-lg-7">
                            <div class="form-group">
                         <label for="field_event_time">@lang('events.field_event_time'):</label>
+
+                        <?php
+
+                        $startTime = date('H:i', strtotime($formdata->start));
+                        $endTime = date('H:i', strtotime($formdata->end));
+                        ?>
+                        @if ($agent->browser() == 'Safari' && $agent->isDesktop())
+                            <div class="vue">
+                                <EventTimeRangePicker starttimeinit="{{ $startTime }}" endtimeinit="{{ $endTime }}" />
+                            </div>
+                        @else
                         <div class="row">
 
                           <div class="col-6">
-                            <input type="time" id="start-time" name="start" class="form-control field" value="{{ date('H:i', strtotime($formdata->start)) }}">
+                            <input type="time" id="start-time" name="start" class="form-control field" value="{{ $startTime }}">
                           </div>
                           <div class="col-6">
                             <label class="sr-only" for="field_event_time_2">@lang('events.field_event_time'):</label>
-                            <input type="time" id="end-time" name="end" class="form-control field" value="{{ date('H:i', strtotime($formdata->end)) }}">
+                            <input type="time" id="end-time" name="end" class="form-control field" value="{{ $endTime }}">
                           </div>
-                          </div>
-
                         </div>
+                        @endif
+
+                      </div>
                       </div>
                       <div class="col-12">
 

--- a/resources/views/events/edit.blade.php
+++ b/resources/views/events/edit.blade.php
@@ -113,7 +113,13 @@
                     <div class="row">
                       <div class="col-lg-7">
                         <label for="event_date">@lang('events.field_event_date'):</label>
-                        <input type="date" id="event_date" name="event_date" class="form-control field" value="<?php echo date('Y-m-d', $formdata->event_date); ?>">
+                        @if ($agent->browser() == 'Safari' && $agent->isDesktop())
+                            <div class="vue">
+                                <EventDatePicker initialvalue="{{ date('Y-m-d', $formdata->event_date) }}" />
+                            </div>
+                        @else
+                            <input type="date" id="event_date" name="event_date" class="form-control field" value="<?php echo date('Y-m-d', $formdata->event_date); ?>">
+                        @endif
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
@edwh would be great to get your feedback on this code!

For DOT-1346, the issue was that we're using inputs with type=time, and that Safari on desktop doesn't support this.

I've used bootstrap-vue's b-form-timepicker component to replace the time range selection.  I've used a hidden input who's value is bound to the value of the timepicker in order to pass the value to the server on form submit.

I've used the agent checker library we have so that we only use this component on desktop Safari, and stick with the browser's own component elsewhere (chiefly because I think it's better to use the browser's native components when they do exist).  Side note: it would be better to do a check on support for input type=time rather than check for a specific browser, but I don't know how to do that.

The other issue I hit was our global CSS overriding lots of bootstrap's style rules and making the components a mess.  I've tried to reset this in the component to make it look sensible again.  Though I've realised I would need to do the same here with the date picker (also not supported on Safari desktop), so if there's a way to *not* inherit any of the parent application's CSS inside a component that would be great - I think you'd mentioned something similar once but it might have been different.