### PR TITLE
DOT-1511 autoapprove events

### DIFF
--- a/app/Events/ApproveEvent.php
+++ b/app/Events/ApproveEvent.php
@@ -22,9 +22,8 @@ class ApproveEvent
      *
      * @return void
      */
-    public function __construct(Party $party, $data)
+    public function __construct(Party $party)
     {
         $this->party = $party;
-        $this->data = $data;
     }
 }

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -365,18 +365,16 @@ class PartyController extends Controller
                     $networks = $groupObj->networks;
 
                     if ($networks && count($networks)) {
-                        error_log("Has networks");
                         $autoapprove = true;
 
                         foreach ($networks as $network) {
-                            error_log("Check network {$network->id} approve {$network->auto_approve_events}");
                             $autoapprove &= $network->auto_approve_events;
                         }
                     }
 
-                    error_log("Auto-approve $autoapprove");
                     if ($autoapprove) {
                         Log::info('Auto-approve event $idParty');
+                        Party::find($idParty)->approve();
                     }
                 } else {
                     $response['danger'] = 'Party could <strong>not</strong> be created. Something went wrong with the database.';

--- a/app/Listeners/CreateWordPressApproveEventPost.php
+++ b/app/Listeners/CreateWordPressApproveEventPost.php
@@ -36,13 +36,7 @@ class CreateWordPressApproveEventPost
      */
     public function handle(ApproveEvent $event)
     {
-        // TODO: why do we receive both the repair event, and the data array?
-        // The data array is just the details of the repair event.
-        // It seems like we only need one.
-        // The 'moderate' flag is perhaps the only data point that should come
-        // through extra?
         $partyId = $event->party->idevents;
-        $data = $event->data;
 
         $theParty = Party::find($partyId);
 
@@ -60,38 +54,36 @@ class CreateWordPressApproveEventPost
         }
 
         try {
-            if (isset($data['moderate']) && $data['moderate'] == 'approve') {
-                $startTimestamp = strtotime($data['event_date'].' '.$data['start']);
-                $endTimestamp = strtotime($data['event_date'].' '.$data['end']);
+            $startTimestamp = strtotime($event->event_date.' '.$event->start);
+            $endTimestamp = strtotime($event->event_date.' '.$event->end);
 
-                $group = Group::where('idgroups', $data['group'])->first();
+            $group = Group::where('idgroups', $event->group)->first();
 
-                $custom_fields = [
-                    ['key' => 'party_grouphash', 'value' => $data['group']],
-                    ['key' => 'party_venue', 'value' => $data['venue']],
-                    ['key' => 'party_location', 'value' => $data['location']],
-                    ['key' => 'party_time', 'value' => $data['start'].' - '.$data['end']],
-                    ['key' => 'party_groupcountry', 'value' => $group->country],
-                    ['key' => 'party_groupcity', 'value' => $group->area],
-                    ['key' => 'party_date', 'value' => $data['event_date']],
-                    ['key' => 'party_timestamp', 'value' => $startTimestamp],
-                    ['key' => 'party_timestamp_end', 'value' => $endTimestamp],
-                    ['key' => 'party_stats', 'value' => $partyId],
-                    ['key' => 'party_lat', 'value' => $data['latitude']],
-                    ['key' => 'party_lon', 'value' => $data['longitude']],
-                    ['key' => 'party_online', 'value' => $data['online'] ?? 0],
-                ];
+            $custom_fields = [
+                ['key' => 'party_grouphash', 'value' => $event->group],
+                ['key' => 'party_venue', 'value' => $event->venue],
+                ['key' => 'party_location', 'value' => $event->location],
+                ['key' => 'party_time', 'value' => $event->start.' - '.$event->end],
+                ['key' => 'party_groupcountry', 'value' => $group->country],
+                ['key' => 'party_groupcity', 'value' => $group->area],
+                ['key' => 'party_date', 'value' => $event->event_date],
+                ['key' => 'party_timestamp', 'value' => $startTimestamp],
+                ['key' => 'party_timestamp_end', 'value' => $endTimestamp],
+                ['key' => 'party_stats', 'value' => $partyId],
+                ['key' => 'party_lat', 'value' => $event->latitude],
+                ['key' => 'party_lon', 'value' => $event->longitude],
+                ['key' => 'party_online', 'value' => $event->online ?? 0],
+            ];
 
-                $content = [
-                    'post_type' => 'party',
-                    'custom_fields' => $custom_fields,
-                ];
+            $content = [
+                'post_type' => 'party',
+                'custom_fields' => $custom_fields,
+            ];
 
-                $party_name = ! empty($data['venue']) ? $data['venue'] : $data['location'];
-                $wpid = $this->wpClient->newPost($party_name, $data['free_text'], $content);
+            $party_name = ! empty($event->venue) ? $event->venue : $event->location;
+            $wpid = $this->wpClient->newPost($party_name, $event->free_text, $content);
 
-                $theParty->update(['wordpress_post_id' => $wpid]);
-            }
+            $theParty->update(['wordpress_post_id' => $wpid]);
         } catch (\Exception $e) {
             Log::error('An error occurred during Wordpress event creation: '.$e->getMessage());
             $notify_users = Fixometer::usersWhoHavePreference('admin-approve-wordpress-event-failure');

--- a/app/Listeners/CreateWordPressApproveEventPost.php
+++ b/app/Listeners/CreateWordPressApproveEventPost.php
@@ -85,8 +85,6 @@ class CreateWordPressApproveEventPost
 
             $theParty->update(['wordpress_post_id' => $wpid]);
         } catch (\Exception $e) {
-            error_log('An error occurred during Wordpress event creation: '.$e->getMessage());
-
             Log::error('An error occurred during Wordpress event creation: '.$e->getMessage());
             $notify_users = Fixometer::usersWhoHavePreference('admin-approve-wordpress-event-failure');
             Notification::send($notify_users, new AdminWordPressCreateEventFailure([

--- a/app/Listeners/CreateWordPressApproveEventPost.php
+++ b/app/Listeners/CreateWordPressApproveEventPost.php
@@ -54,25 +54,25 @@ class CreateWordPressApproveEventPost
         }
 
         try {
-            $startTimestamp = strtotime($event->event_date.' '.$event->start);
-            $endTimestamp = strtotime($event->event_date.' '.$event->end);
+            $startTimestamp = strtotime($theParty->event_date.' '.$theParty->start);
+            $endTimestamp = strtotime($theParty->event_date.' '.$theParty->end);
 
-            $group = Group::where('idgroups', $event->group)->first();
+            $group = Group::where('idgroups', $theParty->group)->first();
 
             $custom_fields = [
-                ['key' => 'party_grouphash', 'value' => $event->group],
-                ['key' => 'party_venue', 'value' => $event->venue],
-                ['key' => 'party_location', 'value' => $event->location],
-                ['key' => 'party_time', 'value' => $event->start.' - '.$event->end],
+                ['key' => 'party_grouphash', 'value' => $theParty->group],
+                ['key' => 'party_venue', 'value' => $theParty->venue],
+                ['key' => 'party_location', 'value' => $theParty->location],
+                ['key' => 'party_time', 'value' => $theParty->start.' - '.$theParty->end],
                 ['key' => 'party_groupcountry', 'value' => $group->country],
                 ['key' => 'party_groupcity', 'value' => $group->area],
-                ['key' => 'party_date', 'value' => $event->event_date],
+                ['key' => 'party_date', 'value' => $theParty->event_date],
                 ['key' => 'party_timestamp', 'value' => $startTimestamp],
                 ['key' => 'party_timestamp_end', 'value' => $endTimestamp],
                 ['key' => 'party_stats', 'value' => $partyId],
-                ['key' => 'party_lat', 'value' => $event->latitude],
-                ['key' => 'party_lon', 'value' => $event->longitude],
-                ['key' => 'party_online', 'value' => $event->online ?? 0],
+                ['key' => 'party_lat', 'value' => $theParty->latitude],
+                ['key' => 'party_lon', 'value' => $theParty->longitude],
+                ['key' => 'party_online', 'value' => $theParty->online ?? 0],
             ];
 
             $content = [
@@ -80,11 +80,13 @@ class CreateWordPressApproveEventPost
                 'custom_fields' => $custom_fields,
             ];
 
-            $party_name = ! empty($event->venue) ? $event->venue : $event->location;
-            $wpid = $this->wpClient->newPost($party_name, $event->free_text, $content);
+            $party_name = ! empty($theParty->venue) ? $theParty->venue : $theParty->location;
+            $wpid = $this->wpClient->newPost($party_name, $theParty->free_text, $content);
 
             $theParty->update(['wordpress_post_id' => $wpid]);
         } catch (\Exception $e) {
+            error_log('An error occurred during Wordpress event creation: '.$e->getMessage());
+
             Log::error('An error occurred during Wordpress event creation: '.$e->getMessage());
             $notify_users = Fixometer::usersWhoHavePreference('admin-approve-wordpress-event-failure');
             Notification::send($notify_users, new AdminWordPressCreateEventFailure([

--- a/app/Notifications/AdminModerationEvent.php
+++ b/app/Notifications/AdminModerationEvent.php
@@ -51,7 +51,7 @@ class AdminModerationEvent extends Notification implements ShouldQueue
                       ->greeting('Hello!')
                       ->line('A new event has been created: \''.$this->arr['event_venue'].'\'.')
                       ->action('View event', $this->arr['event_url'])
-                      ->line('This event might need your moderation, if it hasn\'t yet been moderated by another administrator.')
+                      ->line('This event might need your moderation, if your network moderates events and it hasn\'t yet been moderated by another administrator.')
                       ->line('If you would like to stop receiving these notifications, please edit <a href="'.url('/user/edit/'.$notifiable->id).'">your preferences</a> on your account.');
     }
 

--- a/app/Party.php
+++ b/app/Party.php
@@ -3,11 +3,14 @@
 namespace App;
 
 use App\Device;
+use App\Events\ApproveEvent;
 use App\EventUsers;
 use App\Helpers\Fixometer;
+use App\Notifications\NotifyRestartersOfNewEvent;
 use Auth;
 use Carbon\Carbon;
 use DB;
+use Notification;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
@@ -912,5 +915,32 @@ class Party extends Model implements Auditable
     public function canDelete() {
         $stats = $this->getEventStats();
         return $stats['devices_powered'] == 0 && $stats['devices_unpowered'] == 0;
+    }
+
+    public function approve() {
+        $group = Group::find($this->group);
+
+        // Only send notifications if the event is in the future.
+        // We don't want to send emails to Restarters about past events being added.
+        if ($this->isUpcoming()) {
+            // Retrieving all users from the User model whereby they allow you send emails but their role must not include group admins
+            $group_restarters = User::join('users_groups', 'users_groups.user', '=', 'users.id')
+                ->where('users_groups.group', $this->group)
+                ->where('users_groups.role', 4)
+                ->select('users.*')
+                ->get();
+
+            // If there are restarters against the group
+            if (! $group_restarters->isEmpty()) {
+                // Send user a notification and email
+                Notification::send($group_restarters, new NotifyRestartersOfNewEvent([
+                                                                                         'event_venue' => $this->venue,
+                                                                                         'event_url' => url('/party/view/'.$this->idevents),
+                                                                                         'event_group' => $group->name,
+                                                                                     ]));
+            }
+        }
+
+        event(new ApproveEvent($this));
     }
 }

--- a/app/Providers/OurSentryLogging.php
+++ b/app/Providers/OurSentryLogging.php
@@ -15,7 +15,6 @@ class OurSentryLogging extends ServiceProvider
      */
     public function register()
     {
-        error_log("Our logging register");
     }
 
     /**

--- a/database/migrations/2021_09_10_093142_autoapprove_events.php
+++ b/database/migrations/2021_09_10_093142_autoapprove_events.php
@@ -17,6 +17,13 @@ class AutoapproveEvents extends Migration
         {
             $table->boolean('auto_approve_events')->default(false);
         });
+
+        $rt = \App\Network::where('name', 'Repair Together')->first();
+
+        if ($rt) {
+            $rt->auto_approve_events = true;
+            $rt->save();
+        }
     }
 
     /**

--- a/database/migrations/2021_09_10_093142_autoapprove_events.php
+++ b/database/migrations/2021_09_10_093142_autoapprove_events.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AutoapproveEvents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('networks', function (Blueprint $table)
+        {
+            $table->boolean('auto_approve_events')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('networks', function (Blueprint $table) {
+            $table->dropColumn('auto_approve_events');
+        });
+    }
+}

--- a/tests/Feature/Events/WordpressEventPushTest.php
+++ b/tests/Feature/Events/WordpressEventPushTest.php
@@ -37,14 +37,14 @@ class WordpressEventPushTest extends TestCase
         ]);
         $group = factory(Group::class)->create();
         $restart->addGroup($group);
-        $event = factory(Party::class)->create(['group' => $group->idgroups]);
+        $event = factory(Party::class)->create([
+            'group' => $group->idgroups,
+            'latitude' => 1,
+            'longitude' => 1,
+            'event_date' => '2100-01-01'
+        ]);
 
-        $eventData = factory(Party::class)->raw();
-        $eventData['moderate'] = 'approve';
-        $eventData['latitude'] = '1';
-        $eventData['longitude'] = '1';
-
-        event(new ApproveEvent($event));
+        $event->approve();
     }
 
     /** @test */

--- a/tests/Feature/Events/WordpressEventPushTest.php
+++ b/tests/Feature/Events/WordpressEventPushTest.php
@@ -44,7 +44,7 @@ class WordpressEventPushTest extends TestCase
         $eventData['latitude'] = '1';
         $eventData['longitude'] = '1';
 
-        event(new ApproveEvent($event, $eventData));
+        event(new ApproveEvent($event));
     }
 
     /** @test */
@@ -66,7 +66,7 @@ class WordpressEventPushTest extends TestCase
         $eventData['latitude'] = '1';
         $eventData['longitude'] = '1';
 
-        event(new ApproveEvent($event, $eventData));
+        event(new ApproveEvent($event));
     }
 
     /** @test */

--- a/tests/Feature/Groups/BasicTest.php
+++ b/tests/Feature/Groups/BasicTest.php
@@ -27,7 +27,7 @@ class BasicTest extends TestCase
                 ':user-id' => '1',
                 'tab' => 'mine',
                 ':network' => 'null',
-                ':networks' => '[{"id":1,"name":"Restarters","description":null,"website":null,"default_language":"en","timezone":"Europe\\/London","created_at":"2021-05-24 12:19:37","updated_at":"2021-05-24 12:19:37","events_push_to_wordpress":0,"include_in_zapier":0,"users_push_to_drip":0,"shortname":"restarters","discourse_group":null}]',
+                ':networks' => '[{"id":1,"name":"Restarters","description":null,"website":null,"default_language":"en","timezone":"Europe\\/London","created_at":"2021-05-24 12:19:37","updated_at":"2021-05-24 12:19:37","events_push_to_wordpress":0,"include_in_zapier":0,"users_push_to_drip":0,"shortname":"restarters","discourse_group":null,"auto_approve_events":0}]',
                 ':show-tags' => 'false',
             ],
         ]);


### PR DESCRIPTION
- Move event approval into a method of Event.
- Rework ApproveEvent to remove passing of $data, which the code itself was already sceptical about.
- Add a field into the Network to indicate whether events should be auto-approved.
- Migrate the Repair Together network to set this.
- Tweak email notification to cover this case.
- Add tests for auto-approval (and not).