### PR TITLE
DOT-1386 Can't edit old devices

### DIFF
--- a/resources/assets/js/components/DeviceModel.vue
+++ b/resources/assets/js/components/DeviceModel.vue
@@ -32,7 +32,7 @@ export default {
       }
     },
     translatedModel() {
-      return this.$lang.get('devices.model_or_type')
+      return this.$lang.get('devices.device_model')
     },
     translatedTooltipModel() {
       return this.$lang.get('devices.tooltip_model')

--- a/resources/assets/js/components/EventDeviceSummary.vue
+++ b/resources/assets/js/components/EventDeviceSummary.vue
@@ -80,6 +80,10 @@ export default {
   components: {EventDevice, ConfirmModal},
   mixins: [ event ],
   props: {
+    idevents: {
+      type: Number,
+      required: true
+    },
     device: {
       type: Object,
       required: true
@@ -93,7 +97,22 @@ export default {
       type: Boolean,
       required: false,
       default: true
-    }
+    },
+    clusters: {
+      type: Array,
+      required: false,
+      default: null
+    },
+    brands: {
+      type: Array,
+      required: false,
+      default: null
+    },
+    barrierList: {
+      type: Array,
+      required: false,
+      default: null
+    },
   },
   data () {
     return {


### PR DESCRIPTION
Errors introduced in tech debt change, where we don't have all the props we need.