### PR TITLE
RES-1521 password reset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,15 @@ jobs:
       # We don't have Discourse on CircleCI.
       - run: sed -i 's/FEATURE__DISCOURSE_INTEGRATION=.*$/FEATURE__DISCOURSE_INTEGRATION=false/g' .env
 
+      # ...but we do have Mediawiki.
+      - run: sed -i 's/FEATURE__WIKI_INTEGRATION=.*$/FEATURE__DISCOURSE_INTEGRATION=true/g' .env
+      - run: sed -i 's/WIKI_URL=.*$/WIKI_URL=http://mediawiki:8080/g' .env
+      - run: sed -i 's/WIKI_DB=.*$/WIKI_DB=bitnami_mediawiki/g' .env
+      - run: sed -i 's/WIKI_USER=.*$/WIKI_USER=user/g' .env
+      - run: sed -i 's/WIKI_PASSWORD=.*$/WIKI_PASSWORD=bitnami123/g' .env
+      - run: sed -i 's/WIKI_APIUSER=.*$/WIKI_APIUSER=user/g' .env
+      - run: sed -i 's/WIKI_APIPASSWORD=.*$/WIKI_APIPASSWORD=bitnami123/g' .env
+
       # Playwright needs the debug bar not to appear
       - run: sed -i 's/APP_DEBUG=.*$/APP_DEBUG=FALSE/g' .env
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
 
       # ...but we do have Mediawiki.
       - run: sed -i 's/FEATURE__WIKI_INTEGRATION=.*$/FEATURE__DISCOURSE_INTEGRATION=true/g' .env
-      - run: sed -i 's/WIKI_URL=.*$/WIKI_URL=http://mediawiki:8080/g' .env
+      - run: sed -i 's/WIKI_URL=.*$/WIKI_URL=http:\/\/mediawiki:8080/g' .env
       - run: sed -i 's/WIKI_DB=.*$/WIKI_DB=bitnami_mediawiki/g' .env
       - run: sed -i 's/WIKI_USER=.*$/WIKI_USER=user/g' .env
       - run: sed -i 's/WIKI_PASSWORD=.*$/WIKI_PASSWORD=bitnami123/g' .env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,8 @@ jobs:
           - MEDIAWIKI_DATABASE_USER=bn_mediawiki
           - MEDIAWIKI_DATABASE_NAME=bitnami_mediawiki
           - ALLOW_EMPTY_PASSWORD=yes
-        ports:
-          - '80:80'
-          - '443:443'
+          - MEDIAWIKI_EXTERNAL_HTTP_PORT_NUMBER=8080
+          - MEDIAWIKI_HOST:mediawiki
         depends_on:
           - mariadb
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run: sed -i 's/FEATURE__DISCOURSE_INTEGRATION=.*$/FEATURE__DISCOURSE_INTEGRATION=false/g' .env
 
       # ...but we do have Mediawiki.
-      - run: sed -i 's/FEATURE__WIKI_INTEGRATION=.*$/FEATURE__DISCOURSE_INTEGRATION=true/g' .env
+      - run: sed -i 's/FEATURE__WIKI_INTEGRATION=.*$/FEATURE__WIKI_INTEGRATION=true/g' .env
       - run: sed -i 's/WIKI_URL=.*$/WIKI_URL=http:\/\/mediawiki:8080/g' .env
       - run: sed -i 's/WIKI_DB=.*$/WIKI_DB=bitnami_mediawiki/g' .env
       - run: sed -i 's/WIKI_USER=.*$/WIKI_USER=user/g' .env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           - MEDIAWIKI_DATABASE_NAME=bitnami_mediawiki
           - ALLOW_EMPTY_PASSWORD=yes
           - MEDIAWIKI_EXTERNAL_HTTP_PORT_NUMBER=8080
-          - MEDIAWIKI_HOST:mediawiki
+          - MEDIAWIKI_HOST=mediawiki
         depends_on:
           - mariadb
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,27 @@ jobs:
       - image: mcr.microsoft.com/playwright:focal
         environment:
           NODE_ENV: development
