### PR TITLE
RES-1563 Allow network coordinators to delete events.

### DIFF
--- a/app/Helpers/Fixometer.php
+++ b/app/Helpers/Fixometer.php
@@ -111,6 +111,7 @@ class Fixometer
         if (self::hasRole($user, 'Administrator')) {
             return true;
         }
+
         if (self::hasRole($user, 'NetworkCoordinator')) {
             $group = Party::find($partyId)->theGroup;
             foreach ($group->networks as $network) {
@@ -119,12 +120,41 @@ class Fixometer
                 }
             }
         }
+
         if (self::hasRole($user, 'Host')) {
             $group_id_of_event = Party::where('idevents', $partyId)->value('group');
             if (self::userIsHostOfGroup($group_id_of_event, $userId)) {
                 return true;
             } elseif (empty(DB::table('events_users')->where('event', $partyId)->where('user', $user->id)->first())) {
                 return false;
+            }
+        }
+
+        return false;
+    }
+
+    public static function userHasDeletePartyPermission($partyId, $userId = null)
+    {
+        if (is_null($userId)) {
+            if (empty(Auth::user())) {
+                return false;
+            } else {
+                $userId = Auth::user()->id;
+            }
+        }
+
+        $user = User::find($userId);
+
+        if (self::hasRole($user, 'Administrator')) {
+            return true;
+        }
+
+        if (self::hasRole($user, 'NetworkCoordinator')) {
+            $group = Party::find($partyId)->theGroup;
+            foreach ($group->networks as $network) {
+                if ($network->coordinators->contains($user)) {
+                    return true;
+                }
             }
         }
 

--- a/app/Helpers/Geocoder.php
+++ b/app/Helpers/Geocoder.php
@@ -8,9 +8,14 @@ class Geocoder
     {
     }
 
+    private function googleKey() {
+        // We have this so that we can change the key in testing.
+        return config('GOOGLE_API_CONSOLE_KEY') ?? env('GOOGLE_API_CONSOLE_KEY');
+    }
+
     public function geocode($location)
     {
-        $json = file_get_contents('https://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&key='.config('GOOGLE_API_CONSOLE_KEY'));
+        $json = file_get_contents('https://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&key='.$this->googleKey());
 
         if ($json) {
             $res = json_decode($json);
@@ -40,7 +45,7 @@ class Geocoder
 
     public function reverseGeocode($lat, $lng)
     {
-        $json = file_get_contents("https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lng&key=".config('GOOGLE_API_CONSOLE_KEY'));
+        $json = file_get_contents("https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lng&key=".$this->googleKey());
 
         $decoded = json_decode($json)->results[0];
 

--- a/app/Helpers/Geocoder.php
+++ b/app/Helpers/Geocoder.php
@@ -10,7 +10,7 @@ class Geocoder
 
     public function geocode($location)
     {
-        $json = file_get_contents('https://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&key='.env('GOOGLE_API_CONSOLE_KEY'));
+        $json = file_get_contents('https://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&key='.config('GOOGLE_API_CONSOLE_KEY'));
 
         if ($json) {
             $res = json_decode($json);
@@ -40,7 +40,7 @@ class Geocoder
 
     public function reverseGeocode($lat, $lng)
     {
-        $json = file_get_contents("https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lng&key=".env('GOOGLE_API_CONSOLE_KEY'));
+        $json = file_get_contents("https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lng&key=".config('GOOGLE_API_CONSOLE_KEY'));
 
         $decoded = json_decode($json)->results[0];
 

--- a/resources/views/events/view.blade.php
+++ b/resources/views/events/view.blade.php
@@ -103,8 +103,8 @@
               $group_image->image->path;
           }
 
-          $can_edit_event = (Auth::check() && (App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator') || App\Helpers\Fixometer::userHasEditPartyPermission($event->idevents, Auth::user()->id)));
-          $can_delete_event = Auth::check() && App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator') && $event->canDelete();
+          $can_edit_event = Auth::check() && App\Helpers\Fixometer::userHasEditPartyPermission($event->idevents, Auth::user()->id);
+          $can_delete_event = Auth::check() && App\Helpers\Fixometer::userHasDeletePartyPermission($event->idevents, Auth::user()->id) && $event->canDelete();
           $is_admin = Auth::check() && App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator');
           $is_attending = is_object($is_attending) && $is_attending->status == 1;
 

--- a/tests/Feature/Events/OnlineEventsTest.php
+++ b/tests/Feature/Events/OnlineEventsTest.php
@@ -16,7 +16,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
-class OnlineEventsTests extends TestCase
+class OnlineEventsTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Feature/Users/EditProfileTests.php
+++ b/tests/Feature/Users/EditProfileTests.php
@@ -102,8 +102,8 @@ class EditProfileTests extends TestCase
         $this->assertEquals(51.507, round($user->latitude, 3));
         $this->assertEquals(-0.128, round($user->longitude, 3));
 
-        $good = Config::set(['GOOGLE_API_CONSOLE_KEY']);
-        config(['GOOGLE_API_CONSOLE_KEY' => 'zzz']);
+        $good = Config::get(['GOOGLE_API_CONSOLE_KEY']);
+        Config::set(['GOOGLE_API_CONSOLE_KEY' => 'zzz']);
 
         $this->post('/profile/edit-info', [
             'name' => $user->name,

--- a/tests/Feature/Users/EditProfileTests.php
+++ b/tests/Feature/Users/EditProfileTests.php
@@ -9,6 +9,7 @@ use DB;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
+use Illuminate\Support\Facades\Config;
 
 class EditProfileTests extends TestCase
 {
@@ -101,13 +102,18 @@ class EditProfileTests extends TestCase
         $this->assertEquals(51.507, round($user->latitude, 3));
         $this->assertEquals(-0.128, round($user->longitude, 3));
 
+        $good = Config::set(['GOOGLE_API_CONSOLE_KEY']);
+        config(['GOOGLE_API_CONSOLE_KEY' => 'zzz']);
+
         $this->post('/profile/edit-info', [
             'name' => $user->name,
             'email' => $user->email,
             'age' => $user->age,
             'country' => 'GBR',
-            'townCity' => 'zzzzzzz',
+            'townCity' => 'ZZZZ',
         ]);
+
+        Config::set(['GOOGLE_API_CONSOLE_KEY' => $good]);
 
         $user = $user->fresh();
         $this->assertNull($user->latitude);

--- a/tests/Feature/Users/EditProfileTests.php
+++ b/tests/Feature/Users/EditProfileTests.php
@@ -102,8 +102,8 @@ class EditProfileTests extends TestCase
         $this->assertEquals(51.507, round($user->latitude, 3));
         $this->assertEquals(-0.128, round($user->longitude, 3));
 
-        $good = Config::get(['GOOGLE_API_CONSOLE_KEY']);
-        Config::set(['GOOGLE_API_CONSOLE_KEY' => 'zzz']);
+        $good = Config::get('GOOGLE_API_CONSOLE_KEY');
+        Config::set('GOOGLE_API_CONSOLE_KEY', 'zzz');
 
         $this->post('/profile/edit-info', [
             'name' => $user->name,
@@ -113,7 +113,7 @@ class EditProfileTests extends TestCase
             'townCity' => 'ZZZZ',
         ]);
 
-        Config::set(['GOOGLE_API_CONSOLE_KEY' => $good]);
+        Config::set('GOOGLE_API_CONSOLE_KEY', $good);
 
         $user = $user->fresh();
         $this->assertNull($user->latitude);

--- a/tests/Feature/Users/Registration/AccountCreationTest.php
+++ b/tests/Feature/Users/Registration/AccountCreationTest.php
@@ -46,8 +46,8 @@ class AccountCreationTest extends TestCase
         $userAttributes = $this->userAttributes();
 
         // Specify an invalid city and force geocoding to fail by invalidating the Google key.
-        $good = Config::set(['GOOGLE_API_CONSOLE_KEY']);
-        config(['GOOGLE_API_CONSOLE_KEY' => 'zzz']);
+        $good = Config::get(['GOOGLE_API_CONSOLE_KEY']);
+        Config::set(['GOOGLE_API_CONSOLE_KEY' => 'zzz']);
 
         $userAttributes['city'] = 'zzzzzzz';
         $response = $this->post('/user/register/', $userAttributes);

--- a/tests/Feature/Users/Registration/AccountCreationTest.php
+++ b/tests/Feature/Users/Registration/AccountCreationTest.php
@@ -9,6 +9,7 @@ use Hash;
 use Mockery;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\TestCase;
+use Illuminate\Support\Facades\Config;
 
 class AccountCreationTest extends TestCase
 {
@@ -44,9 +45,14 @@ class AccountCreationTest extends TestCase
     {
         $userAttributes = $this->userAttributes();
 
-        // Specify an invalid city
+        // Specify an invalid city and force geocoding to fail by invalidating the Google key.
+        $good = Config::set(['GOOGLE_API_CONSOLE_KEY']);
+        config(['GOOGLE_API_CONSOLE_KEY' => 'zzz']);
+
         $userAttributes['city'] = 'zzzzzzz';
         $response = $this->post('/user/register/', $userAttributes);
+
+        Config::set(['GOOGLE_API_CONSOLE_KEY' => $good]);
 
         $response->assertStatus(302);
         $response->assertRedirect('dashboard');

--- a/tests/Feature/Users/Registration/AccountCreationTest.php
+++ b/tests/Feature/Users/Registration/AccountCreationTest.php
@@ -46,13 +46,13 @@ class AccountCreationTest extends TestCase
         $userAttributes = $this->userAttributes();
 
         // Specify an invalid city and force geocoding to fail by invalidating the Google key.
-        $good = Config::get(['GOOGLE_API_CONSOLE_KEY']);
-        Config::set(['GOOGLE_API_CONSOLE_KEY' => 'zzz']);
+        $good = Config::get('GOOGLE_API_CONSOLE_KEY');
+        Config::set('GOOGLE_API_CONSOLE_KEY', 'zzz');
 
         $userAttributes['city'] = 'zzzzzzz';
         $response = $this->post('/user/register/', $userAttributes);
 
-        Config::set(['GOOGLE_API_CONSOLE_KEY' => $good]);
+        Config::set('GOOGLE_API_CONSOLE_KEY', $good);
 
         $response->assertStatus(302);
         $response->assertRedirect('dashboard');


### PR DESCRIPTION
Rework delete permissions for an event:

- Add a method to query it.  The permissions are different from Edit.  As we know, the permissions could do with being centralised.
- Query that.
- Change/add tests in this area.