### PR TITLE
DOT-1474 delete events

### DIFF
--- a/app/Party.php
+++ b/app/Party.php
@@ -908,4 +908,9 @@ class Party extends Model implements Auditable
     {
         return strtotime($this->updated_at) > strtotime($this->devices_updated_at) ? $this->updated_at : $this->devices_updated_at;
     }
+
+    public function canDelete() {
+        $stats = $this->getEventStats();
+        return $stats['devices_powered'] == 0 && $stats['devices_unpowered'] == 0;
+    }
 }

--- a/resources/js/components/EventActions.vue
+++ b/resources/js/components/EventActions.vue
@@ -8,7 +8,10 @@
         <b-dropdown-item :href="'/party/duplicate/' + idevents">
           {{ __('events.duplicate_event') }}
         </b-dropdown-item>
-        <b-dropdown-item @click="confirmDelete" v-if="!inProgress && !finished">
+        <b-dropdown-item @click="confirmDelete" v-if="candelete">
+          {{ __('events.delete_event') }}
+        </b-dropdown-item>
+        <b-dropdown-item @click="confirmDelete" v-else-if="canedit" disabled>
           {{ __('events.delete_event') }}
         </b-dropdown-item>
         <div v-if="finished">
@@ -67,6 +70,11 @@ export default {
       required: true
     },
     canedit: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    candelete: {
       type: Boolean,
       required: false,
       default: false

--- a/resources/js/components/EventActions.vue
+++ b/resources/js/components/EventActions.vue
@@ -11,7 +11,7 @@
         <b-dropdown-item @click="confirmDelete" v-if="candelete">
           {{ __('events.delete_event') }}
         </b-dropdown-item>
-        <b-dropdown-item @click="confirmDelete" v-else-if="canedit" disabled>
+        <b-dropdown-item @click="confirmDelete" v-else-if="isAdmin" disabled>
           {{ __('events.delete_event') }}
         </b-dropdown-item>
         <div v-if="finished">
@@ -54,7 +54,7 @@
         </div>
       </div>
     </b-dropdown>
-    <ConfirmModal @confirm="confirmedDelete" ref="confirmdelete" />
+    <ConfirmModal @confirm="confirmedDelete" :message="__('events.confirm_delete')" ref="confirmdelete" />
   </div>
 </template>
 <script>
@@ -83,6 +83,10 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    isAdmin: {
+      type: Boolean,
+      required: true
     },
     inGroup: {
       type: Boolean,

--- a/resources/js/components/EventHeading.vue
+++ b/resources/js/components/EventHeading.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="d-flex justify-content-between mb-3">
       <h1 class="d-block d-md-none">{{ __('events.events') }}</h1>
-      <EventActions :idevents="idevents" :canedit="canedit" :candelete="candelete" :in-group="inGroup" :is-attending="isAttending" class="d-block d-md-none" />
+      <EventActions :idevents="idevents" :canedit="canedit" :candelete="candelete" :is-admin="isAdmin" :in-group="inGroup" :is-attending="isAttending" class="d-block d-md-none" />
     </div>
     <div class="border-top-very-thick border-bottom-thin mb-3">
       <div class="layout mt-4 mb-3 mb-md-3">
@@ -32,7 +32,7 @@
                 </b>
               </div>
             </div>
-            <EventActions :idevents="idevents" :canedit="canedit" :in-group="inGroup" :is-attending="isAttending" class="d-none d-md-block" />
+            <EventActions :idevents="idevents" :canedit="canedit" :candelete="candelete" :is-admin="isAdmin" :in-group="inGroup" :is-attending="isAttending" class="d-none d-md-block" />
           </div>
         </div>
       </div>
@@ -68,6 +68,10 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    isAdmin: {
+      type: Boolean,
+      required: true
     },
     inGroup: {
       type: Boolean,

--- a/resources/js/components/EventHeading.vue
+++ b/resources/js/components/EventHeading.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="d-flex justify-content-between mb-3">
       <h1 class="d-block d-md-none">{{ __('events.events') }}</h1>
-      <EventActions :idevents="idevents" :canedit="canedit" :in-group="inGroup" :is-attending="isAttending" class="d-block d-md-none" />
+      <EventActions :idevents="idevents" :canedit="canedit" :candelete="candelete" :in-group="inGroup" :is-attending="isAttending" class="d-block d-md-none" />
     </div>
     <div class="border-top-very-thick border-bottom-thin mb-3">
       <div class="layout mt-4 mb-3 mb-md-3">
@@ -55,6 +55,11 @@ export default {
       required: true
     },
     canedit: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    candelete: {
       type: Boolean,
       required: false,
       default: false

--- a/resources/js/components/EventPage.vue
+++ b/resources/js/components/EventPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="event">
-    <EventHeading :idevents="idevents" :canedit="canedit" :in-group="inGroup" :is-attending="isAttending" />
+    <EventHeading :idevents="idevents" :canedit="canedit" :candelete="candelete" :in-group="inGroup" :is-attending="isAttending" />
     <div class="layout">
       <div>
         <EventDetails class="pr-md-3" :idevents="idevents" :hosts="hosts" :calendar-links="calendarLinks" :is-attending="isAttending" :discourse-thread="discourseThread" />
@@ -55,6 +55,11 @@ export default {
       default: function () { return [] }
     },
     canedit: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    candelete: {
       type: Boolean,
       required: false,
       default: false

--- a/resources/js/components/EventPage.vue
+++ b/resources/js/components/EventPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="event">
-    <EventHeading :idevents="idevents" :canedit="canedit" :candelete="candelete" :in-group="inGroup" :is-attending="isAttending" />
+    <EventHeading :idevents="idevents" :canedit="canedit" :candelete="candelete" :is-admin="isAdmin" :in-group="inGroup" :is-attending="isAttending" />
     <div class="layout">
       <div>
         <EventDetails class="pr-md-3" :idevents="idevents" :hosts="hosts" :calendar-links="calendarLinks" :is-attending="isAttending" :discourse-thread="discourseThread" />
@@ -63,6 +63,10 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    isAdmin: {
+      type: Boolean,
+      required: true
     },
     isAttending: {
       type: Boolean,

--- a/resources/js/components/GroupEventsScrollTableNumber.vue
+++ b/resources/js/components/GroupEventsScrollTableNumber.vue
@@ -24,5 +24,6 @@ export default {
 <style scoped lang="scss">
 .cell-number {
   width: 60px;
+  height: unset !important;
 }
 </style>

--- a/resources/views/events/view.blade.php
+++ b/resources/views/events/view.blade.php
@@ -104,6 +104,7 @@
           }
 
           $can_edit_event = (Auth::check() && (App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator') || App\Helpers\Fixometer::userHasEditPartyPermission($event->idevents, Auth::user()->id)));
+          $can_delete_event = Auth::check() && App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator') && $event->canDelete();
           $is_attending = is_object($is_attending) && $is_attending->status == 1;
 
           $discourseThread = $is_attending ? (env('DISCOURSE_URL').'/t/'.$event->discourse_thread) : null;
@@ -159,6 +160,7 @@
             :is-attending="{{ $is_attending ? 'true' : 'false' }}"
             discourse-thread="{{ $discourseThread }}"
             :canedit="{{ $can_edit_event ? 'true' : 'false' }}"
+            :candelete="{{ $can_delete_event ? 'true' : 'false' }}"
             :in-group="{{ Auth::user() && Auth::user()->isInGroup($event->theGroup->idgroups) ? 'true' : 'false' }}"
             :hosts="{{ json_encode($expanded_hosts, JSON_INVALID_UTF8_IGNORE) }}"
             :calendar-links="{{ json_encode($calendar_links != [] ? $calendar_links : null, JSON_INVALID_UTF8_IGNORE) }}"

--- a/resources/views/events/view.blade.php
+++ b/resources/views/events/view.blade.php
@@ -105,6 +105,7 @@
 
           $can_edit_event = (Auth::check() && (App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator') || App\Helpers\Fixometer::userHasEditPartyPermission($event->idevents, Auth::user()->id)));
           $can_delete_event = Auth::check() && App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator') && $event->canDelete();
+          $is_admin = Auth::check() && App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator');
           $is_attending = is_object($is_attending) && $is_attending->status == 1;
 
           $discourseThread = $is_attending ? (env('DISCOURSE_URL').'/t/'.$event->discourse_thread) : null;
@@ -161,6 +162,7 @@
             discourse-thread="{{ $discourseThread }}"
             :canedit="{{ $can_edit_event ? 'true' : 'false' }}"
             :candelete="{{ $can_delete_event ? 'true' : 'false' }}"
+            :is-admin="{{ $is_admin ? 'true' : 'false' }}"
             :in-group="{{ Auth::user() && Auth::user()->isInGroup($event->theGroup->idgroups) ? 'true' : 'false' }}"
             :hosts="{{ json_encode($expanded_hosts, JSON_INVALID_UTF8_IGNORE) }}"
             :calendar-links="{{ json_encode($calendar_links != [] ? $calendar_links : null, JSON_INVALID_UTF8_IGNORE) }}"


### PR DESCRIPTION
This adds a canDelete method for events, exposes it to the client so that we can render the relevant option in the menu, and tests the server behaviour.