+      - image: 'bitnami/mariadb:latest'
+        name: mariadb
+        environment:
+          - ALLOW_EMPTY_PASSWORD=yes
+          - MARIADB_USER=bn_mediawiki
+          - MARIADB_DATABASE=bitnami_mediawiki
+      - image: 'bitnami/mediawiki:1'
+        name: mediawiki
+        labels:
+          kompose.service.type: nodeport
+        environment:
+          - MARIADB_HOST=mariadb
+          - MARIADB_PORT_NUMBER=3306
+          - MEDIAWIKI_DATABASE_USER=bn_mediawiki
+          - MEDIAWIKI_DATABASE_NAME=bitnami_mediawiki
+          - ALLOW_EMPTY_PASSWORD=yes
+        ports:
+          - '80:80'
+          - '443:443'
+        depends_on:
+          - mariadb
     steps:
       - checkout
       - run: sudo apt update

--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,7 @@ WIKI_PASSWORD=example
 WIKI_APIUSER=wikiapi
 WIKI_APIPASSWORD=w1k1ap1
 WIKI_COOKIE_PREFIX=wiki_db
+WIKI_HOST=mediawiki
 
 FEATURE__DISCOURSE_INTEGRATION=true
 # Always put quotes around Discourse secrets, because they might contain the hash symbol.

--- a/app/Console/Commands/LanguageSync.php
+++ b/app/Console/Commands/LanguageSync.php
@@ -50,7 +50,7 @@ class LanguageSync extends Command
         if (! env('WIKI_DB')) {
             $this->error('Wiki integration not enabled');
         } else {
-            $dsn = 'mysql:host=localhost;port=3306;dbname='.env('WIKI_DB').';charset=utf8';
+            $dsn = 'mysql:host='.env('WIKI_HOST', 'localhost') . ';port=3306;dbname='.env('WIKI_DB').';charset=utf8';
             $mwdb = new \PDO($dsn, env('WIKI_DB_USER'), env('WIKI_DB_PASSWORD'), [
                 \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci',
                 \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,

--- a/app/Console/Commands/MigrateWikiPasswords.php
+++ b/app/Console/Commands/MigrateWikiPasswords.php
@@ -41,7 +41,7 @@ class MigrateWikiPasswords extends Command
         $users = User::whereNotNull('mediawiki')->whereNull('deleted_at')->get();
 
         foreach ($users as $user) {
-            $this->info("php changePassword.php --user={$user->mediawiki} --password=\"{$user->password}\"");
+            $this->info("php changePassword.php --user={$user->mediawiki} --password='{$user->password}'");
         }
     }
 }

--- a/app/Console/Commands/MigrateWikiPasswords.php
+++ b/app/Console/Commands/MigrateWikiPasswords.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\User;
+use Illuminate\Console\Command;
+
+class MigrateWikiPasswords extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'wiki:migratepasswords';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Move wiki accounts over to the new password format';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $users = User::whereNotNull('mediawiki')->whereNull('deleted_at')->get();
+
+        foreach ($users as $user) {
+            $this->info("php changePassword.php --user={$user->mediawiki} --password=\"{$user->password}\"");
+        }
+    }
+}

--- a/app/Events/PasswordChanged.php
+++ b/app/Events/PasswordChanged.php
@@ -16,14 +16,16 @@ class PasswordChanged
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public $user;
+    public $oldPassword;
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct(User $user)
+    public function __construct(User $user, String $oldPassword)
     {
         $this->user = $user;
+        $this->oldPassword = $oldPassword;
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -204,6 +204,7 @@ class UserController extends Controller
         }
 
         if ($request->input('new-password') == $request->input('new-password-repeat') && Hash::check($request->input('current-password'), $user->password)) {
+            $oldPassword = $user->password;
             $user->setPassword(Hash::make($request->input('new-password')));
             $user->save();
 
@@ -212,7 +213,7 @@ class UserController extends Controller
             'recovery_expires' => strftime('%Y-%m-%d %X', time() + (24 * 60 * 60)),
             ]);
 
-            event(new PasswordChanged($user));
+            event(new PasswordChanged($user, $oldPassword));
 
             return redirect()->back()->with('message', 'User Password Updated!');
         }
@@ -421,17 +422,15 @@ class UserController extends Controller
         return redirect()->back()->with('success', 'Profile updated');
     }
 
