### PR TITLE
DOT-1359 RSVP invisible

### DIFF
--- a/resources/global/css/components/_buttons.scss
+++ b/resources/global/css/components/_buttons.scss
@@ -168,6 +168,12 @@
     color: $black;
     border-color: $black;
   }
+
+  &:disabled,&.disabled {
+    color: grey !important;
+    box-shadow: 5px 5px 0 0 grey !important;
+    border-color: grey;
+  }
 }
 
 .btn-outline-primary {


### PR DESCRIPTION
Disabled primary buttons are white text on a white background.

I switched to grey - not sure if we have a convention for disabled?

It took many times longer to track down which of the multitude of CSS fragments was controlling this than to fix it.  