### PR TITLE
RES-1587 too many volunteers

### DIFF
--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -922,14 +922,15 @@ class PartyController extends Controller
     {
         $group_user_ids = UserGroups::where('group', Party::find($event_id)->group)
         ->where('user', '!=', Auth::user()->id)
+        ->where('status', '=', 1)
         ->pluck('user')
         ->toArray();
 
-        // Users already associated with the event.
-        // (Not including those invited but not RSVPed)
+        // Users already confirmed as attending the event.
+        //
+        // We don't want to return users who are already invited - we shouldn't be able to invite twice.
         $event_user_ids = EventsUsers::where('event', $event_id)
         ->where('user', '!=', Auth::user()->id)
-        ->where('status', 'like', '1')
         ->pluck('user')
         ->toArray();
 

--- a/tests/Feature/Events/InviteEventTest.php
+++ b/tests/Feature/Events/InviteEventTest.php
@@ -92,4 +92,80 @@ class InviteEventTest extends TestCase
         $events = $this->getVueProperties($response)[0][':initial-events'];
         $this->assertNotFalse(strpos($events, '"attending":true'));
     }
+
+    public function testInvitable() {
+        $this->withoutExceptionHandling();
+
+        $group = factory(Group::class)->create();
+        $event = factory(Party::class)->create([
+                                                   'group' => $group,
+                                                   'event_date' => '2130-01-01',
+                                                   'start' => '12:13'
+                                               ]);
+
+        $host = factory(User::class)->states('Host')->create();
+        $this->actingAs($host);
+
+        // Should have no group members and therefore no invitable members.
+        $response = $this->get('/party/get-group-emails-with-names/' . $event->idevents);
+        $members = json_decode($response->getContent());
+        $this->assertEquals([], $members);
+
+        // User joins the group.
+        $user = factory(User::class)->states('Restarter')->create();
+        $this->get('/logout');
+        $this->actingAs($user);
+        $response = $this->get('/group/join/' . $group->idgroups);
+        $this->assertTrue($response->isRedirection());
+
+        // Shouldn't show up as invitable when we are logged in.
+        $response = $this->get('/party/get-group-emails-with-names/' . $event->idevents);
+        $members = json_decode($response->getContent());
+        $this->assertEquals([], $members);
+
+        // Now should show as invitable to the event.
+        $this->get('/logout');
+        $this->actingAs($host);
+        $response = $this->get('/party/get-group-emails-with-names/' . $event->idevents);
+        $members = json_decode($response->getContent());
+        $this->assertEquals(1, count($members));
+
+        // Invite the user to the event.
+        $response = $this->post('/party/invite', [
+            'group_name' => $group->name,
+            'event_id' => $event->idevents,
+            'manual_invite_box' => $user->email,
+            'message_to_restarters' => 'Join us, but not in a creepy zombie way',
+        ]);
+
+        $response->assertSessionHas('success');
+
+        // Invited member should not show up as invitable.
+        $response = $this->get('/party/get-group-emails-with-names/' . $event->idevents);
+        $members = json_decode($response->getContent());
+        $this->assertEquals([], $members);
+
+        // As the user...
+        $this->get('/logout');
+        $this->actingAs($user);
+
+        // Now accept the invitation.
+        $response = $this->get('/party/view/' . $event->idevents);
+        $response->assertSee('You&#039;ve been invited to join an event');
+        preg_match('/href="(\/party\/accept-invite.*?)"/', $response->getContent(), $matches);
+        $this->assertGreaterThan(0, count($matches));
+        $invitation = $matches[1];
+
+        $response = $this->get($invitation);
+        $this->assertTrue($response->isRedirection());
+        $redirectTo = $response->getTargetUrl();
+        $this->assertNotFalse(strpos($redirectTo, '/party/view/' . $event->idevents));
+
+        // Now a group member and confirmed so should not show as invitable.
+        $this->get('/logout');
+        $this->actingAs($host);
+        $response = $this->get('/party/get-group-emails-with-names/' . $event->idevents);
+        $members = json_decode($response->getContent());
+        $this->assertEquals([], $members);
+    }
 }


### PR DESCRIPTION
The logic for which volunteers are invitable is bugged:

- It included people invited to the group but who have not accepted.  They shouldn't be invitable to an event.
- It included people invited to the event already.  We shouldn't be able to pester people by inviting them twice.