### PR TITLE
DOT-1529 dashboard event order

### DIFF
--- a/resources/js/components/DashboardYourGroups.vue
+++ b/resources/js/components/DashboardYourGroups.vue
@@ -118,7 +118,10 @@ export default {
       })
     },
     events() {
-      return this.$store.getters['events/getByGroup'](null).filter(e => e.upcoming)
+      return this.$store.getters['events/getByGroup'](null).filter(e => e.upcoming).sort((a, b) => {
+        // Sort soonest first.
+        return Date.parse(a.event_date + ' ' + a.start) - Date.parse(b.event_date + ' ' + b.start)
+      })
     },
     translatedNewlyAdded() {
       return this.$lang.choice('dashboard.newly_added', this.newGroups, {


### PR DESCRIPTION
Add a sort on the client-side to ensure the order is correct - the store isn't guaranteed to return them in that order.