### PR TITLE
More tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,7 +14,9 @@
             <exclude>./tests/Feature/Admin/Users/WikiLoginTests.php</exclude>
             <exclude>./tests/Feature/Groups/WordpressGroupPushTest.php</exclude>
             <exclude>./tests/Feature/Microtasks/ExampleTest.php</exclude>
+            <exclude>./tests/Feature/Microtasks/FaultcatTest.php</exclude>
             <exclude>./tests/Feature/Microtasks/MisccatTest.php</exclude>
+            <exclude>./tests/Feature/Microtasks/MobifixTest.php</exclude>
             <exclude>./tests/Feature/Zapier/ZapierNetworkTests.php</exclude>
         </testsuite>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,40 +9,32 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-<!--        We have lots of tests which exist but don't run yet.  So we only run a subset of them here. -->
+<!--
+We have lots of tests which exist but don't run yet.  So we only run a subset of them here.  If you see a <file>,
+it means that there is some other test in that directory which doesn't run yet.
+-->
         <testsuite name="Feature">
-            <file>./tests/Feature/Admin/Users/UserDeletedNotificationTest.php</file>
-            <file>./tests/Feature/Admin/Users/ViewUsersTest.php</file>
-
+            <directory suffix=".php">./tests/Feature/Admin</directory>
+            <exclude>./tests/Feature/Admin/Users/WikiLoginTests.php</exclude>
             <directory suffix=".php">./tests/Feature/Dashboard</directory>
             <directory suffix=".php">./tests/Feature/Devices</directory>
             <directory suffix=".php">./tests/Feature/Events</directory>
             <directory suffix=".php">./tests/Feature/Fixometer</directory>
-
-            <file>./tests/Feature/Groups/BasicTest.php</file>
-            <file>./tests/Feature/Groups/GroupCreateTest.php</file>
-            <file>./tests/Feature/Groups/GroupEditTest.php</file>
-            <file>./tests/Feature/Groups/GroupNetworkCreateTest.php</file>
-
-            <directory suffix=".php">./tests/Feature/Microtasks/Workbench</directory>
-            <file>./tests/Feature/Microtasks/BasicTest.php</file>
-            <file>./tests/Feature/Microtasks/MobifixOraTest.php</file>
-            <file>./tests/Feature/Microtasks/PrintcatOraTest.php</file>
-            <file>./tests/Feature/Microtasks/TabicatOraTest.php</file>
-
+            <directory suffix=".php">./tests/Feature/Groups</directory>
+            <exclude>./tests/Feature/Groups/WordpressGroupPushTest.php</exclude>
+            <directory suffix=".php">./tests/Feature/Microtasks/</directory>
+            <exclude>./tests/Feature/Microtasks/ExampleTest.php</exclude>
+            <exclude>./tests/Feature/Microtasks/MisccatTest.php</exclude>
             <directory suffix=".php">./tests/Feature/Networks</directory>
-
-            <file>./tests/Feature/Users/Registration/AccountCreationTest.php</file>
-            <file>./tests/Feature/Users//EditLanguageSettingsTest.php</file>
-            <file>./tests/Feature/Users//EditProfileTest.php</file>
-
+            <directory suffix=".php">./tests/Feature/Users</directory>
             <file>./tests/Feature/DeviceStatsTest.php</file>
             <file>./tests/Feature/EventStatsTest.php</file>
             <file>./tests/Feature/GroupStatsTest.php</file>
         </testsuite>
 
         <testsuite name="Unit">
-            <file>./tests/Unit/UsernameGeneratorTest</file>
+            <directory suffix=".php">./tests/Unit</directory>
+            <exclude>./tests/Unit/CharsetTest.php</exclude>
         </testsuite>
     </testsuites>
     <filter>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,7 +25,6 @@
             <file>./tests/Feature/Groups/GroupEditTest.php</file>
             <file>./tests/Feature/Groups/GroupNetworkCreateTest.php</file>
             <file>./tests/Feature/Microtasks/BasicTest.php</file>
