### PR TITLE
DOT-1480 500 error when editing an event with added devices

### DIFF
--- a/database/migrations/2021_04_06_113426_printcat_ora_setup.php
+++ b/database/migrations/2021_04_06_113426_printcat_ora_setup.php
@@ -13,7 +13,7 @@ class PrintcatOraSetup extends Migration {
      */
     public function up() {
 
-        if (!Schema::hasTable('devices_faults_tablets_ora_opinions')) {
+        if (!Schema::hasTable('devices_faults_printers_ora_opinions')) {
             Schema::create('devices_faults_printers_ora_opinions', function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('id_ords', 16)->index();

--- a/database/migrations/2021_04_06_113426_printcat_ora_setup.php
+++ b/database/migrations/2021_04_06_113426_printcat_ora_setup.php
@@ -13,7 +13,7 @@ class PrintcatOraSetup extends Migration {
      */
     public function up() {
 
-        if (!Schema::hasTable('devices_faults_printers_ora_opinions')) {
+        if (!Schema::hasTable('devices_faults_tablets_ora_opinions')) {
             Schema::create('devices_faults_printers_ora_opinions', function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('id_ords', 16)->index();

--- a/database/migrations/2021_05_11_130314_create_microtask_surveys.php
+++ b/database/migrations/2021_05_11_130314_create_microtask_surveys.php
@@ -13,17 +13,22 @@ class CreateMicrotaskSurveys extends Migration
      */
     public function up()
     {
-        Schema::create('microtask_surveys', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('task', 32)->index();
-            $table->text('payload');
-            $table->string('session_id', 191);
-            $table->ipAddress('ip_address');
-            $table->unsignedInteger('user_id')->nullable();
-            $table->timestamps();
-            $table->charset = 'utf8mb4';
-            $table->collation = 'utf8mb4_unicode_ci';
-        });
+        if (!Schema::hasTable('microtask_surveys')) {
+            Schema::create(
+                'microtask_surveys',
+                function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('task', 32)->index();
+                    $table->text('payload');
+                    $table->string('session_id', 191);
+                    $table->ipAddress('ip_address');
+                    $table->unsignedInteger('user_id')->nullable();
+                    $table->timestamps();
+                    $table->charset = 'utf8mb4';
+                    $table->collation = 'utf8mb4_unicode_ci';
+                }
+            );
+        }
     }
 
     /**

--- a/resources/lang/en/event-audits.php
+++ b/resources/lang/en/event-audits.php
@@ -41,6 +41,7 @@ return array (
       'volunteers' => '<strong>Quantity of Volunteers</strong> was modified from "<strong>:old</strong>" to "<strong>:new</strong>"',
       'hours' => '<strong>Event Hours</strong> was modified from "<strong>:old</strong>" to "<strong>:new</strong>"',
       'wordpress_post_id' => '<strong>Wordpress post ID</strong> was modified from "<strong>:old</strong>" to "<strong>:new</strong>"',
+      'devices_updated_at' => '<strong>Event Devices Updated At</strong> was modified from "<strong>:old</strong>" to "<strong>:new</strong>"',
     ),
   ),
 );

--- a/resources/views/partials/log-accordion.blade.php
+++ b/resources/views/partials/log-accordion.blade.php
@@ -15,6 +15,8 @@
                     <tbody>
                       @foreach ($audit->getModified() as $attribute => $modified)
                           <tr>
+                            {{-- Some updated data is an array. --}}
+                            @php($modified['new'] = is_array($modified['new']) ? json_encode($modified['new']) : $modified['new'])
                             <td>@lang($type.'.'.$audit->event.'.modified.'.$attribute, $modified)</td>
                           </tr>
                       @endforeach


### PR DESCRIPTION
The scenario here is:

- Create an event in the past
- Add a device
- Edit the event

The audit logs contain the new `devices_updated_at `information which is an array, e.g. this:

`{"devices_updated_at":{"date":"2021-06-23 13:37:18.545386","timezone_type":3,"timezone":"Europe\/London"}}`

The method we use to render audit logs fails if a value is an array.

I'm not sure whether or not we ought to be stopping the data getting into the audit log in array form?  But such data now exists in the live DB.  We can make it render acceptably by spotting it and encoding it.