### PR TITLE
Permission check lost in recent restructure

### DIFF
--- a/resources/views/group/view.blade.php
+++ b/resources/views/group/view.blade.php
@@ -173,6 +173,7 @@
                   :top-devices="{{ json_encode($top) }}"
                   :events="{{ json_encode($expanded_events) }}"
                   :volunteers="{{ json_encode($expanded_volunteers) }}"
+                  :canedit="{{ $can_edit_group ? 'true' : 'false' }}"
                   calendar-copy-url="{{ $showCalendar ? url("/calendar/group/{$group->idgroups}") : '' }}"
                   calendar-edit-url="{{ $showCalendar ? url("/profile/edit/{$user->id}#list-calendar-links") : '' }}"
           />


### PR DESCRIPTION
We noticed that the pencil icon for editing volunteers was missing.  This fixes that.