-            <file>./tests/Feature/Microtasks/FaultcatTest.php</file>
             <file>./tests/Feature/Microtasks/MobifixOraTest.php</file>
             <file>./tests/Feature/Microtasks/MobifixTest.php</file>
             <file>./tests/Feature/Microtasks/PrintcatOraTest.php</file>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,23 +11,31 @@
     <testsuites>
 <!--        We have lots of tests which exist but don't run yet.  So we only run a subset of them here. -->
         <testsuite name="Feature">
+            <file>./tests/Feature/Admin/Users/UserDeletedNotificationTest.php</file>
+            <file>./tests/Feature/Admin/Users/ViewUsersTest.php</file>
+
             <directory suffix=".php">./tests/Feature/Dashboard</directory>
             <directory suffix=".php">./tests/Feature/Devices</directory>
             <directory suffix=".php">./tests/Feature/Events</directory>
             <directory suffix=".php">./tests/Feature/Fixometer</directory>
-            <directory suffix=".php">./tests/Feature/Microtasks/Workbench</directory>
-            <directory suffix=".php">./tests/Feature/Networks</directory>
-            <file>./tests/Feature/Users/Registration/AccountCreationTest.php</file>
-            <file>./tests/Feature/Admin/Users/UserDeletedNotificationTest.php</file>
-            <file>./tests/Feature/Admin/Users/ViewUsersTest.php</file>
+
             <file>./tests/Feature/Groups/BasicTest.php</file>
             <file>./tests/Feature/Groups/GroupCreateTest.php</file>
             <file>./tests/Feature/Groups/GroupEditTest.php</file>
             <file>./tests/Feature/Groups/GroupNetworkCreateTest.php</file>
+
+            <directory suffix=".php">./tests/Feature/Microtasks/Workbench</directory>
             <file>./tests/Feature/Microtasks/BasicTest.php</file>
             <file>./tests/Feature/Microtasks/MobifixOraTest.php</file>
             <file>./tests/Feature/Microtasks/PrintcatOraTest.php</file>
             <file>./tests/Feature/Microtasks/TabicatOraTest.php</file>
+
+            <directory suffix=".php">./tests/Feature/Networks</directory>
+
+            <file>./tests/Feature/Users/Registration/AccountCreationTest.php</file>
+            <file>./tests/Feature/Users//EditLanguageSettingsTest.php</file>
+            <file>./tests/Feature/Users//EditProfileTest.php</file>
+
             <file>./tests/Feature/DeviceStatsTest.php</file>
             <file>./tests/Feature/EventStatsTest.php</file>
             <file>./tests/Feature/GroupStatsTest.php</file>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,32 +9,19 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-<!--
-We have lots of tests which exist but don't run yet.  So we only run a subset of them here.  If you see a <file>,
-it means that there is some other test in that directory which doesn't run yet.
--->
         <testsuite name="Feature">
-            <directory suffix=".php">./tests/Feature/Admin</directory>
+            <directory suffix=".php">./tests/Feature</directory>
             <exclude>./tests/Feature/Admin/Users/WikiLoginTests.php</exclude>
-            <directory suffix=".php">./tests/Feature/Dashboard</directory>
-            <directory suffix=".php">./tests/Feature/Devices</directory>
-            <directory suffix=".php">./tests/Feature/Events</directory>
-            <directory suffix=".php">./tests/Feature/Fixometer</directory>
-            <directory suffix=".php">./tests/Feature/Groups</directory>
             <exclude>./tests/Feature/Groups/WordpressGroupPushTest.php</exclude>
-            <directory suffix=".php">./tests/Feature/Microtasks/</directory>
             <exclude>./tests/Feature/Microtasks/ExampleTest.php</exclude>
             <exclude>./tests/Feature/Microtasks/MisccatTest.php</exclude>
-            <directory suffix=".php">./tests/Feature/Networks</directory>
-            <directory suffix=".php">./tests/Feature/Users</directory>
-            <file>./tests/Feature/DeviceStatsTest.php</file>
-            <file>./tests/Feature/EventStatsTest.php</file>
-            <file>./tests/Feature/GroupStatsTest.php</file>
+            <exclude>./tests/Feature/Zapier/ZapierNetworkTests.php</exclude>
         </testsuite>
 
         <testsuite name="Unit">
             <directory suffix=".php">./tests/Unit</directory>
             <exclude>./tests/Unit/CharsetTest.php</exclude>
