### PR TITLE
DOT-1427 translation skin

### DIFF
--- a/resources/wiki/css/app.scss
+++ b/resources/wiki/css/app.scss
@@ -268,4 +268,6 @@ body {
 
 .tux-grouplist__item__label {
   width: 100% !important;
+  font-size: 90% !important;
+  min-width: 157px !important;
 }

--- a/resources/wiki/css/app.scss
+++ b/resources/wiki/css/app.scss
@@ -261,3 +261,11 @@ body {
 .uls-menu {
   z-index: 10000 !important;
 }
+
+.tux-grouplist__item__icon {
+  display: none !important;
+}
+
+.tux-grouplist__item__label {
+  width: 100% !important;
+}


### PR DESCRIPTION
Make this look a little better.
* Hide the icon, which adds little and chews up space.  
* Shrink the font slightly.
* Force a width.