### PR TITLE
RES-1595 Change how start/end time changes are handled.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,7 @@
             <exclude>./tests/Feature/Microtasks/FaultcatTest.php</exclude>
             <exclude>./tests/Feature/Microtasks/MisccatTest.php</exclude>
             <exclude>./tests/Feature/Microtasks/MobifixTest.php</exclude>
-            <exclude>./tests/Feature/StatsTestCase.php</exclude>
+            <exclude>./tests/Feature/Stats/StatsTestCase.php</exclude>
         </testsuite>
 
         <testsuite name="Unit">

--- a/resources/js/components/EventTimeRangePicker.vue
+++ b/resources/js/components/EventTimeRangePicker.vue
@@ -7,6 +7,7 @@
         v-model="currentStartTime"
         :class="{ hasError: hasError, 'mr-1': true, time: true }"
         placeholder="--:--"
+        @blur="changeCurrentStartTime"
     />
     <b-form-input
         size="lg"
@@ -15,6 +16,7 @@
         v-model="currentEndTime"
         :class="{ hasError: hasError, 'ml-1': true, time: true }"
         placeholder="--:--"
+        @blur="changeCurrentEndTime"
     />
   </div>
 </template>
@@ -72,12 +74,6 @@ export default {
       },
       immediate: true
     },
-    currentStartTime(newVal) {
-      this.$emit('update:start', newVal)
-    },
-    currentEndTime(newVal) {
-      this.$emit('update:end', newVal)
-    },
     currentPickerStartTime(newVal) {
       // Trim seconds
       if (newVal) {
@@ -110,7 +106,13 @@ export default {
           this.currentEndTime = hours + ':' + mins
         }
       }
-    }
+    },
+    changeCurrentStartTime() {
+      this.$emit('update:start', this.currentStartTime)
+    },
+    changeCurrentEndTime() {
+      this.$emit('update:end', this.currentEndTime)
+    },
   }
 }
 </script>


### PR DESCRIPTION
The current code uses a watch to spot when times have changed.  Suppose you have an event start of '17:00' and an event end of '18:00' which you want to change.  If you type in the field, e.g. '19', what happens is that on the '1' the hour changes to '01'.  Then we spot that '01' is before '17', and is therefore invalid, so we reset it.

This PR waits until you move away from the input, and fires the $emit to change the value then.  This behaves better.