### PR TITLE
DOT-1415 Group name lost from Fixometer URL

### DIFF
--- a/resources/assets/js/components/FixometerPage.vue
+++ b/resources/assets/js/components/FixometerPage.vue
@@ -389,7 +389,7 @@ export default {
       }
 
       if (this.group) {
-        ret += 'group=' + encodeURIComponent(this.groupd) + '&'
+        ret += 'group=' + encodeURIComponent(this.group) + '&'
       }
 
       if (this.from_date) {


### PR DESCRIPTION
The smallest of fixes - one character typo.