### PR TITLE
DOT-1510 RSVP button doesn't work when invited

### DIFF
--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -78,6 +78,13 @@ class PartyController extends Controller
         $thisone['attending'] = Auth::user() && $event->isBeingAttendedBy(Auth::user()->id);
         $thisone['allinvitedcount'] = $event->allInvited->count();
 
+        // We might have been invited; if so we should include the invitation link.
+        $is_attending = EventsUsers::where('event', $event->idevents)->where('user', Auth::user()->id)->first();
+
+        if ($is_attending && $is_attending->status !== 1) {
+            $thisone['invitation'] = "/party/accept-invite/{$event->idevents}/{$is_attending->status}";
+        }
+
         // TODO LATER Consider whether these stats should be in the event or passed into the store.
         $thisone['stats'] = $event->getEventStats($emissionRatio);
         $thisone['participants_count'] = $event->participants;

--- a/resources/js/components/GroupEventScrollTable.vue
+++ b/resources/js/components/GroupEventScrollTable.vue
@@ -76,7 +76,7 @@
         <span />
       </template>
       <template slot="cell(actions)" slot-scope="data" v-bind:upcoming="upcoming">
-        <GroupEventsScrollTableActions :idevents="data.item.actions.idevents" />
+        <GroupEventsScrollTableActions :idevents="data.item.actions.idevents" class="actionsHeight" />
       </template>
 
       <template slot="head(participants_count)">
@@ -457,5 +457,9 @@ export default {
 
 .minHeight {
   min-height: 330px;
+}
+
+.actionsHeight {
+  height: unset !important;
 }
 </style>

--- a/resources/js/components/GroupEventsScrollTableActions.vue
+++ b/resources/js/components/GroupEventsScrollTableActions.vue
@@ -20,6 +20,9 @@
           {{ __('groups.join_group_button') }}
         </b-btn>
         <!-- We can't RSVP if the event is starting soon. -->
+        <b-btn variant="primary" :href="event.invitation" :disabled="startingSoon" v-else-if="event.invitation">
+          {{ __('events.RSVP') }}
+        </b-btn>
         <b-btn variant="primary" :href="'/party/join/' + idevents" :disabled="startingSoon" v-else>
           {{ __('events.RSVP') }}
         </b-btn>

--- a/resources/views/events/view.blade.php
+++ b/resources/views/events/view.blade.php
@@ -32,7 +32,7 @@
             <div class="row">
               <div class="col-md-8 col-lg-9 d-flex flex-column align-content-center">@lang('events.pending_rsvp_message')</div>
               <div class="col-md-4 col-lg-3 d-flex flex-column align-content-center">
-                <a href="/party/accept-invite/{{{ $is_attending->event }}}/{{{ $is_attending->status }}}" class="btn btn-info">@lang('events.pending_rsvp_button')</a>
+                <a href="/party/accept-invite/{{{ $is_attending->event }}}/{{{ $is_attending->status }}}" class="btn btn-primary">@lang('events.pending_rsvp_button')</a>
               </div>
             </div>
 

--- a/tests/Feature/Events/InviteEventTest.php
+++ b/tests/Feature/Events/InviteEventTest.php
@@ -74,10 +74,11 @@ class InviteEventTest extends TestCase
         preg_match('/href="(\/party\/accept-invite.*?)"/', $response->getContent(), $matches);
         $invitation = $matches[1];
 
-        // ...but shouldn't show up in the list of events as we have not yet accepted.
+        // ...should show up in the list of events with an invitation as we have not yet accepted.
         $response = $this->get('/party');
         $events = $this->getVueProperties($response)[0][':initial-events'];
         $this->assertNotFalse(strpos($events, '"attending":false'));
+        $this->assertNotFalse(strpos($events, '"invitation"'));
 
         // Now accept the invitation.
         $response = $this->get($invitation);


### PR DESCRIPTION
Add an invitation property to the even when we've been invited, and use that as the link for the RSVP button.  I don't think we need to change the text of that button in this case, and there's not much room.

Also fix the format of the button on the individual event page when you've been invited, as it doesn't really match the design.