+            <exclude>./tests/Unit/WikiPageRetriever.php</exclude>
         </testsuite>
     </testsuites>
     <filter>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,19 +12,27 @@
 <!--        We have lots of tests which exist but don't run yet.  So we only run a subset of them here. -->
         <testsuite name="Feature">
             <directory suffix=".php">./tests/Feature/Dashboard</directory>
-            <directory suffix=".php">./tests/Feature/Fixometer</directory>
             <directory suffix=".php">./tests/Feature/Devices</directory>
             <directory suffix=".php">./tests/Feature/Events</directory>
-            <directory suffix=".php">./tests/Feature/Networks</directory>
+            <directory suffix=".php">./tests/Feature/Fixometer</directory>
             <directory suffix=".php">./tests/Feature/Microtasks/Workbench</directory>
+            <directory suffix=".php">./tests/Feature/Networks</directory>
             <file>./tests/Feature/Users/Registration/AccountCreationTest.php</file>
+            <file>./tests/Feature/Admin/Users/UserDeletedNotificationTest.php</file>
+            <file>./tests/Feature/Admin/Users/ViewUsersTest.php</file>
             <file>./tests/Feature/Groups/BasicTest.php</file>
             <file>./tests/Feature/Groups/GroupCreateTest.php</file>
+            <file>./tests/Feature/Groups/GroupEditTest.php</file>
             <file>./tests/Feature/Groups/GroupNetworkCreateTest.php</file>
             <file>./tests/Feature/Microtasks/BasicTest.php</file>
-            <file>./tests/Feature/Microtasks/DeviceStatsTest.php</file>
-            <file>./tests/Feature/Microtasks/EventStatsTest.php</file>
-            <file>./tests/Feature/Microtasks/GroupStatsTest.php</file>
+            <file>./tests/Feature/Microtasks/FaultcatTest.php</file>
+            <file>./tests/Feature/Microtasks/MobifixOraTest.php</file>
+            <file>./tests/Feature/Microtasks/MobifixTest.php</file>
+            <file>./tests/Feature/Microtasks/PrintcatOraTest.php</file>
+            <file>./tests/Feature/Microtasks/TabicatOraTest.php</file>
+            <file>./tests/Feature/DeviceStatsTest.php</file>
+            <file>./tests/Feature/EventStatsTest.php</file>
+            <file>./tests/Feature/GroupStatsTest.php</file>
         </testsuite>
 
         <testsuite name="Unit">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,7 @@
         <testsuite name="Unit">
             <directory suffix=".php">./tests/Unit</directory>
             <exclude>./tests/Unit/CharsetTest.php</exclude>
-            <exclude>./tests/Unit/WikiPageRetriever.php</exclude>
+            <exclude>./tests/Unit/WikiPageRetrieverTest.php</exclude>
         </testsuite>
     </testsuites>
     <filter>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,7 +26,6 @@
             <file>./tests/Feature/Groups/GroupNetworkCreateTest.php</file>
             <file>./tests/Feature/Microtasks/BasicTest.php</file>
             <file>./tests/Feature/Microtasks/MobifixOraTest.php</file>
-            <file>./tests/Feature/Microtasks/MobifixTest.php</file>
             <file>./tests/Feature/Microtasks/PrintcatOraTest.php</file>
             <file>./tests/Feature/Microtasks/TabicatOraTest.php</file>
             <file>./tests/Feature/DeviceStatsTest.php</file>

--- a/tests/Feature/Admin/Users/ViewUsersTest.php
+++ b/tests/Feature/Admin/Users/ViewUsersTest.php
@@ -63,7 +63,7 @@ class ViewUsersTest extends TestCase
         $response = $this->get('/user/all');
 
         // Then we should see the last login date for that user
-        $response->assertSeeText($lastLogin->diffForHumans());
+        $response->assertSeeText($lastLogin->diffForHumans(null, true));
     }
 
     /** @test */
@@ -79,7 +79,7 @@ class ViewUsersTest extends TestCase
         $response = $this->get('/user/all/search?name=' . $user->name);
 
         // Then we should see the last login date for that user
-        $response->assertSeeText($lastLogin->diffForHumans());
+        $response->assertSeeText($lastLogin->diffForHumans(null, true));
     }
 
     /** @test */
