### PR TITLE
Various bugs on events page

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -929,9 +929,15 @@ class GroupController extends Controller
 
     public function getMakeHost($group_id, $user_id, Request $request)
     {
-        //Has current logged in user got permission to add host
-        if ((FixometerHelper::hasRole(Auth::user(), 'Host') && FixometerHelper::userIsHostOfGroup($group_id, Auth::id())) || FixometerHelper::hasRole(Auth::user(), 'Administrator')) {
-            $group = Group::find($group_id);
+        // Has current logged in user got permission to add host?
+        // - Is a host of the group.
+        // - Is a network coordinator of a network which the group is in.
+        // - Is an Administrator
+        $group = Group::find($group_id);
+
+        if ((FixometerHelper::hasRole(Auth::user(), 'Host') && FixometerHelper::userIsHostOfGroup($group_id, Auth::id())) ||
+            (Auth::user()->hasRole('NetworkCoordinator') && !Auth::user()->networks->intersect($group->networks)->isEmpty()) ||
+            FixometerHelper::hasRole(Auth::user(), 'Administrator')) {
             $user = User::find($user_id);
 
             $group->makeMemberAHost($user);

--- a/resources/assets/js/components/CollapsibleSection.vue
+++ b/resources/assets/js/components/CollapsibleSection.vue
@@ -6,11 +6,12 @@
       'mb-3': true,
       'justify-content-between': true
       }" @click="toggle">
-      <div class="d-flex w-100">
-        <div class="d-flex flex-column justify-content-center">
-          <slot name="title" />
-        </div>
-        <div v-if="count" :class="{
+      <div class="d-flex w-100 justify-content-between">
+        <div>
+          <div class="d-flex flex-column justify-content-center">
+            <slot name="title" />
+          </div>
+          <div v-if="count" :class="{
           'd-inline' : true,
           'd-md-none' : !alwaysShowCount,
           'text-muted' : true,
@@ -21,9 +22,10 @@
           <span v-if="countBadge">
             &nbsp;<b-badge variant="primary" pill>{{ count }}</b-badge>
           </span>
-          <span v-else>
+            <span v-else>
             &nbsp;<span :class="countClass">({{ count }})</span>
           </span>
+          </div>
         </div>
         <slot name="title-right" />
       </div>

--- a/resources/assets/js/components/GroupEvents.vue
+++ b/resources/assets/js/components/GroupEvents.vue
@@ -52,7 +52,7 @@
               </div>
             </template>
             <p v-if="!past.length">
-              {{ translatedNoPastEvents }}.
+              {{ translatedNoPastEvents }}
             </p>
             <b-table-simple v-else responsive class="pl-0 pl-md-3 pr-0 pr-md-3 pb-2 mb-2" table-class="m-0 leave-tables-alone">
               <GroupEventsTableHeading past />
@@ -117,8 +117,8 @@
           </div>
         </template>
         <template slot="content">
-          <p v-if="!upcoming.length">
-            {{ translatedNoPastEvents }}.
+          <p v-if="!past.length">
+            {{ translatedNoPastEvents }}
           </p>
           <b-table-simple v-else sticky-header="50vh" responsive class="pl-0 pl-md-3 pr-0 pr-md-3 pb-2 mb-2" table-class="m-0 leave-tables-alone">
             <GroupEventsTableHeading past />

--- a/resources/assets/js/components/GroupEventsPage.vue
+++ b/resources/assets/js/components/GroupEventsPage.vue
@@ -35,6 +35,11 @@ export default {
       required: false,
       default: null
     },
+    canedit: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
   },
   computed: {
     group() {

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -117,6 +117,8 @@
 
       foreach (array_merge($upcoming_events->all(), $past_events->all()) as $event) {
           $thisone = $event->getAttributes();
+//          $group = ;
+          $thisone['group'] = \App\Group::find($event->group);
           $thisone['attending'] = Auth::user() && $event->isBeingAttendedBy(Auth::user()->id);
           $thisone['allinvitedcount'] = $event->allInvited->count();
 
@@ -146,6 +148,8 @@
             calendar-copy-url="{{ $calendar_copy_url }}"
             calendar-edit-url="{{ $calendar_edit_url }}"
             :add-button="false"
+            :canedit="{{ $can_edit_group ? 'true' : 'false' }}"
+            add-group-name
         />
       </div>
       @else
@@ -156,6 +160,7 @@
           calendar-copy-url="{{ $showCalendar ? url("/calendar/group/{$group->idgroups}") : '' }}"
           calendar-edit-url="{{ $calendar_edit_url }}"
           :initial-group="{{ json_encode($group) }}"
+          :canedit="{{ $can_edit_event ? 'true' : 'false' }}"
         />
       </div>
       @endif

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -117,8 +117,13 @@
 
       foreach (array_merge($upcoming_events->all(), $past_events->all()) as $event) {
           $thisone = $event->getAttributes();
-//          $group = ;
-          $thisone['group'] = \App\Group::find($event->group);
+
+          if (is_null($group)) {
+              // We are showing events for multiple groups and so we need to pass the relevant group, in order that
+              // we can show the group name and link to it.
+              $thisone['group'] = \App\Group::find($event->group);
+          }
+
           $thisone['attending'] = Auth::user() && $event->isBeingAttendedBy(Auth::user()->id);
           $thisone['allinvitedcount'] = $event->allInvited->count();
 


### PR DESCRIPTION
Add button in collapsible section should be on the right hand side
Remove a couple of double full-stops.
No past events showing on mobile group events page.
Edit flags not being passed down in group events page.