### PR TITLE
Allow network administrator to make someone a host

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -936,9 +936,9 @@ class GroupController extends Controller
         $group = Group::find($group_id);
         $loggedInUser = Auth::user();
 
-        if ((FixometerHelper::hasRole($loggedInUser, 'Host') && FixometerHelper::userIsHostOfGroup($group_id, Auth::id())) ||
+        if (($loggedInUser->hasRole('Host') && FixometerHelper::userIsHostOfGroup($group_id, $loggedInUser->id)) ||
             $loggedInUser->isCoordinatorForGroup($group) ||
-            FixometerHelper::hasRole($loggedInUser, 'Administrator')) {
+            $loggedInUser->hasRole('Administrator')) {
             $user = User::find($user_id);
 
             $group->makeMemberAHost($user);

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -929,9 +929,15 @@ class GroupController extends Controller
 
     public function getMakeHost($group_id, $user_id, Request $request)
     {
-        //Has current logged in user got permission to add host
-        if ((FixometerHelper::hasRole(Auth::user(), 'Host') && FixometerHelper::userIsHostOfGroup($group_id, Auth::id())) || FixometerHelper::hasRole(Auth::user(), 'Administrator')) {
-            $group = Group::find($group_id);
+        // Has current logged in user got permission to add host?
+        // - Is a host of the group.
+        // - Is a network coordinator of a network which the group is in.
+        // - Is an Administrator
+        $group = Group::find($group_id);
+
+        if ((FixometerHelper::hasRole(Auth::user(), 'Host') && FixometerHelper::userIsHostOfGroup($group_id, Auth::id())) ||
+            (Auth::user()->hasRole('NetworkCoordinator') && !Auth::user()->networks->intersect($group->networks)->isEmpty()) ||
+            FixometerHelper::hasRole(Auth::user(), 'Administrator')) {
             $user = User::find($user_id);
 
             $group->makeMemberAHost($user);

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -934,10 +934,11 @@ class GroupController extends Controller
         // - Is a network coordinator of a network which the group is in.
         // - Is an Administrator
         $group = Group::find($group_id);
+        $loggedInUser = Auth::user();
 
-        if ((FixometerHelper::hasRole(Auth::user(), 'Host') && FixometerHelper::userIsHostOfGroup($group_id, Auth::id())) ||
-            (Auth::user()->hasRole('NetworkCoordinator') && !Auth::user()->networks->intersect($group->networks)->isEmpty()) ||
-            FixometerHelper::hasRole(Auth::user(), 'Administrator')) {
+        if ((FixometerHelper::hasRole($loggedInUser, 'Host') && FixometerHelper::userIsHostOfGroup($group_id, Auth::id())) ||
+            $loggedInUser->isCoordinatorForGroup($group) ||
+            FixometerHelper::hasRole($loggedInUser, 'Administrator')) {
             $user = User::find($user_id);
 
             $group->makeMemberAHost($user);


### PR DESCRIPTION
The front end code already displays the pencil appropriately.  This change modifies the permission check to allow a network coordinator to make someone a host.

It doesn't seem right to me that network coordinator is a user-level field.  You could surely be a coordinator of one network and not have that role on others.  So I may be missing something here - please review the logic.