### PR TITLE
DOT-1247 Style wiki search button

### DIFF
--- a/resources/wiki/css/components/_search-button.scss
+++ b/resources/wiki/css/components/_search-button.scss
@@ -24,7 +24,7 @@
           border-radius: 0;
           border: 1px solid #000;
           padding: 20px 25px;
-          border-left: 0 !important;
+          border-left: 1px solid black !important;
 
           &::before {
             content: '';


### PR DESCRIPTION
As per the conversation in there, we need to style the wiki search magnifying glass differently.  That's handled in restarters CSS.