### PR TITLE
Prevent error if create event with no location

### DIFF
--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -182,11 +182,18 @@ class PartyController extends Controller
                 'event_date' => 'required',
                 'start' => 'required',
                 'end' => 'required',
+                'location' => [
+                    function ($attribute, $value, $fail) use ($request){
+                        if (!$request->filled('online') && !$value) {
+                            $fail(__('events.validate_location'));
+                        }
+                    }
+                ]
             ]);
 
             $error = array();
 
-            if ($request->has('location')) {
+            if ($request->filled('location')) {
                 try {
                     $results = $this->geocoder->geocode($request->get('location'));
 

--- a/resources/assets/js/components/MicrotaskingVolunteering.vue
+++ b/resources/assets/js/components/MicrotaskingVolunteering.vue
@@ -45,7 +45,7 @@
                             <b-td class="text-center">{{ translatedMyQuests }}</b-td>
                         </template>
                         <template v-else>
-                            <b-td class="text-center" colspan="2"><a class="btn btn-primary" href="/mobifix">{{ translatedJoin }}</a></b-td>
+                            <b-td class="text-center" colspan="2"><a class="btn btn-primary" href="/about">{{ translatedJoin }}</a></b-td>
                         </template>
                     </b-tr>
                 </b-tbody>

--- a/resources/lang/en/events.php
+++ b/resources/lang/en/events.php
@@ -188,5 +188,6 @@ return array (
   'confirm_delete' => 'Are you sure you want to delete this event?',
   'RSVP' => 'RSVP',
   'form_error' => 'Please check the form above for errors.',
-  'your_events' => 'Your events'
+  'your_events' => 'Your events',
+  'validate_location' => 'Location must be present unless the event is online.'
 );

--- a/resources/views/events/create.blade.php
+++ b/resources/views/events/create.blade.php
@@ -168,6 +168,9 @@
                             <div class="form-group">
                               <label for="autocomplete">@lang('events.field_event_venue'):</label>
                               <input type="text" placeholder="Enter your address" id="autocomplete" name="location" class="form-control field field-geolocate" aria-describedby="locationHelpBlock" value="{{ old('location') }}">
+                              @if($errors->has('location'))
+                                <p class="text-danger">{{ $errors->first('location') }}</p>
+                              @endif
 
                               <small id="locationHelpBlock" class="form-text text-muted">
                                 @lang('events.field_venue_helper')


### PR DESCRIPTION
I can't reproduce the original problem, but the code doesn't look like it handles missing locations well.

I've added some validation on the server to reject the create gracefully if no location is supplied and the event is not online.

The user experience is poor for errors on this form - we have basic HTML validation using "required", which means we see the default browser error message when we try to submit something which is missing.  But we don't have any more complex validation, which makes it hard to validation combinations of fields like this, except on the server.  Server-side validation means we lose the form data we submitted.  There are also other error cases (e.g. create an event with an end time after the start time).  

We should rewrite the event creation page into Vue and add better validation, and perhaps then consider whether we really need pre-moderation of events rather than post-moderation.  Let me know if you want me to create a story for that.