### PR TITLE
DOT 1374 MW skin

### DIFF
--- a/resources/wiki/css/components/_alerts.scss
+++ b/resources/wiki/css/components/_alerts.scss
@@ -3,6 +3,7 @@
   border: 0;
   padding-right: 4rem;
   background-color: #f45b69 !important;
+  z-index: 1000;
 
   .postedit-icon,
   .postedit-icon-checkmark,

--- a/resources/wiki/css/components/_alerts.scss
+++ b/resources/wiki/css/components/_alerts.scss
@@ -1,9 +1,12 @@
+.postedit-container {
+  z-index: 10000 !important;
+}
+
 .mw-notification {
   padding: 0.75rem 1.25rem;
   border: 0;
   padding-right: 4rem;
   background-color: #f45b69 !important;
-  z-index: 1000;
 
   .postedit-icon,
   .postedit-icon-checkmark,


### PR DESCRIPTION
Notifications for saved wiki edits aren't appearing above the navbar.  

The way these get added is a bit odd - looks like some CSS rules are dynamically added in.  Took a bit of experimentation to get the right z-index on the right class.