### PR TITLE
DOT-1390 Remove cookies for stats

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -999,17 +999,20 @@ function initAutocomplete() {
 
   jQuery(document).ready(function () {
     groupsMap();
-    gdprCookieNotice({
-      locale: 'en',
-      timeout: 500, //Time until the cookie bar appears
-      expiration: 30, //This is the default value, in days
-      domain: restarters.cookie_domain, //If you run the same cookie notice on all subdomains, define the main domain starting with a .
-      implicit: false, //Accept cookies on page scroll automatically
-      statement: '/about/cookie-policy', //Link to your cookie statement page
-      performace: ['DYNSRV'], //Cookies in the performance category.
-      analytics: ['_ga','_gat', '_gid'], //Cookies in the analytics category.
-      marketing: [] //Cookies in the marketing category.
-    });
+
+    if (window.gdprCookieNotice) {
+      gdprCookieNotice({
+        locale: 'en',
+        timeout: 500, //Time until the cookie bar appears
+        expiration: 30, //This is the default value, in days
+        domain: restarters.cookie_domain, //If you run the same cookie notice on all subdomains, define the main domain starting with a .
+        implicit: false, //Accept cookies on page scroll automatically
+        statement: '/about/cookie-policy', //Link to your cookie statement page
+        performace: ['DYNSRV'], //Cookies in the performance category.
+        analytics: ['_ga','_gat', '_gid'], //Cookies in the analytics category.
+        marketing: [] //Cookies in the marketing category.
+      });
+    }
 
       let hash = document.location.hash;
       if (hash) {

--- a/resources/views/group/stats.blade.php
+++ b/resources/views/group/stats.blade.php
@@ -1,4 +1,4 @@
-@include('layouts.header_plain', ['iframe' => true])
+@include('layouts.header_nocookie', ['iframe' => true])
 @yield('content')
 @if($format == 'row')
 

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -8,7 +8,6 @@
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    <!--<title>{{ config('app.name', 'Laravel') }} @hasSection('title')- @yield('title')@endif</title>-->
     <title>
         @hasSection('title')
         @yield('title')

--- a/resources/views/layouts/header_nocookie.blade.php
+++ b/resources/views/layouts/header_nocookie.blade.php
@@ -1,0 +1,30 @@
+<!doctype html>
+<html class="body-plain" lang="{{ app()->getLocale() }}">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        @yield('extra-meta')
+        <!-- CSRF Token -->
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <!--<title>{{ config('app.name', 'Laravel') }}</title>-->
+        <title>
+            @hasSection('title')
+            @yield('title')
+            @else
+            {{ config('app.name', 'Laravel') }}
+            @endif
+        </title>
+
+        @yield('extra-css')
+
+        <!-- Styles -->
+        @if( isset($iframe) )
+        <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+        <link href="{{ asset('css/iframe.css') }}" rel="stylesheet">
+        @else
+        <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+        @endif
+  </head>
+<body>

--- a/resources/views/layouts/header_nocookie.blade.php
+++ b/resources/views/layouts/header_nocookie.blade.php
@@ -8,7 +8,6 @@
         <!-- CSRF Token -->
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <!--<title>{{ config('app.name', 'Laravel') }}</title>-->
         <title>
             @hasSection('title')
             @yield('title')

--- a/resources/views/layouts/header_plain.blade.php
+++ b/resources/views/layouts/header_plain.blade.php
@@ -8,7 +8,6 @@
         <!-- CSRF Token -->
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <!--<title>{{ config('app.name', 'Laravel') }}</title>-->
         <title>
             @hasSection('title')
             @yield('title')

--- a/resources/views/party/stats.blade.php
+++ b/resources/views/party/stats.blade.php
@@ -1,4 +1,4 @@
-@include('layouts.header_plain', ['iframe' => true])
+@include('layouts.header_nocookie', ['iframe' => true])
 @yield('content')
 <div class="" id="party-headline-stats">
 


### PR DESCRIPTION
- Create a new 'nocookie' layout, which doesn't include the Google stuff.
- Remove the cookie notice which is then not needed
- Use this from the stats template.
- Stop the global JS barfing.

Tested in Brave to ensure it looks clean.

