### PR TITLE
RES-1596 mounted sentry error

### DIFF
--- a/resources/js/components/RichTextEditor.vue
+++ b/resources/js/components/RichTextEditor.vue
@@ -89,7 +89,7 @@ export default {
     }
   },
   mounted() {
-    this.currentValue = value
+    this.currentValue = this.value
   }
 }
 </script>


### PR DESCRIPTION
Sentry error caused by missing "this".  It may be benign, but is easy to fix.