-    /**
-     * @ToDo : test and delete commented
-     */
-    public function recover()
+    public function recover(Request $request)
     {
         $User = new User;
 
-        if (strtoupper($_SERVER['REQUEST_METHOD']) == 'POST' && isset($_POST['email']) && ! empty($_POST['email'])) {
-            $email = $_POST['email'];
+        $email = $request->get('email');
+
+        if ($request->getMethod() == 'POST' && $email) {
             if (empty($email) || ! filter_var($email, FILTER_VALIDATE_EMAIL)) {
-                $response['danger'] = 'Please input a <strong>valid</strong> email.';
+                $response['danger'] = __('passwords.invalid');
             } else {
                 $user = $User->where('email', $email)->first();
 
@@ -448,39 +447,41 @@ class UserController extends Controller
 
                     // update record
                     $user->update([
-                    'recovery' => $data['recovery'],
-                    'recovery_expires' => $data['recovery_expires'],
+                        'recovery' => $data['recovery'],
+                        'recovery_expires' => $data['recovery_expires'],
                     ]);
 
                     User::find($id)->notify(new ResetPassword([
                       'url' => env('APP_URL').'/user/reset?recovery='.$data['recovery'],
                     ]));
 
-                    $response['success'] = 'Email Sent! Please check your inbox and follow instructions';
+                    $response['success'] = __('passwords.sent');
                 } else {
-                    $response['danger'] = 'This email is not in our database.';
+                    $response['danger'] = __('passwords.user');
                 }
             }
 
             return view('auth.forgot-password', [//user.recover
-            'title' => 'Account recovery',
-            'response' => $response,
+                'title' => __('passwords.recover_title'),
+                'response' => $response,
             ]);
         }
 
         return view('auth.forgot-password', [//user.recover
-        'title' => 'Account recovery',
+            'title' => __('passwords.recover_title'),
         ]);
     }
 
