### PR TITLE
DOT-1158 Fixometer showing undefined weight for most recent event after search

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -190,6 +190,9 @@ class DeviceController extends Controller
         ->orderBy('event_date', 'DESC')
         ->first();
 
+        $most_recent_finished_event['id_events'] = $most_recent_finished_event->idevents;
+        $most_recent_finished_event['waste_prevented'] = $most_recent_finished_event->WastePrevented;
+
         $user_groups = Group::with('allRestarters', 'parties', 'groupImage.image')
         ->join('users_groups', 'users_groups.group', '=', 'groups.idgroups')
         ->join('events', 'events.group', '=', 'groups.idgroups')


### PR DESCRIPTION
Missing bit of code in DeviceController::search().

There's duplication between search() and index(), but search() will be removed once DOT-1287 is released.