@@ -90,25 +90,25 @@ class ViewUsersTest extends TestCase
         $dateOfLeastRecentLogin = new Carbon('-1 year');
 
         $userWithMostRecentLogin = factory(User::class)->create([
-            'updated_at' => $dateOfMostRecentLogin,
+            'last_login_at' => $dateOfMostRecentLogin,
         ]);
         $otherUsers = factory(User::class, 42)->create([
-            'updated_at' => new Carbon('-1 month'),
+            'last_login_at' => new Carbon('-1 month'),
         ]);
         $userWithLeastRecentLogin = factory(User::class)->create([
-            'updated_at' => $dateOfLeastRecentLogin,
+            'last_login_at' => $dateOfLeastRecentLogin,
         ]);
 
         // When we visit the list of users and sort it by last login descending
-        $response = $this->get('/user/all/search?sort=lastlogin&sortdir=desc');
+        $response = $this->get('/user/all/search?sort=last_login_at&sortdir=desc');
 
         // Then the first result is the most recent login
-        $response->assertSeeText($dateOfMostRecentLogin->diffForHumans());
+        $response->assertSeeText($dateOfMostRecentLogin->diffForHumans(null, true));
 
         // When we visit the list of users and sort it by last login descending
-        $response = $this->get('/user/all/search?sort=lastlogin&sortdir=asc');
+        $response = $this->get('/user/all/search?sort=last_login_at&sortdir=asc');
 
         // Then the first result is the most recent login
-        $response->assertSeeText($dateOfLeastRecentLogin->diffForHumans());
+        $response->assertSeeText($dateOfLeastRecentLogin->diffForHumans(null, true));
     }
 }

--- a/tests/Feature/Groups/GroupEditTest.php
+++ b/tests/Feature/Groups/GroupEditTest.php
@@ -13,16 +13,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class GroupEditTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        DB::statement("SET foreign_key_checks=0");
-        Group::truncate();
-        User::truncate();
-        GroupTags::truncate();
-        DB::statement("SET foreign_key_checks=1");
-    }
-
     /** @test */
     public function group_tags_retained_after_edited_by_host()
     {
@@ -33,6 +23,18 @@ class GroupEditTest extends TestCase
         $group->addTag($tag);
 
         $host = factory(User::class)->states('Host')->create();
+        $group->addVolunteer($host);
+        $group->makeMemberAHost($host);
+
         $this->actingAs($host);
+
+        $response = $this->post('/group/edit/'.$group->idgroups, [
+            [
+                'description' => 'Test'
+            ]
+        ]);
+
+        $this->assertEquals(1, count($group->group_tags));
+        $this->assertEquals($tag->tag_name, $group->group_tags[0]->tag_name);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,11 +3,13 @@
 namespace Tests;
 
 use App\Audits;
+use App\Brands;
 use App\Category;
 use App\Device;
 use App\EventsUsers;
 use App\Group;
 use App\GroupNetwork;
+use App\GroupTags;
 use App\Network;
 
 use App\Party;
@@ -44,7 +46,10 @@ abstract class TestCase extends BaseTestCase
         Device::truncate();
         GroupNetwork::truncate();
         Category::truncate();
+        Brands::truncate();
+        GroupTags::truncate();
         DB::delete('delete from user_network');
+        DB::delete('delete from grouptags_groups');
         DB::table('notifications')->truncate();
         DB::statement("SET foreign_key_checks=1");
 

--- a/tests/Unit/Events/EventPermissionsTests.php
+++ b/tests/Unit/Events/EventPermissionsTests.php
@@ -13,7 +13,7 @@ use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
-class PermissionsTests extends TestCase
+class EventPermissionsTests extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
We're now down at a handful of existing tests that don't work, which are excluded in phpuninit.xml.
* Some are ones which integrate with other components (wiki, Wordpress, Zapier).  These probably aren't worth getting running in CircleCI any time soon.
* Some are ones which relate to quests.  Can you think about whether these will disappear or should be made to work?
* One (ExampleTest) uses RefreshDatabase.  Perhaps the stuff I added in TestCase should use that too?  This one could probably be made to work but doesn't feel too important.

So we might be able to move on to adding new tests.  See what you think.