### PR TITLE
Introduce a better translation mechanism

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1517,11 +1517,19 @@ function initAutocomplete() {
 jQuery(document).ready(function () {
   // Vue.
   //
-  // Create a mixin so that $lang is available in all components.
+  // Create a mixin for translation.
   Vue.mixin({
     computed: {
       $lang() {
+        // We want this to be available in all components.
         return Lang
+      }
+    },
+    methods: {
+      __(key) {
+        // This means we can use __('key') in Vue templates in the same way as we are used to in Laravel
+        // templates.
+        return this.$lang.get(key)
       }
     }
   })

--- a/resources/assets/js/components/DashboardYourGroups.vue
+++ b/resources/assets/js/components/DashboardYourGroups.vue
@@ -17,7 +17,7 @@
               {{ translatedGroupsHeading }}
             </h3>
             <p>
-              {{ translatedCatchUp }}
+              {{ __('dashboard.catch_up') }}
             </p>
           </div>
           <div class="group-list">
@@ -97,9 +97,6 @@ export default {
     },
     translatedSeeAll() {
       return this.$lang.get('dashboard.see_all_groups')
-    },
-    translatedCatchUp() {
-      return this.$lang.get('dashboard.catch_up')
     },
     translatedYourGroupsHeading() {
       return this.$lang.get('dashboard.your_groups_heading')


### PR DESCRIPTION
We currently do translations in Vue components by having computed properties which call this.$lang.get().  This works but leads to a lot of dull code.

This PR introduces a `__()` method which is in a global mixin and therefore available everywhere.  This is named to match the Laravel translation call, which means it's one fewer thing to remember.  We can then pass in the key directly in a template, e.g. 

```
            <p>
              {{ __('dashboard.catch_up') }}
            </p>
```

I've used it in one example, but if you like this approach then I'll go through and apply it throughout - bit dull to do but removes a bunch of code that doesn't deserve to live.

In Vue 2, filters might be a natural way to do this, and I like them, but they're being retired in Vue 3.  

This has the additional minor advantage of making it easier to refactor by moving template chunks between components - at the moment you also have to move the relevant computed properties, and we can easily end up with computed properties which are no longer actually used.