### PR TITLE
RES-1608 discourse group logo

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -552,8 +552,8 @@ class Group extends Model implements Auditable
     
     public function createDiscourseGroup() {
         // Get the host who created the group.
-	$success = false;
-	$member = UserGroups::where('group', $this->idgroups)->first();
+        $success = false;
+        $member = UserGroups::where('group', $this->idgroups)->first();
         $host = null;
 
         if (!empty($member)) {
@@ -661,7 +661,7 @@ class Group extends Model implements Auditable
             } catch (\Exception $ex) {
                 Log::error('Could not create group ('.$this->idgroups.') thread: '.$ex->getMessage());
             }
-	} while ($retry);
+    	} while ($retry);
 
         return $success;
     }

--- a/app/Listeners/CreateWordpressPostForGroup.php
+++ b/app/Listeners/CreateWordpressPostForGroup.php
@@ -37,8 +37,10 @@ class CreateWordpressPostForGroup
 
         $group = Group::find($id);
 
-        if (! empty($group)) {
+        if (empty($group)) {
             Log::error('Group not found');
+
+            return;
         }
 
         if (! $group->eventsShouldPushToWordpress()) {

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -288,7 +288,7 @@ class DiscourseService
                                 $group->save();
                                 Log::debug("...saved update to group");
                             } else {
-                                Log::error("Failed to update flair url for {$discourseId}");
+                                Log::error("Failed to update flair url");
                                 throw new \Exception("Failed to update flair url for {$discourseId}");
                             }
                         } else {

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -280,7 +280,12 @@ class DiscourseService
 
                             Log::debug("Response from flair_url update " . $response->getBody());
 
-                            if ($response->getStatusCode() != 200) {
+                            if ($response->getStatusCode() === 200) {
+                                // Update the group to record that we've uploaded, then we'll skip this next time
+                                // through.
+                                $group->discourse_logo = $group->groupimage->idimages;
+                                $group->save();
+                            } else {
                                 Log::error("Failed to update flair url for {$discourseId}");
                                 throw new \Exception("Failed to update flair url for {$discourseId}");
                             }

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -231,7 +231,7 @@ class DiscourseService
 
                 // Check if the flair_url needs updating.  This keeps the logo in sync with changes on Restarters.
                 Log::debug("Check Discourse logo {$group->discourse_logo} vs {$group->groupimage->idimages}");
-                if (!$group->discourse_logo || $group->discourse_logo != $group->groupimage->idimages) {
+                if (!$group->discourse_logo || $group->discourse_logo != $group->groupimage->image->idimages) {
                     // We need to update it.  To do that, we first have to upload the image file to Discourse.
                     Log::debug("Need to update flair_url with ". $group->groupImagePath());
 
@@ -283,8 +283,10 @@ class DiscourseService
                             if ($response->getStatusCode() === 200) {
                                 // Update the group to record that we've uploaded, then we'll skip this next time
                                 // through.
-                                $group->discourse_logo = $group->groupimage->idimages;
+                                Log::debug("Updated flair url OK for {$discourseId} to {$group->groupimage->idimages}");
+                                $group->discourse_logo = $group->groupimage->image->idimages;
                                 $group->save();
+                                Log::debug("...saved update to group");
                             } else {
                                 Log::error("Failed to update flair url for {$discourseId}");
                                 throw new \Exception("Failed to update flair url for {$discourseId}");

--- a/database/migrations/2022_01_04_123128_group_discourse_logo.php
+++ b/database/migrations/2022_01_04_123128_group_discourse_logo.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class GroupDiscourseLogo extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->integer('discourse_logo')->default(null)->nullable()->comment('ID of last Laraval Group image applied to Discourse Group');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn('discourse_group');
+        });
+    }
+}


### PR DESCRIPTION
Enhance Discourse sync to apply any group logo to the Discourse group as a flair URL.  

I’ve not added an automated test, as:

- It’s so dependent on the Discourse API that mocking would make it a bit pointless.
- Testing it properly in the Docker Discourse environment would be quite a lot of work.
- I’ve added logs in the error cases so that they will show up in Sentry.

