### PR TITLE
DOT-1422 Add button mislabelled on group page

### DIFF
--- a/resources/assets/js/components/GroupEvents.vue
+++ b/resources/assets/js/components/GroupEvents.vue
@@ -13,9 +13,7 @@
       </template>
       <template slot="title-right">
         <b-btn variant="primary" href="/party/create" class="align-self-center text-nowrap" v-if="addButton">
-          <span class="d-none d-md-block">
-            {{ translatedAddEvent }}
-          </span>
+          {{ translatedAddEvent }}
         </b-btn>
       </template>
       <template slot="content">

--- a/resources/assets/js/components/GroupEvents.vue
+++ b/resources/assets/js/components/GroupEvents.vue
@@ -147,6 +147,9 @@ export default {
     translatedOtherEvents() {
       return this.$lang.get('events.other_events')
     },
+    translatedAddEvent() {
+      return this.$lang.get('dashboard.add_event')
+    },
     translatedAddEventMobile() {
       return this.$lang.get('events.add_new_event_mobile')
     },

--- a/resources/assets/js/components/GroupEvents.vue
+++ b/resources/assets/js/components/GroupEvents.vue
@@ -13,9 +13,9 @@
       </template>
       <template slot="title-right">
         <b-btn variant="primary" href="/party/create" class="align-self-center text-nowrap" v-if="addButton">
-            <span class="d-none d-md-block">
-              {{ translatedAddEvent }}
-            </span>
+          <span class="d-none d-md-block">
+            {{ translatedAddEvent }}
+          </span>
         </b-btn>
       </template>
       <template slot="content">
@@ -148,10 +148,7 @@ export default {
       return this.$lang.get('events.other_events')
     },
     translatedAddEvent() {
-      return this.$lang.get('dashboard.add_event')
-    },
-    translatedAddEventMobile() {
-      return this.$lang.get('events.add_new_event_mobile')
+      return this.$lang.get('events.add_new_event')
     },
     translatedSeeAll() {
       return this.$lang.get('events.event_all')

--- a/resources/lang/en/events.php
+++ b/resources/lang/en/events.php
@@ -172,7 +172,6 @@ return array (
   'editing' => 'Editing :event',
   'event_log' => 'Event log',
   'add_new_event' => 'Add new event',
-  'add_new_event_mobile' => 'Add',
   'created_success_message' => 'Event created!  It will be approved by a coordinator shortly.  You can continue to edit it in the meantime.',
   'not_counting' => 'Not counting toward this event\'s environmental impact is|Not counting toward this event\'s environmental impact are',
   'impact_calculation' => '<b>How do we calculate environmental impact?</b><p>For powered items: We’ve researched the average weight and CO2 footprint of products across a range of categories, from smartphones to hairdryers. When you enter a powered item that you’ve fixed, we use these averages to estimate the impact of that repair based on the category of the item.</p><p>For unpowered items: When you enter an unpowered item that you’ve repaired, we use the item weight you enter yourself. This is because we don’t have reference data for unpowered items yet, which also means we can’t provide a CO2 estimate.</p><p><a href="https://therestartproject.org/faq/" target="_blank" rel="nofollow">Learn more about how we calculate impact here</a></p>',


### PR DESCRIPTION
This looks like merge issues though I've not dug into the history.  
* On mobile the Add Event is inside the dropdown menu and therefore doesn't need a label and translation.
* On desktop it should use the correct label, and the classes are not needed as the CollapsibleSection has them.