### PR TITLE
RES-1607 Wordpress event time

### DIFF
--- a/app/Console/Commands/MigrateWikiPasswords.php
+++ b/app/Console/Commands/MigrateWikiPasswords.php
@@ -41,7 +41,7 @@ class MigrateWikiPasswords extends Command
         $users = User::whereNotNull('mediawiki')->whereNull('deleted_at')->get();
 
         foreach ($users as $user) {
-            $this->info("php changePassword.php --user={$user->mediawiki} --password='{$user->password}'");
+            $this->info("php changePassword.php --user=\"{$user->mediawiki}\" --password='{$user->password}'");
         }
     }
 }

--- a/app/Listeners/CreateWordpressPostForEvent.php
+++ b/app/Listeners/CreateWordpressPostForEvent.php
@@ -63,7 +63,7 @@ class CreateWordpressPostForEvent
                 ['key' => 'party_grouphash', 'value' => $theParty->group],
                 ['key' => 'party_venue', 'value' => $theParty->venue],
                 ['key' => 'party_location', 'value' => $theParty->location],
-                ['key' => 'party_time', 'value' => $theParty->start.' - '.$theParty->end],
+                ['key' => 'party_time', 'value' => substr($theParty->start, 0, 5) . ' - ' . substr($theParty->end, 0, 5)],
                 ['key' => 'party_groupcountry', 'value' => $group->country],
                 ['key' => 'party_groupcity', 'value' => $group->area],
                 ['key' => 'party_date', 'value' => $theParty->event_date],

--- a/app/Listeners/EditWordpressPostForEvent.php
+++ b/app/Listeners/EditWordpressPostForEvent.php
@@ -60,7 +60,7 @@ class EditWordpressPostForEvent
                     ['key' => 'party_groupcity', 'value' => $group->area],
                     ['key' => 'party_venue', 'value' => $data['venue']],
                     ['key' => 'party_location', 'value' => $data['location']],
-                    ['key' => 'party_time', 'value' => $data['start'].' - '.$data['end']],
+                    ['key' => 'party_time', 'value' => substr($data['start'], 0, 5).' - '.substr($data['end'], 0, 5)],
                     ['key' => 'party_date', 'value' => $data['event_date']],
                     ['key' => 'party_timestamp', 'value' => $startTimestamp],
                     ['key' => 'party_timestamp_end', 'value' => $endTimestamp],


### PR DESCRIPTION
Ensure that the event start/end pushed to Wordpress doesn't contain seconds.