### PR TITLE
DAT-529 Use empty strings rather than nulls for empty problems.

### DIFF
--- a/app/Device.php
+++ b/app/Device.php
@@ -711,4 +711,9 @@ AND devices.event = events.idevents ';
         $types = DB::table('devices')->whereNotNull('item_type')->select('item_type', DB::raw('COUNT(*) as count'))->groupBy('item_type')->orderBy('count', 'desc')->get()->toArray();
         return $types;
     }
+
+    public function setProblemAttribute($value) {
+        // Map null values to empty strings to avoid Metabase problems.
+        $this->attributes['problem'] = $value === NULL ? '' : $value;
+    }
 }

--- a/app/Device.php
+++ b/app/Device.php
@@ -714,6 +714,6 @@ AND devices.event = events.idevents ';
 
     public function setProblemAttribute($value) {
         // Map null values to empty strings to avoid Metabase problems.
-        $this->attributes['problem'] = $value === NULL ? '' : $value;
+        $this->attributes['problem'] = $value ?? '';
     }
 }

--- a/database/migrations/2021_06_09_164834_no_null_problems.php
+++ b/database/migrations/2021_06_09_164834_no_null_problems.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class NoNullProblems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // See https://github.com/doctrine/dbal/issues/3161.
+        DB::connection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+
+        Schema::table('devices', function (Blueprint $table) {
+            $table->mediumText('problem')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::connection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+
+        Schema::table('devices', function (Blueprint $table) {
+            $table->mediumText('problem')->nullable(true)->change();
+        });
+    }
+}

--- a/tests/Feature/Devices/NullProblemTest.php
+++ b/tests/Feature/Devices/NullProblemTest.php
@@ -36,7 +36,7 @@ class NullProblemTest extends TestCase
     public function null_problem_mapped_to_empty_string()
     {
         $this->device_inputs['problem'] = NULL;
-        $response = $this->post('/device/create', $this->device_inputs);
+        $this->post('/device/create', $this->device_inputs);
 
         $device = Device::find(1);
         $this->assertEquals('', $device->problem);

--- a/tests/Feature/Devices/NullProblemTest.php
+++ b/tests/Feature/Devices/NullProblemTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Device;
+use App\Party;
+use App\User;
+
+use DB;
+use Tests\TestCase;
+
+class NullProblemTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        DB::statement("SET foreign_key_checks=0");
+        User::truncate();
+        Party::truncate();
+        Device::truncate();
+        DB::statement("SET foreign_key_checks=1");
+
+        $event = factory(Party::class)->create();
+        $this->device_inputs = factory(Device::class)->raw([
+                                                               'event_id' => $event->idevents,
+                                                               'quantity' => 1,
+                                                           ]);
+
+        $admin = factory(User::class)->state('Administrator')->create();
+        $this->actingAs($admin);
+
+        $this->withoutExceptionHandling();
+    }
+
+    /** @test */
+    public function null_problem_mapped_to_empty_string()
+    {
+        $this->device_inputs['problem'] = NULL;
+        $response = $this->post('/device/create', $this->device_inputs);
+
+        $device = Device::find(1);
+        $this->assertEquals('', $device->problem);
+    }
+}


### PR DESCRIPTION
Add a migration to sort out the existing values, and a mutator to ensure no new null values sneak in.