### PR TITLE
Dat 640 stats estimate zero

### DIFF
--- a/app/Device.php
+++ b/app/Device.php
@@ -392,21 +392,17 @@ class Device extends Model implements Auditable
     }
 
     /**
-     * Powered estimate only takes precedence over category weight when Misc.
-     *
-     * REDUNDANT?
+     * Powered estimate only takes precedence over category weight when Misc and if not 0.
      */
     public function eCo2Diverted($emissionRatio, $displacementFactor)
     {
         $footprint = 0;
 
         if ($this->isFixed()) {
-            if ($this->deviceCategory->isMiscPowered()) {
-                if (is_numeric($this->estimate)) {
-                    $footprint = $this->estimate * $emissionRatio;
-                }
+            if ($this->deviceCategory->isMiscPowered() && is_numeric($this->estimate) && $this->estimate > 0) {
+                $footprint = $this->estimate * $emissionRatio;
             } else {
-                $footprint = (float) $this->deviceCategory->footprint;
+                $footprint = $this->deviceCategory->footprint;
             }
         }
 
@@ -414,19 +410,18 @@ class Device extends Model implements Auditable
     }
 
     /**
-     * Unpowered estimate always takes precedence over category weight.
+     * Unpowered estimate always takes precedence over category weight unless is is 0.
      *
-     * REDUNDANT?
      */
     public function uCo2Diverted($emissionRatio, $displacementFactor)
     {
         $footprint = 0;
 
         if ($this->isFixed()) {
-            if (is_numeric($this->estimate)) {
-                $footprint = $this->estimate * $emissionRatio;
+            if (is_numeric($this->estimate) && $this->estimate > 0) {
+                $footprint = ($this->estimate * $emissionRatio);
             } else {
-                $footprint = (float) $this->deviceCategory->footprint;
+                $footprint = $this->deviceCategory->footprint;
             }
         }
 
@@ -434,21 +429,18 @@ class Device extends Model implements Auditable
     }
 
     /**
-     * Powered estimate only takes precedence over category weight when Misc.
+     * Powered estimate only takes precedence over category weight when Misc and if not 0.
      *
-     * REDUNDANT?
      */
     public function eWasteDiverted()
     {
         $ewasteDiverted = 0;
 
         if ($this->isFixed() && $this->deviceCategory->isPowered()) {
-            if ($this->deviceCategory->isMiscPowered()) {
-                if (is_numeric($this->estimate)) {
-                    $ewasteDiverted = $this->estimate;
-                }
+            if ($this->deviceCategory->isMiscPowered() && is_numeric($this->estimate) && $this->estimate > 0) {
+                $ewasteDiverted = $this->estimate;
             } else {
-                $ewasteDiverted = (float) $this->deviceCategory->weight;
+                $ewasteDiverted = $this->deviceCategory->weight;
             }
         }
 
@@ -456,19 +448,18 @@ class Device extends Model implements Auditable
     }
 
     /**
-     * Unpowered estimate always takes precedence over category weight.
+     * Unpowered estimate always takes precedence over category weight unless it is 0.
      *
-     * REDUNDANT?
      */
     public function uWasteDiverted()
     {
         $wasteDiverted = 0;
 
         if ($this->isFixed() && $this->deviceCategory->isUnpowered()) {
-            if (is_numeric($this->estimate)) {
+            if (is_numeric($this->estimate) && $this->estimate > 0) {
                 $wasteDiverted = $this->estimate;
             } else {
-                $wasteDiverted = (float) $this->deviceCategory->weight;
+                $wasteDiverted = $this->deviceCategory->weight;
             }
         }
 

--- a/app/Group.php
+++ b/app/Group.php
@@ -261,8 +261,13 @@ class Group extends Model implements Auditable
         $allEvents = Party::where('events.group', $this->idgroups)
             ->get();
 
+
+        // Send these to getEventStats() to speed things up a bit.
+        $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
+        $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
+
         foreach ($allEvents as $event) {
-            $stats = $event->getEventStats();
+            $stats = $event->getEventStats($eEmissionRatio, $uEmissionratio);
 
             if ($stats['devices_powered'] || $stats['devices_unpowered']) {
                 $ret = false;
@@ -549,7 +554,7 @@ class Group extends Model implements Auditable
     {
         $this->distance = $val;
     }
-    
+
     public function createDiscourseGroup() {
         // Get the host who created the group.
         $success = false;

--- a/app/Helpers/LcaStats.php
+++ b/app/Helpers/LcaStats.php
@@ -107,9 +107,13 @@ AND d.category <> 50
     }
 
     /**
-     * BORKED ATTEMPT TO APPLY SENT FILTERS TO STATS QUERY
-     * MAY BE REDUNDANT
-     * SEE ApiController::getDevices()
+     * BORKED ATTEMPT TO APPLY REQUEST FILTERS TO STATS QUERY.
+     *
+     * See \app\Http\Controllers\ApiController::getDevices() for more info.
+     *
+     * @ToDo Determine if this is useful and fix.
+     *
+     * It could replace getWasteStats() if it worked.
      */
     public static function getWasteStatsFiltered($filters = [])
     {

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -63,12 +63,17 @@ class EventController extends Controller
         }
 
         $collection = collect([]);
+
+        // Send these to getEventStats() to speed things up a bit.
+        $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
+        $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
+
         foreach ($parties as $key => $party) {
             $group = $groups_array->filter(function ($group) use ($party) {
                 return $group['id'] == $party->group;
             })->first();
 
-            $eventStats = $party->getEventStats();
+            $eventStats = $party->getEventStats($eEmissionRatio, $uEmissionratio);
             // Push Party to Collection
             $collection->push([
              'id' => $party->idevents,

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -145,7 +145,16 @@ class ApiController extends Controller
     }
 
     /**
-     * REDUNDANT???
+     * THIS METHOD HAS NOT BEEN REFACTORED FOR UNPOWERED DEVICES!!
+     * An attempt was made, see \app\Helpers\LcaStats::getWasteStatsFiltered().
+     * Deemed too time-consuming and possibly redundant.
+     * It was eventually found to be called from a Vue that rendered the search table on the Fixometer landing page.
+     * Stats produced by this method were subsequently removed from that table.
+     *
+     * Possibly called externally!
+     * See \routes\api.php.
+     *
+     * @ToDo Determine usage and refactor or deprecate (stats) as appropriate.
      *
      * List/search devices.
      *

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -171,10 +171,15 @@ class ExportController extends Controller
                     $k = implode(' ', $key);
                 });
                 $headers = array_merge(['Date', 'Venue', 'Group'], $statsKeys);
+
+                // Send these to getEventStats() to speed things up a bit.
+                $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
+                $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
+
                 // prepare the column values
                 $PartyArray = [];
                 foreach ($PartyList as $i => $party) {
-                    $stats = $party->getEventStats();
+                    $stats = $party->getEventStats($eEmissionRatio, $uEmissionratio);
                     array_walk($stats, function (&$v) {
                         $v = round($v);
                     });

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -370,13 +370,17 @@ class GroupController extends Controller
 
         $expanded_events = [];
 
+        // Send these to getEventStats() to speed things up a bit.
+        $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
+        $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
+
         foreach (array_merge($upcoming_events->all(), $past_events->all()) as $event) {
             $thisone = $event->getAttributes();
             $thisone['attending'] = Auth::user() && $event->isBeingAttendedBy(Auth::user()->id);
             $thisone['allinvitedcount'] = $event->allInvited->count();
 
             // TODO LATER Consider whether these stats should be in the event or passed into the store.
-            $thisone['stats'] = $event->getEventStats();
+            $thisone['stats'] = $event->getEventStats($eEmissionRatio, $uEmissionratio);
             $thisone['participants_count'] = $event->participants;
             $thisone['volunteers_count'] = $event->allConfirmedVolunteers->count();
 

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -1326,13 +1326,16 @@ class PartyController extends Controller
                'co2_emissions_prevented' => $gstats['co2_total'],
            ]);
         }
+        // Send these to getEventStats() to speed things up a bit.
+        $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
+        $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
 
         $collection = collect([]);
         foreach ($parties as $key => $party) {
             $group = $groups_array->filter(function ($group) use ($party) {
                 return $group['id'] == $party->group;
             })->first();
-            $estats = $party->getEventStats();
+            $estats = $party->getEventStats($eEmissionRatio, $uEmissionratio);
             // Push Party to Collection
             $collection->push([
              'id' => $party->idevents,

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -42,6 +42,10 @@ class SearchController extends Controller
                     $dropdowns['allowed_parties']
                 );
 
+                // Send these to getEventStats() to speed things up a bit.
+                $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
+                $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
+
                 if (count($PartyList) > 0) {
                     $partyIds = [];
 
@@ -50,7 +54,7 @@ class SearchController extends Controller
                     foreach ($PartyList as $party) {
                         $partyIds[] = $party->idevents;
 
-                        $eventStats = $party->getEventStats();
+                        $eventStats = $party->getEventStats($eEmissionRatio, $uEmissionratio);
                         foreach (array_keys($stats) as $v) {
                             $party->{$v} = $eventStats[$v];
                             $stats[$v] += $eventStats[$v];

--- a/routes/api.php
+++ b/routes/api.php
@@ -77,5 +77,9 @@ Route::group(['middleware' => 'auth:api'], function () {
 
 Route::get('/groups/{group}/events', 'API\GroupController@getEventsForGroup');
 
-// REDUNDANT???
+/**
+ * @ToDo Determine usage and deprecate if redundant.
+ *
+ * See app\Http\Controllers\ApiController::getDevices() for more info.
+ */
 Route::get('/devices/{page}/{size}', [App\Http\Controllers\ApiController::class, 'getDevices']);


### PR DESCRIPTION
Fixes issue with numeric 0 estimate values when used in stats calculations.

Included in the fix is a few benign changes to speed up stats calcs when in loops (just sending in the emission ratios to the method so they don't get fetched over and over) and a lot of enhanced comments about stats methods.