### PR TITLE
RES-1621 EventCreated notification sent to wrong place.

### DIFF
--- a/app/Party.php
+++ b/app/Party.php
@@ -1055,7 +1055,8 @@ class Party extends Model implements Auditable
         }
 
         // Notify the person who created it that it has now been approved.
-        $host = User::find(EventsUsers::where('event', $this->idevents)->first());
+        $eu = EventsUsers::where('event', $this->idevents)->first();
+        $host = User::find($eu->user);
 
         if ($host) {
             Notification::send($host, new EventConfirmed($this));

--- a/app/Party.php
+++ b/app/Party.php
@@ -1056,10 +1056,13 @@ class Party extends Model implements Auditable
 
         // Notify the person who created it that it has now been approved.
         $eu = EventsUsers::where('event', $this->idevents)->first();
-        $host = User::find($eu->user);
 
-        if ($host) {
-            Notification::send($host, new EventConfirmed($this));
+        if ($eu) {
+            $host = User::find($eu->user);
+
+            if ($host) {
+                Notification::send($host, new EventConfirmed($this));
+            }
         }
 
         event(new ApproveEvent($this));

--- a/app/Party.php
+++ b/app/Party.php
@@ -1055,7 +1055,7 @@ class Party extends Model implements Auditable
         }
 
         // Notify the person who created it that it has now been approved.
-        $eu = EventsUsers::where('event', $this->idevents)->first();
+        $eu = EventsUsers::where('event', $this->idevents)->orderBy('idevents_users')->first();
 
         if ($eu) {
             $host = User::find($eu->user);


### PR DESCRIPTION
We were passing an EventsUsers instance into Notification::send.  I think this is working in test because the database is clean and all the ids are 1 - added something to the retro.  Changed to pass the user.