-    public function reset()
+    public function reset(Request $request)
     {
         $User = new User;
 
-        if (! isset($_GET['recovery']) || empty($_GET['recovery'])) {
+        $recovery = $request->post('recovery');
+
+        if (!$recovery) {
             $valid_code = false;
         } else {
-            $recovery = filter_var($_GET['recovery'], FILTER_SANITIZE_STRING);
+            $recovery = filter_var($recovery, FILTER_SANITIZE_STRING);
             $user = $User->where('recovery', '=', $recovery)->first();
 
             if (is_object($user) && strtotime($user->recovery_expires) > time()) {
@@ -490,52 +491,39 @@ class UserController extends Controller
             }
         }
 
-        if (strtoupper($_SERVER['REQUEST_METHOD']) == 'POST' && isset($_POST['password']) && ! empty($_POST['password']) && isset($_POST['confirm_password']) && ! empty($_POST['confirm_password'])) {
-            $recovery = $_POST['recovery'];
-            $pwd = $_POST['password'];
-            $cpwd = $_POST['confirm_password'];
-            if (empty($recovery) || ! filter_var($recovery, FILTER_SANITIZE_STRING)) {
-                $response['danger'] = 'Recovery code invalid.';
+        $pwd = $request->post('password');
+        $cpwd = $request->post('confirm_password');
+        $response = null;
+        $email = null;
+
+        if ($request->getMethod() == 'POST' && $pwd && $cpwd) {
+            if (!$valid_code) {
+                $response['danger'] = __('passwords.token');
             } elseif ($pwd !== $cpwd) {
-                $response['danger'] = 'The passwords do not match';
+                $response['danger'] = __('passwords.match');
             } else {
-                $user = $User->where('recovery', '=', $recovery)->first();
-                if (! empty($user)) {
-                    $data = [
+                $email = $user->email;
+                $oldPassword = $user->password;
+
+                $update = $user->update([
                     'password' => crypt($pwd, '$1$'.strrev(md5(env('APP_KEY')))),
-                    ];
-                    $update = $user->update($data);
-                    if ($update) {
-                        return redirect('login')->with('success', 'Password updated, please login to continue');
-                    } else {
-                        $response['danger'] = 'Could not update the password.';
-                    }
+                ]);
+
+                if ($update) {
+                    event(new PasswordChanged($user, $oldPassword));
+                    return redirect('login')->with('success', __('passwords.updated'));
                 } else {
-                    $response['danger'] = 'No account matches the recovery code';
+                    $response['danger'] = __('passwords.failed');
                 }
             }
         }
 
-        if (! isset($recovery)) {
-            $recovery = null;
-        }
-
-        if (! isset($response)) {
-            $response = null;
-        }
-
-        if (isset($user)) {
-            $email = $user->email;
-        } else {
-            $email = null;
-        }
-
-        return view('auth.reset-password', [//user.reset
-        'title' => 'Account recovery',
-        'recovery' => $recovery,
-        'valid_code' => $valid_code,
-        'response' => $response,
-        'email' => $email,
+        return view('auth.reset-password', [
+            'title' => 'Account recovery',
+            'recovery' => $recovery,
+            'valid_code' => $valid_code,
+            'response' => $response,
+            'email' => $email,
         ]);
     }
 

--- a/app/Listeners/LogInToWiki.php
+++ b/app/Listeners/LogInToWiki.php
@@ -16,6 +16,10 @@ use Mediawiki\Api\Service\UserCreator;
 
 class LogInToWiki
 {
+    // We use the Laravel hashed password as the mediawiki password.  This means we can log in to the wiki
+    // if we need to, which we wouldn't always be able to do if we used the original password (for example
+    // during password reset).  It also avoids Mediawiki complaining about the password being a common one.
+
     protected $wikiUserCreator;
 
     /**
@@ -43,21 +47,21 @@ class LogInToWiki
 
         if ($user->wiki_sync_status == WikiSyncStatus::CreateAtLogin) {
             Log::info("Need to create " . $user->name);
-            $this->createUserInWiki($user, $this->request->input('password'));
+            $this->createUserInWiki($user);
         }
 
         if (! is_null($user->mediawiki) && ! empty($user->mediawiki) &&
             $user->wiki_sync_status == WikiSyncStatus::Created) {
-            $this->logUserIn($user->mediawiki, $this->request->input('password'));
+            $this->logUserIn($user);
         }
     }
 
-    protected function createUserInWiki($user, $password)
+    protected function createUserInWiki($user)
     {
         try {
             // Mediawiki does strange things with underscores.
             $mediawikiUsername = str_replace('_', '-', $user->username);
-            $this->wikiUserCreator->create($mediawikiUsername, $password, $user->email);
+            $this->wikiUserCreator->create($mediawikiUsername, $user->password, $user->email);
 
             $user->wiki_sync_status = WikiSyncStatus::Created;
             $user->mediawiki = $mediawikiUsername;
@@ -67,13 +71,13 @@ class LogInToWiki
         }
     }
 
-    protected function logUserIn($wikiUsername, $password)
+    protected function logUserIn($user)
     {
         try {
-            Log::info("Log in to wiki $wikiUsername");
+            Log::info("Log in to wiki $user->mediawiki");
             $api = MediawikiApi::newFromApiEndpoint(env('WIKI_URL').'/api.php');
-            $api->login(new ApiUser($wikiUsername, $password));
-            Log::info("Logged in to wiki $wikiUsername");
+            $api->login(new ApiUser($user->mediawiki, $user->password));
+            Log::info("Logged in to wiki $user->mediawiki");
 
             // NGM: it appears that right from the beginning MediawikiApi->getClient access modifier was changed
             // in our vendor folder from private to public in order to access the underlying client for the cookies.
@@ -88,7 +92,7 @@ class LogInToWiki
                 }
             }
         } catch (\Exception $ex) {
-            Log::error("Failed to log user '".$wikiUsername."' in to mediawiki: ".$ex->getMessage());
+            Log::error("Failed to log user '".$user->mediawiki."' in to mediawiki: ".$ex->getMessage());
         }
     }
 }

--- a/app/Listeners/LogInToWiki.php
+++ b/app/Listeners/LogInToWiki.php
@@ -39,10 +39,10 @@ class LogInToWiki
     {
         $user = $event->user;
 
-        // TODO: for all of this we need to move to restarters.net being the auth provider for Mediawiki.
-        // This is currently a workaround.
+
 
         if ($user->wiki_sync_status == WikiSyncStatus::CreateAtLogin) {
+            Log::info("Need to create " . $user->name);
             $this->createUserInWiki($user, $this->request->input('password'));
         }
 
@@ -70,8 +70,10 @@ class LogInToWiki
     protected function logUserIn($wikiUsername, $password)
     {
         try {
+            Log::info("Log in to wiki $wikiUsername");
             $api = MediawikiApi::newFromApiEndpoint(env('WIKI_URL').'/api.php');
             $api->login(new ApiUser($wikiUsername, $password));
+            Log::info("Logged in to wiki $wikiUsername");
 
             // NGM: it appears that right from the beginning MediawikiApi->getClient access modifier was changed
             // in our vendor folder from private to public in order to access the underlying client for the cookies.

--- a/app/Providers/MediawikiServiceProvider.php
+++ b/app/Providers/MediawikiServiceProvider.php
@@ -34,8 +34,10 @@ class MediawikiServiceProvider extends ServiceProvider
 
         $this->app->singleton(MediawikiFactory::class, function () {
             try {
+                Log::debug('Connect to Mediawiki');
                 $api = new MediawikiApi(env('WIKI_URL').'/api.php');
                 $api->login(new ApiUser(env('WIKI_APIUSER'), env('WIKI_APIPASSWORD')));
+                Log::debug('...connected');
 
                 return new MediawikiFactory($api);
             } catch (\Exception $ex) {

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -18,5 +18,9 @@ return [
     'throttled' => 'Please wait before retrying.',
     'token' => 'This password reset token is invalid.',
     'user' => "We can't find a user with that e-mail address.",
-
+    'invalid' => 'Please input a valid email.',
+    'recover_title' => 'Account Recovery',
+    'match' => 'The passwords do not match',
+    'updated' => 'Password updated, please login to continue.',
+    'failed' => 'Could not update the password.'
 ];

--- a/tests/Feature/Users/PasswordResetTest.php
+++ b/tests/Feature/Users/PasswordResetTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Notifications\ResetPassword;
+use App\User;
+use DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class PasswordResetTest extends TestCase
+{
+    public function testInvalidEmail() {
+        $response = $this->post('/user/recover', [
+            'email' => 'bademail!'
+        ]);
+
+        $response->assertSeeText(__('passwords.invalid'));
+    }
+
+    public function testUnknownEmail() {
+        $response = $this->post('/user/recover', [
+            'email' => 'nobody@nowhere.com'
+        ]);
+
+        $response->assertSeeText(__('passwords.user'));
+    }
+
+    public function testResetSuccess()
+    {
+        Notification::fake();
+        Event::fake();
+
+        $restarter = factory(User::class)->states('Restarter')->create();
+
+        $response = $this->post('/user/recover', [
+            'email' => $restarter->email
+        ]);
+
+        $response->assertSeeText(__('passwords.sent'));
+
+        Notification::assertSentTo(
+            [$restarter], ResetPassword::class
+        );
+
+        $restarter->refresh();
+
+        // Invalid code
+        $response = $this->post('/user/reset', [
+            'recovery' => '',
+            'password' => 'newpass',
+            'confirm_password' => 'newpass'
+        ]);
+
+        // Invalid code
+        $response = $this->post('/user/reset', [
+            'recovery' => $restarter->recovery . '1',
+            'password' => 'newpass',
+            'confirm_password' => 'newpass'
+        ]);
+
+        $response->assertSeeText('using is invalid');
+
+        // Valid but mismatch passwords.
+        $response = $this->post('/user/reset', [
+            'recovery' => $restarter->recovery,
+            'password' => 'newpass',
+            'confirm_password' => 'mismatch'
+        ]);
+
+        $response->assertSeeText(__('passwords.match'));
+
+        // Valid - should redirect to login patch and dispatch password changed event to update the wiki.
+        $this->followingRedirects();
+        $response = $this->post('/user/reset', [
+            'recovery' => $restarter->recovery,
+            'password' => 'newpass',
+            'confirm_password' => 'newpass'
+        ]);
+
+        $response->assertSeeText(__('passwords.updated'));
+        Event::assertDispatched(\App\Events\PasswordChanged::class);
+    }
+}

--- a/tests/Feature/Users/RecoverTest.php
+++ b/tests/Feature/Users/RecoverTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Notifications\ResetPassword;
+use App\Events\PasswordChanged;
+use App\User;
+use DB;
+use Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Event;
+use Mockery;
+use Symfony\Component\DomCrawler\Crawler;
+use Tests\TestCase;
+
+class RecoverTest extends TestCase
+{
+    public function testRecover()
+    {
+        $restarter = factory(User::class)->state('Restarter')->create([
+                                                                          'password' => Hash::make('passw0rd'),
+                                                                      ]);
+
+        // Fetch the recover page.
+        $response = $this->get('/user/recover');
+        $response->assertStatus(200);
+        $response->assertSee(__('auth.forgotten_pw_text'));
+
+        // Post a recover request - invalid email
+        $response = $this->post('/user/recover', [
+            'email' => 'zzzz'
+        ]);
+        $response->assertSee('alert-danger');
+
+        // Post a valid recover request.
+        Notification::fake();
+
+        $response = $this->post('/user/recover', [
+            'email' => $restarter->email
+        ]);
+        $response->assertSee('alert-success');
+
+        $this->recovery = null;
+
+        Notification::assertSentTo(
+            $restarter,
+            ResetPassword::class,
+            function ($notification, $channels) use ($restarter)
+            {
+                // retrive the mail content
+                $mailData = $notification->toMail($restarter)->toArray();
+                $this->recovery = $mailData['actionUrl'];
+                return true;
+            });
+
+        // Now fetch the reset page - first in error.
+        $response = $this->get('/user/reset');
+        $response->assertSee('The recovery code you\'re using is invalid');
+        $response = $this->get($this->recovery . 'zz');
+        $response->assertSee('The recovery code you\'re using is invalid');
+
+        $response = $this->get($this->recovery);
+        $response->assertSee('id="confirm_password"');
+
+        // Now submit the reset request - first in error.
+        $response = $this->post($this->recovery, [
+            'password' => "1234",
+            'confirm_password' => "1234",
+            'recovery' => null
+        ]);
+        $response->assertSee('The recovery code you\'re using is invalid');
+
+        $p = strrpos($this->recovery, '=');
+        $this->recoveryCode = substr($this->recovery, $p + 1);
+
+        $response = $this->post($this->recovery, [
+            'password' => "1234",
+            'confirm_password' => "12345",
+            'recovery' => $this->recoveryCode
+        ]);
+        $response->assertSee('The passwords do not match');
+
+        // Now a successful reset, which redirects back to the login page.
+        $p = strrpos($this->recovery, '=');
+        $value = substr($this->recovery, $p + 1);
+
+        Event::fake([
+                        PasswordChanged::class,
+                    ]);
+
+        $response = $this->post($this->recovery, [
+            'password' => "1234",
+            'confirm_password' => "1234",
+            'recovery' => $value
+        ]);
+        $this->assertTrue($response->isRedirection());
+        Event::assertDispatched(PasswordChanged::class);
+
+        $response->assertSessionHas('success');
+
+        // Now log in with the new password.
+        $response = $this->get('/login');
+        $response->assertStatus(200);
+
+        $crawler = new Crawler($response->getContent());
+
+        $tokens = $crawler->filter('input[name=_token]')->each(function (Crawler $node, $i) {
+            return $node;
+        });
+
+        $tokenValue = $tokens[0]->attr('value');
+
+        $names = $crawler->filter('input[name=my_name]')->each(function (Crawler $node, $i) {
+            return $node;
+        });
+
+        $nameValue = $names[0]->attr('value');
+
+        $times = $crawler->filter('input[name=my_time]')->each(function (Crawler $node, $i) {
+            return $node;
+        });
+
+        $timeValue = $times[0]->attr('value');
+
+        $response = $this->post('/login', [
+            '_token' => $tokenValue,
+            'my_name' => $nameValue,
+            'my_time' => $timeValue,
+            'email' => $restarter->email,
+            'password' => '1234',
+        ]);
+
+        // Should redirect to dashboard.
+        $this->assertTrue($response->isRedirection());
+        $redirectTo = $response->getTargetUrl();
+        $this->assertNotFalse(strpos($redirectTo, '/dashboard'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -77,7 +77,7 @@ abstract class TestCase extends BaseTestCase
     {
         // Return a test user.
         $userAttributes = [];
-        $userAttributes['name'] = 'Test'.$this->userCount++;
+        $userAttributes['name'] = 'Test'.uniqid($this->userCount++, true);
         $userAttributes['email'] = $userAttributes['name'].'@restarters.dev';
         $userAttributes['age'] = '1982';
         $userAttributes['country'] = 'GBR';


### PR DESCRIPTION
Lots of good stuff.

- Add Mediawiki image to the CircleCI configuration and enable wiki integration.  This means our tests now run with a real wiki.
- Change Mediawiki passwords to use the hashed Laravel password.
- Add a test of password recovery/reset.  This needs the code to be a bit more standard Laravel (avoid $_POST etc).
- Add a command to generate the Mediawiki commands to run from maintenance/ to migrate the passwords.
- Make the test users more unique, because we don't clean out the wiki users between tests.