### PR TITLE
RES-1603 When no location set, events page should prompt to set one

### DIFF
--- a/resources/js/components/GroupEvents.vue
+++ b/resources/js/components/GroupEvents.vue
@@ -33,7 +33,7 @@
       </template>
       <template slot="content">
         <b-tabs class="ourtabs w-100">
-          <GroupEventsTab active :limit="limit" :events="nearby" :canedit="canedit" :add-group-name="addGroupName" title="groups.nearby" noneMessage="groups.no_other_nearby_events" />
+          <GroupEventsTab active :limit="limit" :events="nearby" :canedit="canedit" :add-group-name="addGroupName" title="groups.nearby" :noneMessage="nearbyNoneMessage" />
           <GroupEventsTab :limit="limit" :events="all" :canedit="canedit" :add-group-name="addGroupName" title="groups.all" noneMessage="groups.no_other_events" filters />
         </b-tabs>
       </template>
@@ -108,7 +108,11 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    }
+    },
+    location: {
+      type: String,
+      required: true
+    },
   },
   computed: {
     events() {
@@ -134,6 +138,15 @@ export default {
     },
     all() {
       return this.events.filter(e => e.all)
+    },
+    nearbyNoneMessage() {
+      if (this.location) {
+        // We have a location, so we can say that there are no other nearby events.
+        return this.$lang.get('groups.no_other_nearby_events')
+      } else {
+        // We don't have a location - nudge to add one.
+        return this.$lang.get('events.no_location')
+      }
     },
     translatedTitle() {
       // If we have a group then we are putting the name elsewhere and just want "events" (force the plural).  Otherwise

--- a/resources/js/components/GroupEventsPage.vue
+++ b/resources/js/components/GroupEventsPage.vue
@@ -7,6 +7,7 @@
         :canedit="canedit"
         :calendar-copy-url="calendarCopyUrl"
         add-button
+        :location="location"
     />
   </div>
 </template>
@@ -41,7 +42,11 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    }
+    },
+    location: {
+      type: String,
+      required: true
+    },
   },
   computed: {
     group() {

--- a/resources/js/components/GroupEventsTab.vue
+++ b/resources/js/components/GroupEventsTab.vue
@@ -7,9 +7,8 @@
         </div>
       </div>
     </template>
-    <p v-if="!events.length">
-      {{ translatedNoneMessage }}
-    </p>
+    <!--        eslint-disable-next-line-->
+    <p v-if="!events.length" v-html="translatedNoneMessage" />
     <GroupEventScrollTable v-else :limit="limit" :events="events" :canedit="canedit" :add-group-name="addGroupName" :past="past" :filters="filters" />
   </b-tab>
 </template>

--- a/resources/lang/en/events.php
+++ b/resources/lang/en/events.php
@@ -210,4 +210,5 @@ return [
   'address_error' => 'The address you entered could not be found.  Please try a more general address, and enter any more specific address details in the event description.',
   'before_submit_text_autoapproved' => 'When you create or save this event, it will be made public.',
   'created_success_message_autoapproved' => 'Event created! It is now public.',
+  'no_location' => '<b>You do not currently have a town/city set.  You can set one in <a href="/profile/edit">your profile</a>.</b>'
 ];

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -108,6 +108,7 @@
             :canedit="{{ $can_edit_group ? 'true' : 'false' }}"
             add-group-name
             show-other
+            location="{{ Auth::user()->location ?? '' }}"
         />
       </div>
       @else
@@ -120,6 +121,7 @@
           calendar-edit-url="{{ $calendar_edit_url }}"
           :initial-group="{{ json_encode($group, JSON_INVALID_UTF8_IGNORE) }}"
           :canedit="{{ $can_edit_group ? 'true' : 'false' }}"
+          location="{{ Auth::user()->location ?? '' }}"
         />
       </div>
       @endif


### PR DESCRIPTION
Add a better prompt.

This is another example where we pass props around because we don't have an "auth" on the client side.  Will add to retro.