### PR TITLE
RES-1624 timezones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
           - DB_DATABASE: restarters_db
           - DB_USERNAME: restarters
           - DB_PASSWORD: s3cr3t
+          - TZ: "UTC"
       - image: circleci/mysql:5.7.33
         environment:
           # You can connect once ssh'd in using  mysql -u root -p -h 127.0.0.1
@@ -28,6 +29,7 @@ jobs:
       - image: mcr.microsoft.com/playwright:focal
         environment:
           NODE_ENV: development
+          TZ: "UTC"
       - image: 'bitnami/mariadb:latest'
         name: mariadb
         environment:
@@ -46,6 +48,7 @@ jobs:
           - ALLOW_EMPTY_PASSWORD=yes
           - MEDIAWIKI_EXTERNAL_HTTP_PORT_NUMBER=8080
           - MEDIAWIKI_HOST=mediawiki
+          - TZ: "UTC"
         depends_on:
           - mariadb
     steps:

--- a/app/Console/Commands/SyncEvents.php
+++ b/app/Console/Commands/SyncEvents.php
@@ -58,6 +58,7 @@ class SyncEvents extends Command
 
                 return;
             }
+            // TODO Timezones
             $eventsQuery->where('event_date', '>=', $this->option('datefrom'));
             $this->info('Starting from date: '.$dateFrom);
         }
@@ -70,6 +71,7 @@ class SyncEvents extends Command
 
         foreach ($events as $event) {
             try {
+                // TODO Timezones
                 $startTimestamp = strtotime($event->event_date.' '.$event->start);
                 $endTimestamp = strtotime($event->event_date.' '.$event->end);
 
@@ -82,6 +84,7 @@ class SyncEvents extends Command
                     ['key' => 'party_venue', 'value' => $event->venue],
                     ['key' => 'party_location', 'value' => $event->location],
                     ['key' => 'party_time', 'value' => $event->start.' - '.$event->end],
+                    // TODO Timezones
                     ['key' => 'party_date', 'value' => $event->event_date],
                     ['key' => 'party_timestamp', 'value' => $startTimestamp],
                     ['key' => 'party_timestamp_end', 'value' => $endTimestamp],

--- a/app/Console/Commands/SyncEvents.php
+++ b/app/Console/Commands/SyncEvents.php
@@ -58,8 +58,7 @@ class SyncEvents extends Command
 
                 return;
             }
-            // TODO Timezones
-            $eventsQuery->where('event_date', '>=', $this->option('datefrom'));
+            $eventsQuery->where('event_start_utc', '>=', $this->option('datefrom'));
             $this->info('Starting from date: '.$dateFrom);
         }
 
@@ -71,9 +70,8 @@ class SyncEvents extends Command
 
         foreach ($events as $event) {
             try {
-                // TODO Timezones
-                $startTimestamp = strtotime($event->event_date.' '.$event->start);
-                $endTimestamp = strtotime($event->event_date.' '.$event->end);
+                $startTimestamp = strtotime($event->event_start_utc);
+                $endTimestamp = strtotime($event->event_end_utc);
 
                 $group = Group::where('idgroups', $event->group)->first();
 
@@ -84,7 +82,6 @@ class SyncEvents extends Command
                     ['key' => 'party_venue', 'value' => $event->venue],
                     ['key' => 'party_location', 'value' => $event->location],
                     ['key' => 'party_time', 'value' => $event->start.' - '.$event->end],
-                    // TODO Timezones
                     ['key' => 'party_date', 'value' => $event->event_date],
                     ['key' => 'party_timestamp', 'value' => $startTimestamp],
                     ['key' => 'party_timestamp_end', 'value' => $endTimestamp],

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,6 +33,7 @@ class Kernel extends ConsoleKernel
     {
         $schedule->call(function () {
             $parties = Party::doesnthave('devices')
+            // TODO Timezones
             ->where('event_date', '>=', date('Y-m-d', strtotime(Carbon::now()->subDays(env('NO_DATA_ENTERED', 5)))))
               ->where('event_date', '<=', date('Y-m-d', strtotime(Carbon::now())))
                 ->get();

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,9 +33,8 @@ class Kernel extends ConsoleKernel
     {
         $schedule->call(function () {
             $parties = Party::doesnthave('devices')
-            // TODO Timezones
-            ->where('event_date', '>=', date('Y-m-d', strtotime(Carbon::now()->subDays(env('NO_DATA_ENTERED', 5)))))
-              ->where('event_date', '<=', date('Y-m-d', strtotime(Carbon::now())))
+            ->where('event_start_utc', '>=', date('Y-m-d', strtotime(Carbon::now()->subDays(env('NO_DATA_ENTERED', 5)))))
+              ->where('event_end_utc', '<', date('Y-m-d', strtotime(Carbon::now())))
                 ->get();
 
             foreach ($parties as $party) {

--- a/app/Device.php
+++ b/app/Device.php
@@ -69,7 +69,7 @@ class Device extends Model implements Auditable
 
     public function getList($params = null)
     {
-        //Tested!
+        // TODO Timezones
         $sql = 'SELECT * FROM `view_devices_list`';
 
         if (! is_null($params)) {
@@ -340,6 +340,7 @@ class Device extends Model implements Auditable
     public function export()
     {
         //Tested
+        // TODO Timezones
         return DB::select(DB::raw('SELECT
                     `c`.`name` AS `category`,
                     `brand`,

--- a/app/Device.php
+++ b/app/Device.php
@@ -69,7 +69,7 @@ class Device extends Model implements Auditable
 
     public function getList($params = null)
     {
-        // TODO Timezones
+        // TODO Timezones.  The input filters are in local time, so we need to fix the client.
         $sql = 'SELECT * FROM `view_devices_list`';
 
         if (! is_null($params)) {
@@ -340,7 +340,6 @@ class Device extends Model implements Auditable
     public function export()
     {
         //Tested
-        // TODO Timezones
         return DB::select(DB::raw('SELECT
                     `c`.`name` AS `category`,
                     `brand`,
@@ -349,7 +348,7 @@ class Device extends Model implements Auditable
                     `repair_status`,
                     `spare_parts`,
                     `e`.`location`,
-                    UNIX_TIMESTAMP( CONCAT(`e`.`event_date`, " ", `e`.`start`) ) AS `event_timestamp`,
+                    UNIX_TIMESTAMP(event_start_utc) AS `event_timestamp`,
                     `g`.`name` AS `group_name`
 
                 FROM `devices` AS `d`

--- a/app/Device.php
+++ b/app/Device.php
@@ -67,52 +67,6 @@ class Device extends Model implements Auditable
         return \App\Helpers\LcaStats::getDisplacementFactor();
     }
 
-    public function getList($params = null)
-    {
-        // TODO Timezones.  The input filters are in local time, so we need to fix the client.
-        $sql = 'SELECT * FROM `view_devices_list`';
-
-        if (! is_null($params)) {
-            $sql .= ' WHERE 1=1 AND ';
-
-            $params = array_filter($params);
-            foreach ($params as $field => $value) {
-                if ($field == 'brand' || $field == 'model' || $field == 'problem') {
-                    $params[$field] = '%'.strtolower($value).'%';
-                } elseif ($field == 'event_date') {
-                    $params[$field] = implode(' AND ', $value);
-                }
-            }
-
-            $clauses = [];
-
-            foreach ($params as $f => $v) {
-                if ($f == 'event_date') {
-                    $clauses[] = 'event_date BETWEEN '.$v;
-                }
-                if ($f == 'category' || $f == 'group') {
-                    $clauses[] = 'id'.$f.' IN ('.$v.')';
-                } elseif ($f == 'brand' || $f == 'model' || $f == 'problem') {
-                    $clauses[] = $f.' LIKE :'.$f;
-                }
-            }
-
-            $sql .= implode(' AND ', $clauses);
-        }
-
-        $sql .= ' ORDER BY `sorter` DESC';
-
-        if (! empty($params) && array_key_exists('event_date', $params)) {
-            unset($params['event_date']);
-        }
-
-        if ($params != null) {
-            return DB::select(DB::raw($sql), $params);
-        }
-
-        return DB::select(DB::raw($sql));
-    }
-
     public function ofThisUser($id)
     {
         //Tested

--- a/app/Group.php
+++ b/app/Group.php
@@ -385,6 +385,7 @@ class Group extends Model implements Auditable
      */
     public function upcomingParties($exclude_parties = [])
     {
+        // TODO Timezones
         $from = date('Y-m-d');
 
         if (! empty($exclude_parties)) {
@@ -409,6 +410,7 @@ class Group extends Model implements Auditable
      */
     public function pastParties($exclude_parties = [])
     {
+        // TODO Timezones
         if (! empty($exclude_parties)) {
             return $this->parties()
                 ->where('event_date', '<', date('Y-m-d'))
@@ -450,6 +452,7 @@ class Group extends Model implements Auditable
 
     public function getNextUpcomingEvent()
     {
+        // TODO Timezones
         $event = $this->parties()
             ->whereNotNull('wordpress_post_id')
             ->whereDate('event_date', '>=', date('Y-m-d'))
@@ -693,7 +696,10 @@ class Group extends Model implements Auditable
 
         if (!$timezone) {
             // This should not occur if the networks are set up correctly.
-            throw new \Exception('Group cannot resolve timezone');
+            // TODO Later on we should throw an exception, but only once this code has gone live, as we rely on
+            // the default behaviour during migration.
+            //throw new \Exception("Group {$this->idgroups} cannot resolve timezone");
+            $timezone = 'Europe/London';
         }
 
         return $timezone;

--- a/app/Group.php
+++ b/app/Group.php
@@ -422,7 +422,7 @@ class Group extends Model implements Auditable
                 ->get();
         }
 
-        return $this->parties()->where('event_start_utc', '<', $now)->get();
+        return $this->parties()->where('event_end_utc', '<', $now)->get();
     }
 
     /**
@@ -690,7 +690,7 @@ class Group extends Model implements Auditable
                         // This should not occur if the networks are set up correctly.
                         \Sentry\captureMessage("Problem getting timezone for group {$this->idgroups} - networks conflict with $timezone and {$network->timezone}.  Will use $timezone.");
                         // TODO Convert to exception once groups have timezones set by Neil.
-                        // throw new \Exception("Group is in networks with conflicting timezones");
+                        // throw new \Exception("Group does not have own timezone and is in networks with conflicting timezones");
                     }
                 } else {
                     // First timezone found.

--- a/app/Group.php
+++ b/app/Group.php
@@ -452,11 +452,10 @@ class Group extends Model implements Auditable
 
     public function getNextUpcomingEvent()
     {
-        // TODO Timezones
         $event = $this->parties()
             ->whereNotNull('wordpress_post_id')
-            ->whereDate('event_date', '>=', date('Y-m-d'))
-            ->orderBy('event_date', 'asc');
+            ->whereDate('event_start_utc', '>=', date('Y-m-d H:i:s'))
+            ->orderBy('event_start_utc', 'asc');
 
         if (! $event->count()) {
             return null;

--- a/app/Group.php
+++ b/app/Group.php
@@ -453,7 +453,7 @@ class Group extends Model implements Auditable
     {
         $event = $this->parties()
             ->whereNotNull('wordpress_post_id')
-            ->whereDate('event_start_utc', '>=', date('Y-m-d H:i:s'))
+            ->where('event_start_utc', '>=', date('Y-m-d H:i:s'))
             ->orderBy('event_start_utc', 'asc');
 
         if (! $event->count()) {

--- a/app/Group.php
+++ b/app/Group.php
@@ -683,7 +683,9 @@ class Group extends Model implements Auditable
                 if ($timezone) {
                     if ($timezone != $network->timezone) {
                         // This should not occur if the networks are set up correctly.
-                        throw new \Exception("Group is in networks with conflicting timezones");
+                        \Sentry\captureMessage("Problem getting timezone for group {$this->idgroups} - networks conflict with $timezone and {$network->timezone}.  Will use $timezone.");
+                        // TODO Convert to exception once groups have timezones set by Neil.
+                        // throw new \Exception("Group is in networks with conflicting timezones");
                     }
                 } else {
                     // First timezone found.

--- a/app/Group.php
+++ b/app/Group.php
@@ -376,7 +376,7 @@ class Group extends Model implements Auditable
     }
 
     /**
-     * All parties for the group that are taking place today or later.
+     * All parties for the group that are taking place in the future.
      *
      * @author Christopher Kelker - @date 2019-03-21
      * @editor  Christopher Kelker, Neil Mather
@@ -385,23 +385,21 @@ class Group extends Model implements Auditable
      */
     public function upcomingParties($exclude_parties = [])
     {
-        // TODO Timezones
-        $from = date('Y-m-d');
+        $from = date('Y-m-d H:i:s');
 
         if (! empty($exclude_parties)) {
             return $this->parties()
-                ->where('event_date', '>=', $from)
+                ->where('event_end_utc', '>', $from)
                 ->whereNotIn('idevents', $exclude_parties)
                 ->get();
         }
 
-        return $this->parties()->where('event_date', '>=', $from)->get();
+        return $this->parties()->where('event_end_utc', '>', $from)->get();
     }
 
     /**
      * [pastParties description]
-     * All Past Parties where between the Start Parties Date
-     * is yesterday or a month earlier.
+     * All Past Parties.
      *
      * @author Christopher Kelker - @date 2019-03-21
      * @editor  Christopher Kelker
@@ -410,15 +408,16 @@ class Group extends Model implements Auditable
      */
     public function pastParties($exclude_parties = [])
     {
-        // TODO Timezones
+        $now = date('Y-m-d H:i:s');
+
         if (! empty($exclude_parties)) {
             return $this->parties()
-                ->where('event_date', '<', date('Y-m-d'))
+                ->where('event_end_utc', '<', $now)
                 ->whereNotIn('idevents', $exclude_parties)
                 ->get();
         }
 
-        return $this->parties()->where('event_date', '<', date('Y-m-d'))->get();
+        return $this->parties()->where('event_start_utc', '<', $now)->get();
     }
 
     /**

--- a/app/Helpers/Fixometer.php
+++ b/app/Helpers/Fixometer.php
@@ -998,14 +998,12 @@ class Fixometer
     public static function filterColumns()
     {
         return [
-            // 'deviceID' => '#', - shouldn't really hide this column as this allows someone to view or edit the device!
             'category' => 'Category',
             'brand' => 'Brand',
             'model' => 'Model',
             'problem' => 'Comment',
             'group_name' => 'Group',
             'event_date' => 'Date',
-            //'location' => 'Location', no column for this
             'repair_status' => 'State',
         ];
     }

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -27,8 +27,8 @@ class EventController extends Controller
                   ->join('users', 'users.id', '=', 'user_network.user_id');
 
         if (! empty($date_from) && ! empty($date_to)) {
-            // TODO Timezones.  The API call may return events spanning multiple timezones, and it's unclear what
-            // timezone the inputs will be in.
+            // TODO Timezones.  Add optional timezone parameter to route, defaulted to UTC, and let API users
+            // know about.
             $parties = $parties->where('events.event_date', '>=', date('Y-m-d', strtotime($date_from)))
            ->where('events.event_date', '<=', date('Y-m-d', strtotime($date_to)));
         }

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -10,7 +10,6 @@ use Illuminate\Http\Request;
 
 class EventController extends Controller
 {
-    /** ToDo Test */
     public function getEventsByUsersNetworks(Request $request, $date_from = null, $date_to = null)
     {
         $authenticatedUser = Auth::user();
@@ -28,7 +27,8 @@ class EventController extends Controller
                   ->join('users', 'users.id', '=', 'user_network.user_id');
 
         if (! empty($date_from) && ! empty($date_to)) {
-            // TODO Timezones
+            // TODO Timezones.  The API call may return events spanning multiple timezones, and it's unclear what
+            // timezone the inputs will be in.
             $parties = $parties->where('events.event_date', '>=', date('Y-m-d', strtotime($date_from)))
            ->where('events.event_date', '<=', date('Y-m-d', strtotime($date_to)));
         }

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -28,6 +28,7 @@ class EventController extends Controller
                   ->join('users', 'users.id', '=', 'user_network.user_id');
 
         if (! empty($date_from) && ! empty($date_to)) {
+            // TODO Timezones
             $parties = $parties->where('events.event_date', '>=', date('Y-m-d', strtotime($date_from)))
            ->where('events.event_date', '<=', date('Y-m-d', strtotime($date_to)));
         }

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -221,9 +221,7 @@ class GroupController extends Controller
     {
         $group = $group->load('parties');
 
-        // TODO Timezones
-
-        $events = $group->parties->sortByDesc('event_date');
+        $events = $group->parties->sortByDesc('event_start_utc');
 
         if ($request->has('format') && $request->input('format') == 'location') {
             $events = $events->map(function ($event) {

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -221,6 +221,8 @@ class GroupController extends Controller
     {
         $group = $group->load('parties');
 
+        // TODO Timezones
+
         $events = $group->parties->sortByDesc('event_date');
 
         if ($request->has('format') && $request->input('format') == 'location') {

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -242,8 +242,6 @@ class ApiController extends Controller
             // We need the total weight/CO2 impact for this filtering.
             $d = new Device();
 
-            DB::enableQueryLog();
-
             $wheres[] = ['repair_status', '=', env('DEVICE_FIXED')];
 
             // We select the powered and unpowered weights separately and then add them afterwards just because

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -205,10 +205,12 @@ class ApiController extends Controller
         }
 
         if ($from_date) {
+            // TODO Timezones
             $wheres[] = ['events.event_date', '>=', $from_date];
         }
 
         if ($to_date) {
+            // TODO Timezones
             $wheres[] = ['events.event_date', '<=', $to_date];
         }
 

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -205,13 +205,11 @@ class ApiController extends Controller
         }
 
         if ($from_date) {
-            // TODO Timezones
-            $wheres[] = ['events.event_date', '>=', $from_date];
+            $wheres[] = ['events.event_start_utc', '>=', $from_date];
         }
 
         if ($to_date) {
-            // TODO Timezones
-            $wheres[] = ['events.event_date', '<=', $to_date];
+            $wheres[] = ['events.event_end_utc', '<=', $to_date];
         }
 
         // Get the items we want for this page.

--- a/app/Http/Controllers/CalendarEventsController.php
+++ b/app/Http/Controllers/CalendarEventsController.php
@@ -130,15 +130,12 @@ class CalendarEventsController extends Controller
             if (! is_null($event->event_date) && $event->event_date != '0000-00-00') {
                 $ical[] = 'BEGIN:VEVENT';
 
-                // Timezone currently fixed to Europe/London, but in future when we
-                // have better timezone support in the app this will need amending.
                 $ical[] = 'TZID:Europe/London';
                 $ical[] = "UID:{$event->idevents}";
                 $ical[] = 'DTSTAMP:'.date($this->ical_format).'';
                 $ical[] = "SUMMARY:{$event->venue} ({$event->name})";
-                // TODO Timezones
-                $ical[] = 'DTSTART;TZID=Europe/London:'.date($this->ical_format, strtotime($event->event_date.' '.$event->start)).'';
-                $ical[] = 'DTEND;TZID=Europe/London:'.date($this->ical_format, strtotime($event->event_date.' '.$event->end)).'';
+                $ical[] = 'DTSTART;TZID=' . $event->timezone . ':'.date($this->ical_format, strtotime($event->event_date.' '.$event->start)).'';
+                $ical[] = 'DTEND;TZID=' . $event->timezone . ':'.date($this->ical_format, strtotime($event->event_date.' '.$event->end)).'';
                 $ical[] = 'DESCRIPTION:'.url('/party/view').'/'.$event->idevents;
                 $ical[] = "LOCATION:{$event->location}";
                 $ical[] = 'URL:'.url('/party/view').'/'.$event->idevents;

--- a/app/Http/Controllers/CalendarEventsController.php
+++ b/app/Http/Controllers/CalendarEventsController.php
@@ -41,6 +41,7 @@ class CalendarEventsController extends Controller
       })
       ->select('events.*', 'groups.name')
       ->groupBy('idevents')
+            // TODO Timezones
       ->orderBy('event_date', 'ASC')
       ->get();
 
@@ -56,6 +57,8 @@ class CalendarEventsController extends Controller
       })
       ->select('events.*', 'groups.name')
       ->groupBy('events.idevents')
+            // TODO Timezones
+
       ->orderBy('events.event_date', 'ASC')
       ->get();
 
@@ -74,6 +77,7 @@ class CalendarEventsController extends Controller
       })
       ->select('events.*', 'groups.name')
       ->groupBy('events.idevents')
+      // TODO Timezones
       ->orderBy('events.event_date', 'ASC')
       ->get();
 
@@ -94,6 +98,7 @@ class CalendarEventsController extends Controller
       })
       ->select('events.*', 'groups.name')
       ->groupBy('events.idevents')
+    // TODO Timezones
       ->orderBy('events.event_date', 'ASC')
       ->get();
 
@@ -136,6 +141,7 @@ class CalendarEventsController extends Controller
                 $ical[] = "UID:{$event->idevents}";
                 $ical[] = 'DTSTAMP:'.date($this->ical_format).'';
                 $ical[] = "SUMMARY:{$event->venue} ({$event->name})";
+                // TODO Timezones
                 $ical[] = 'DTSTART;TZID=Europe/London:'.date($this->ical_format, strtotime($event->event_date.' '.$event->start)).'';
                 $ical[] = 'DTEND;TZID=Europe/London:'.date($this->ical_format, strtotime($event->event_date.' '.$event->end)).'';
                 $ical[] = 'DESCRIPTION:'.url('/party/view').'/'.$event->idevents;

--- a/app/Http/Controllers/CalendarEventsController.php
+++ b/app/Http/Controllers/CalendarEventsController.php
@@ -41,8 +41,7 @@ class CalendarEventsController extends Controller
       })
       ->select('events.*', 'groups.name')
       ->groupBy('idevents')
-            // TODO Timezones
-      ->orderBy('event_date', 'ASC')
+      ->orderBy('event_start_utc', 'ASC')
       ->get();
 
         $this->exportCalendar($events);
@@ -57,9 +56,7 @@ class CalendarEventsController extends Controller
       })
       ->select('events.*', 'groups.name')
       ->groupBy('events.idevents')
-            // TODO Timezones
-
-      ->orderBy('events.event_date', 'ASC')
+      ->orderBy('events.event_start_utc', 'ASC')
       ->get();
 
         if (empty($events)) {
@@ -77,8 +74,7 @@ class CalendarEventsController extends Controller
       })
       ->select('events.*', 'groups.name')
       ->groupBy('events.idevents')
-      // TODO Timezones
-      ->orderBy('events.event_date', 'ASC')
+      ->orderBy('events.event_start_utc', 'ASC')
       ->get();
 
         if (empty($events)) {
@@ -98,8 +94,7 @@ class CalendarEventsController extends Controller
       })
       ->select('events.*', 'groups.name')
       ->groupBy('events.idevents')
-    // TODO Timezones
-      ->orderBy('events.event_date', 'ASC')
+      ->orderBy('events.event_start_utc', 'ASC')
       ->get();
 
         if (empty($events)) {

--- a/app/Http/Controllers/CalendarEventsController.php
+++ b/app/Http/Controllers/CalendarEventsController.php
@@ -130,7 +130,7 @@ class CalendarEventsController extends Controller
             if (! is_null($event->event_date) && $event->event_date != '0000-00-00') {
                 $ical[] = 'BEGIN:VEVENT';
 
-                $ical[] = 'TZID:Europe/London';
+                $ical[] = 'TZID:' . $event->timezone;
                 $ical[] = "UID:{$event->idevents}";
                 $ical[] = 'DTSTAMP:'.date($this->ical_format).'';
                 $ical[] = "SUMMARY:{$event->venue} ({$event->name})";

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -37,6 +37,7 @@ class DeviceController extends Controller
         $most_recent_finished_event = Party::with('theGroup')
         ->hasDevicesRepaired(1)
         ->eventHasFinished()
+        // TODO Timezones
         ->orderBy('event_date', 'DESC')
         ->first();
 

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -37,8 +37,7 @@ class DeviceController extends Controller
         $most_recent_finished_event = Party::with('theGroup')
         ->hasDevicesRepaired(1)
         ->eventHasFinished()
-        // TODO Timezones
-        ->orderBy('event_date', 'DESC')
+        ->orderBy('event_start_utc', 'DESC')
         ->first();
 
         if ($most_recent_finished_event) {

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -290,9 +290,7 @@ class ExportController extends Controller
             }
 
             //By date
-            // TODO Timezones.  This is trick because the input fields are currently in local time, but the events
-            // we are exporting might span multiple time zones.  We need to change the client to pass in a UTC
-            // string.
+            // TODO Timezones.  This is only used by admins and therefore the dates can be assumed to be in UTC.
             if ($request->input('from_date') !== null && $request->input('to_date') == null) {
                 $user_events = $user_events->whereDate('events.event_date', '>', $request->input('from_date'));
             } elseif ($request->input('to_date') !== null && $request->input('from_date') == null) {

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -290,7 +290,9 @@ class ExportController extends Controller
             }
 
             //By date
-            // TODO Timezones
+            // TODO Timezones.  This is trick because the input fields are currently in local time, but the events
+            // we are exporting might span multiple time zones.  We need to change the client to pass in a UTC
+            // string.
             if ($request->input('from_date') !== null && $request->input('to_date') == null) {
                 $user_events = $user_events->whereDate('events.event_date', '>', $request->input('from_date'));
             } elseif ($request->input('to_date') !== null && $request->input('from_date') == null) {
@@ -363,8 +365,8 @@ class ExportController extends Controller
         $all_city_hours_completed = $city_hours_completed->orderBy('event_hours', 'DESC')->get();
         $city_hours_completed = $city_hours_completed->orderBy('event_hours', 'DESC')->take(5)->get();
 
-        //order by users id
-        $user_events = $user_events->orderBy('events.event_date', 'DESC');
+        //order by event date.
+        $user_events = $user_events->orderBy('events.event_start_utc', 'DESC');
 
         //Select all necessary information for table
         $user_events = $user_events->select(

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -290,6 +290,7 @@ class ExportController extends Controller
             }
 
             //By date
+            // TODO Timezones
             if ($request->input('from_date') !== null && $request->input('to_date') == null) {
                 $user_events = $user_events->whereDate('events.event_date', '>', $request->input('from_date'));
             } elseif ($request->input('to_date') !== null && $request->input('from_date') == null) {

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -1392,7 +1392,7 @@ class GroupController extends Controller
         $exclude_parties = [];
         if (! empty($date_from) && ! empty($date_to)) {
             foreach ($group->parties as $party) {
-                // TODO Timezones
+                // TODO Timezones.  The inputs are probably in local timezones.
                 if (! Fixometer::validateBetweenDates($party->event_date, $date_from, $date_to)) {
                     $exclude_parties[] = $party->idevents;
                 }

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -1392,6 +1392,7 @@ class GroupController extends Controller
         $exclude_parties = [];
         if (! empty($date_from) && ! empty($date_to)) {
             foreach ($group->parties as $party) {
+                // TODO Timezones
                 if (! Fixometer::validateBetweenDates($party->event_date, $date_from, $date_to)) {
                     $exclude_parties[] = $party->idevents;
                 }

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -246,7 +246,10 @@ class PartyController extends Controller
                 $hours = $dtDiff->h;
 
                 // No errors. We can proceed and create the Party.
+                //
+                // timezone needs to be the first attribute set, because it is used in mutators for later attributes.
                 $data = [
+                    'timezone' => $groupobj->timezone,
                     'event_date' => $event_date,
                     'start' => $start,
                     'end' => $end,
@@ -263,8 +266,7 @@ class PartyController extends Controller
                     'user_id' => $user_id,
                     'created_at' => date('Y-m-d H:i:s'),
                     'shareable_code' => Fixometer::generateUniqueShareableCode(\App\Party::class, 'shareable_code'),
-                    'online' => $online,
-                    'timezone' => $groupobj->timezone
+                    'online' => $online
                 ];
 
                 $party = Party::create($data);

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -125,8 +125,13 @@ class PartyController extends Controller
             }
 
             // ...and any other upcoming events
+            DB::enableQueryLog();
+
             $other_upcoming_events = Party::future()->
                 whereNotIn('idevents', \Illuminate\Support\Arr::pluck($events, 'idevents'))->get();
+
+            $queries = DB::getQueryLog();
+            error_log(var_export($queries, TRUE));
 
             foreach ($other_upcoming_events as $event) {
                 $e = self::expandEvent($event, NULL);

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -506,6 +506,7 @@ class PartyController extends Controller
             }
 
             $audits = Party::findOrFail($id)->audits;
+            $party = $Party->findThis($id)[0];
 
             return view('events.edit', [ //party.edit
                 'response' => $response,

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -1332,7 +1332,8 @@ class PartyController extends Controller
          ->join('users', 'users.access_group_tag_id', '=', 'group_tags.id');
 
         if (! empty($date_from) && ! empty($date_to)) {
-            // TODO Timezones
+            // TODO Timezones.  The API call may return events spanning multiple timezones, and it's unclear what
+            // timezone the inputs will be in.
             $parties = $parties->where('events.event_date', '>=', date('Y-m-d', strtotime($date_from)))
            ->where('events.event_date', '<=', date('Y-m-d', strtotime($date_to)));
         }

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -125,13 +125,8 @@ class PartyController extends Controller
             }
 
             // ...and any other upcoming events
-            DB::enableQueryLog();
-
             $other_upcoming_events = Party::future()->
                 whereNotIn('idevents', \Illuminate\Support\Arr::pluck($events, 'idevents'))->get();
-
-            $queries = DB::getQueryLog();
-            error_log(var_export($queries, TRUE));
 
             foreach ($other_upcoming_events as $event) {
                 $e = self::expandEvent($event, NULL);

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -54,7 +54,8 @@ class PartyController extends Controller
 
     public static function expandEvent($event, $group)
     {
-        $thisone = $event->getAttributes();
+        // Use attributesToArray rather than getAttributes so that our custom accessors are invoked.
+        $thisone = $event->attributesToArray();
 
         if (is_null($group)) {
             // We are showing events for multiple groups and so we need to pass the relevant group, in order that
@@ -208,9 +209,12 @@ class PartyController extends Controller
                 $start = $request->input('start');
                 $end = $request->input('end');
 
+                // Convert these to the UTC timezone for storage.
                 $startCarbon = Carbon::parse($event_date . ' ' . $start, $timezone);
+                $startCarbon->setTimezone('UTC');
                 $event_start_utc = $startCarbon->toIso8601String();
                 $endCarbon = Carbon::parse($event_date . ' ' . $end, $timezone);
+                $endCarbon->setTimezone('UTC');
                 $event_end_utc = $endCarbon->toIso8601String();
             }
 

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -174,9 +174,9 @@ class PartyController extends Controller
             // We might be passed a timezone; if not then use the timezone of the group.
             $timezone = $request->input('timezone', $groupobj->timezone);
 
-            // There are two ways events can be created.
+            // There are two ways event date/times can be created.
             // 1. By passing event_start_utc and event_end_utc, or
-            // 2. By passing event_date, start, end.
+            // 2. By passing event_date, start, end (deprecated).
             if ($request->has('event_start_utc') && $request->has('event_end_utc')) {
                 $request->validate([
                                        'location' => [
@@ -435,9 +435,9 @@ class PartyController extends Controller
             // We might have been passed a timezone; if not then inherit from the current value.
             $timezone = $request->input('timezone', Party::find($id)->timezone);
 
-            // There are two ways events can be update.
+            // There are two ways event date/times can be updated.
             // 1. By passing event_start_utc and event_end_utc, or
-            // 2. By passing event_date, start, end.
+            // 2. By passing event_date, start, end (deprecated).
             if ($request->has('event_start_utc') && $request->has('event_end_utc')) {
                 $event_start_utc = $request->input('event_start_utc');
                 $event_end_utc = $request->input('event_end_utc');

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -223,7 +223,8 @@ class PartyController extends Controller
 
             // Check whether the event should be auto-approved, if all of the networks it belongs to
             // allow it.
-            $autoapprove = Group::where('idgroups', $group)->first()->auto_approve;
+            $groupobj = Group::where('idgroups', $group)->first();
+            $autoapprove = $groupobj->auto_approve;
 
             // formatting dates for the DB
             $event_date = date('Y-m-d', strtotime($event_date));
@@ -263,6 +264,7 @@ class PartyController extends Controller
                     'created_at' => date('Y-m-d H:i:s'),
                     'shareable_code' => Fixometer::generateUniqueShareableCode(\App\Party::class, 'shareable_code'),
                     'online' => $online,
+                    'timezone' => $groupobj->timezone
                 ];
 
                 $party = Party::create($data);
@@ -1291,6 +1293,7 @@ class PartyController extends Controller
          ->join('users', 'users.access_group_tag_id', '=', 'group_tags.id');
 
         if (! empty($date_from) && ! empty($date_to)) {
+            // TODO Timezones
             $parties = $parties->where('events.event_date', '>=', date('Y-m-d', strtotime($date_from)))
            ->where('events.event_date', '<=', date('Y-m-d', strtotime($date_to)));
         }

--- a/app/Listeners/CreateWordpressPostForEvent.php
+++ b/app/Listeners/CreateWordpressPostForEvent.php
@@ -54,9 +54,9 @@ class CreateWordpressPostForEvent
         }
 
         try {
-            // TODO Timezones
-            $startTimestamp = strtotime($theParty->event_date.' '.$theParty->start);
-            $endTimestamp = strtotime($theParty->event_date.' '.$theParty->end);
+            // TODO Timezones.  We need to pass the timezone and display it.
+            $startTimestamp = strtotime($theParty->event_start_utc);
+            $endTimestamp = strtotime($theParty->event_end_utc);
 
             $group = Group::where('idgroups', $theParty->group)->first();
 

--- a/app/Listeners/CreateWordpressPostForEvent.php
+++ b/app/Listeners/CreateWordpressPostForEvent.php
@@ -54,6 +54,7 @@ class CreateWordpressPostForEvent
         }
 
         try {
+            // TODO Timezones
             $startTimestamp = strtotime($theParty->event_date.' '.$theParty->start);
             $endTimestamp = strtotime($theParty->event_date.' '.$theParty->end);
 

--- a/app/Listeners/CreateWordpressPostForEvent.php
+++ b/app/Listeners/CreateWordpressPostForEvent.php
@@ -54,7 +54,8 @@ class CreateWordpressPostForEvent
         }
 
         try {
-            // TODO Timezones.  We need to pass the timezone and display it.
+            // TODO Timezones.  We need to pass party_timezone field, and change party_time to have timezone
+            // in brackets afterwards.
             $startTimestamp = strtotime($theParty->event_start_utc);
             $endTimestamp = strtotime($theParty->event_end_utc);
 

--- a/app/Listeners/EditWordpressPostForEvent.php
+++ b/app/Listeners/EditWordpressPostForEvent.php
@@ -8,6 +8,7 @@ use App\Helpers\Fixometer;
 use App\Network;
 use App\Notifications\AdminWordPressEditEventFailure;
 use App\Party;
+use Carbon\Carbon;
 use HieuLe\WordpressXmlrpcClient\WordpressClient;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
@@ -49,9 +50,9 @@ class EditWordpressPostForEvent
 
         try {
             if (is_numeric($theParty->wordpress_post_id)) {
-                // TODO Timezones
-                $startTimestamp = strtotime($data['event_date'].' '.$data['start']);
-                $endTimestamp = strtotime($data['event_date'].' '.$data['end']);
+                // TODO Timezones - this code doesn't yet push the timezone information to Wordpress.
+                $start = Carbon::parse($data['event_start_utc']);
+                $end = Carbon::parse($data['event_end_utc']);
 
                 $group = Group::where('idgroups', $theParty->group)->first();
 
@@ -61,10 +62,10 @@ class EditWordpressPostForEvent
                     ['key' => 'party_groupcity', 'value' => $group->area],
                     ['key' => 'party_venue', 'value' => $data['venue']],
                     ['key' => 'party_location', 'value' => $data['location']],
-                    ['key' => 'party_time', 'value' => substr($data['start'], 0, 5).' - '.substr($data['end'], 0, 5)],
-                    ['key' => 'party_date', 'value' => $data['event_date']],
-                    ['key' => 'party_timestamp', 'value' => $startTimestamp],
-                    ['key' => 'party_timestamp_end', 'value' => $endTimestamp],
+                    ['key' => 'party_time', 'value' => $start->toTimeString('minute') .' - '. $end->toTimeString('minute')],
+                    ['key' => 'party_date', 'value' => $start->toDateString()],
+                    ['key' => 'party_timestamp', 'value' => $start->timestamp],
+                    ['key' => 'party_timestamp_end', 'value' => $end->timestamp],
                     ['key' => 'party_stats', 'value' => $id],
                     ['key' => 'party_lat', 'value' => $data['latitude']],
                     ['key' => 'party_lon', 'value' => $data['longitude']],

--- a/app/Listeners/EditWordpressPostForEvent.php
+++ b/app/Listeners/EditWordpressPostForEvent.php
@@ -50,7 +50,8 @@ class EditWordpressPostForEvent
 
         try {
             if (is_numeric($theParty->wordpress_post_id)) {
-                // TODO Timezones.  We need to pass the timezone and display it.
+                // TODO Timezones.  We need to pass party_timezone field, and change party_time to have timezone
+                // in brackets afterwards.
                 $startTimestamp = strtotime($theParty->event_start_utc);
                 $endTimestamp = strtotime($theParty->event_end_utc);
 

--- a/app/Listeners/EditWordpressPostForEvent.php
+++ b/app/Listeners/EditWordpressPostForEvent.php
@@ -50,9 +50,9 @@ class EditWordpressPostForEvent
 
         try {
             if (is_numeric($theParty->wordpress_post_id)) {
-                // TODO Timezones - this code doesn't yet push the timezone information to Wordpress.
-                $start = Carbon::parse($data['event_start_utc']);
-                $end = Carbon::parse($data['event_end_utc']);
+                // TODO Timezones.  We need to pass the timezone and display it.
+                $startTimestamp = strtotime($theParty->event_start_utc);
+                $endTimestamp = strtotime($theParty->event_end_utc);
 
                 $group = Group::where('idgroups', $theParty->group)->first();
 
@@ -62,10 +62,10 @@ class EditWordpressPostForEvent
                     ['key' => 'party_groupcity', 'value' => $group->area],
                     ['key' => 'party_venue', 'value' => $data['venue']],
                     ['key' => 'party_location', 'value' => $data['location']],
-                    ['key' => 'party_time', 'value' => $start->toTimeString('minute') .' - '. $end->toTimeString('minute')],
-                    ['key' => 'party_date', 'value' => $start->toDateString()],
-                    ['key' => 'party_timestamp', 'value' => $start->timestamp],
-                    ['key' => 'party_timestamp_end', 'value' => $end->timestamp],
+                    ['key' => 'party_time', 'value' => substr($theParty->start, 0, 5) . ' - ' . substr($theParty->end, 0, 5)],
+                    ['key' => 'party_date', 'value' => $theParty->event_date],
+                    ['key' => 'party_timestamp', 'value' => $startTimestamp],
+                    ['key' => 'party_timestamp_end', 'value' => $endTimestamp],
                     ['key' => 'party_stats', 'value' => $id],
                     ['key' => 'party_lat', 'value' => $data['latitude']],
                     ['key' => 'party_lon', 'value' => $data['longitude']],

--- a/app/Listeners/EditWordpressPostForEvent.php
+++ b/app/Listeners/EditWordpressPostForEvent.php
@@ -49,6 +49,7 @@ class EditWordpressPostForEvent
 
         try {
             if (is_numeric($theParty->wordpress_post_id)) {
+                // TODO Timezones
                 $startTimestamp = strtotime($data['event_date'].' '.$data['start']);
                 $endTimestamp = strtotime($data['event_date'].' '.$data['end']);
 

--- a/app/Party.php
+++ b/app/Party.php
@@ -82,7 +82,7 @@ class Party extends Model implements Auditable
 
     public function findAllSearchable()
     {
-        // TODO Can this be replaced by Partp::past?
+        // TODO Can this be replaced by Party::past?
         return DB::select(DB::raw('SELECT
                     `e`.`idevents` AS `id`,
                     UNIX_TIMESTAMP(`event_start_utc`) AS `event_timestamp`,
@@ -593,6 +593,12 @@ class Party extends Model implements Auditable
     public function getEventEnd()
     {
         return date('H:i', strtotime($this->end));
+    }
+
+    public function getEventTimestampAttribute()
+    {
+        // Returning in local time.
+        return "{$this->event_date} {$this->start}";
     }
 
     public function getEventStartEnd()

--- a/app/Party.php
+++ b/app/Party.php
@@ -1070,73 +1070,31 @@ class Party extends Model implements Auditable
 
     // TODO The intention is that we migrate all the code over to use the UTC variants of event date/start/end.
     // Timezone-aware, ISO8601 formatted.  These are unambiguous, e.g. for API results.
-    public function getStartDateTimeISO8601Attribute() {
-        error_log("Start utc " . $this->event_start_utc);
-        $start = new Carbon($this->event_start_utc);
+    public function getEventStartUtcAttribute() {
+        $start = Carbon::parse($this->attributes['event_start_utc'], 'UTC');
         return $start->toIso8601String();
     }
 
-    public function getEndDateTimeISO8601Attribute() {
-        $end = new Carbon($this->event_end_utc);
+    public function getEventEndUtcAttribute() {
+        $end = Carbon::parse($this->attributes['event_end_utc'], 'UTC');
         return $end->toIso8601String();
     }
 
     // Mutators for legacy event_date/start/end fields.  These are now derived from the UTC fields via virtual
-    // columns, so to set these values we update the UTC fields.
+    // columns, and therefore should never be set directly.  Throw exceptions to ensure that they are not.
+    //
+    // You might think that we could have mutators which set these correctly.  But this isn't possible; the UTC value
+    // of the date depends on the local date, time and timezone, and cannot be set in isolation.
     public function setEventDateAttribute($val) {
-        // We want to change the date value.  What we are passed is local, so first parse it using the event's
-        // timezone.
-        $c = Carbon::parse($val, $this->timezone);
-
-        // Now change that date to UTC, which might result in a different date.
-        $c->setTimezone('UTC');
-
-        // Now copy over the date values, which are now in UTC, to the start and end UTC times.
-        $start = new Carbon($this->event_start_utc);
-        $start->year = $c->year;
-        $start->month = $c->month;
-        $start->day = $c->day;
-        $end = new Carbon($this->event_end_utc);
-        $end->year = $c->year;
-        $end->month = $c->month;
-        $end->day = $c->day;
-
-        $this->event_start_utc = $start->toIso8601String();
-        error_log("Set date utc " . $this->event_start_utc);
-        $this->event_end_utc = $end->toIso8601String();
+        throw new \Exception("Attempt to set event time fields directly; please use event_start_utc and event_end_utc");
     }
 
     public function setStartAttribute($val) {
-        // We want to change the start time.  The value we are passed is local, so first parse it using the event's
-        // timezone.
-        $c = Carbon::parse($val, $this->timezone);
-
-        // Now change that to UTC, which might adjust the time.
-        $c->setTimezone('UTC');
-
-        // Now copy over the time values, which are now in UTC, to our UTC time.
-        $start = new Carbon($this->event_start_utc);
-        $start->hour = $c->hour;
-        $start->minute = $c->minute;
-        $start->second = $c->second;
-        $this->event_start_utc = $start->toIso8601String();
-        error_log("Set start  utc " . $this->event_start_utc);
+        throw new \Exception("Attempt to set event time fields directly; please use event_start_utc and event_end_utc");
     }
 
     public function setEndAttribute($val) {
-        // We want to change the end time.  The value we are passed is local, so first parse it using the event's
-        // timezone.
-        $c = Carbon::parse($val, $this->timezone);
-
-        // Now change that to UTC, which might adjust the time.
-        $c->setTimezone('UTC');
-
-        // Now copy over the time values, which are now in UTC, to our UTC time..
-        $end = new Carbon($this->event_end_utc);
-        $end->hour = $c->hour;
-        $end->minute = $c->minute;
-        $end->second = $c->second;
-        $this->event_end_utc = $end->toIso8601String();
+        throw new \Exception("Attempt to set event time fields directly; please use event_start_utc and event_end_utc");
     }
 
     // We also need accessors, to avoid any cases where we mutate the values and access them before we have

--- a/app/Party.php
+++ b/app/Party.php
@@ -1081,20 +1081,34 @@ class Party extends Model implements Auditable
     }
 
     // Mutators for legacy event_date/start/end fields.  These are now derived from the UTC fields via virtual
-    // columns, and therefore should never be set directly.  Throw exceptions to ensure that they are not.
+    // columns, and therefore should never be set directly.  Throw exceptions to ensure that they are not, until we
+    // have retired these fields.
+    //
+    // The tests create events using the old fields, and we've not changed those yet, but PartyFactory will have
+    // populated the new ones - so just ignore that.
     //
     // You might think that we could have mutators which set these correctly.  But this isn't possible; the UTC value
     // of the date depends on the local date, time and timezone, and cannot be set in isolation.
     public function setEventDateAttribute($val) {
-        throw new \Exception("Attempt to set event time fields directly; please use event_start_utc and event_end_utc");
+        if (!array_key_exists('event_start_utc', $this->attributes)) {
+            throw new \Exception("Attempt to set event time fields directly; please use event_start_utc and event_end_utc");
+        }
     }
 
     public function setStartAttribute($val) {
-        throw new \Exception("Attempt to set event time fields directly; please use event_start_utc and event_end_utc");
+        if (!array_key_exists('event_start_utc', $this->attributes)) {
+            throw new \Exception(
+                "Attempt to set event time fields directly; please use event_start_utc and event_end_utc"
+            );
+        }
     }
 
     public function setEndAttribute($val) {
-        throw new \Exception("Attempt to set event time fields directly; please use event_start_utc and event_end_utc");
+        if (!array_key_exists('event_start_utc', $this->attributes)) {
+            throw new \Exception(
+                "Attempt to set event time fields directly; please use event_start_utc and event_end_utc"
+            );
+        }
     }
 
     // We also need accessors, to avoid any cases where we mutate the values and access them before we have

--- a/app/Party.php
+++ b/app/Party.php
@@ -403,7 +403,7 @@ class Party extends Model implements Auditable
         $query = $query->undeleted();
         $now = date('Y-m-d H:i:s');
         $query = $query->where('event_start_utc', '<=', $now)
-            ->where('event_end_utc', '<=', $now);
+            ->where('event_end_utc', '>=', $now);
         return $query;
     }
 
@@ -640,7 +640,7 @@ class Party extends Model implements Auditable
             return true;
         }
 
-        return true;
+        return false;
     }
 
     public function isInProgress()

--- a/app/Party.php
+++ b/app/Party.php
@@ -44,6 +44,7 @@ class Party extends Model implements Auditable
         'discourse_thread',
         'devices_updated_at',
         'link',
+        'timezone'
     ];
     protected $hidden = ['created_at', 'updated_at', 'deleted_at', 'frequency', 'group', 'group', 'user_id', 'wordpress_post_id', 'cancelled', 'devices_updated_at'];
 
@@ -1062,5 +1063,16 @@ class Party extends Model implements Auditable
         }
 
         event(new ApproveEvent($this));
+    }
+
+    public function getTimezoneAttribute($value)
+    {
+        // We might have a timezone attribute on the event.
+        if ($value) {
+            return $value;
+        }
+
+        // Use the timezone from the group (which will fallback to network if required).
+        return $this->theGroup->timezone;
     }
 }

--- a/app/Party.php
+++ b/app/Party.php
@@ -301,7 +301,7 @@ class Party extends Model implements Auditable
         return self::when($only_past, function ($query) {
             // We only want the ones in the past.
             $now = date('Y-m-d H:i:s');
-            return $query->whereDate('event_end_utc', '<', $now);
+            return $query->where('event_end_utc', '<', $now);
         })->when(is_numeric($group), function ($query) use ($group) {
             // For a specific group.  Note that 'admin' is not numeric so won't pass this test.
             return $query->where('group', $group);
@@ -387,14 +387,14 @@ class Party extends Model implements Auditable
     public function scopePast($query) {
         // A past event is an event where the end time is less than now.
         $query = $query->undeleted();
-        $query = $query->whereDate('event_end_utc', '<', date('Y-m-d H:i:s'));
+        $query = $query->where('event_end_utc', '<', date('Y-m-d H:i:s'));
         return $query;
     }
 
     public function scopeFuture($query) {
         // A future event is an event where the start time is greater than now.
         $query = $query->undeleted();
-        $query = $query->whereDate('event_start_utc', '>', date('Y-m-d H:i:s'));
+        $query = $query->where('event_start_utc', '>', date('Y-m-d H:i:s'));
         return $query;
     }
 
@@ -402,8 +402,8 @@ class Party extends Model implements Auditable
         // An active event is an event which has started and not yet finished.
         $query = $query->undeleted();
         $now = date('Y-m-d H:i:s');
-        $query = $query->whereDate('event_start_utc', '<=', $now)
-            ->whereDate('event_end_utc', '<=', $now);
+        $query = $query->where('event_start_utc', '<=', $now)
+            ->where('event_end_utc', '<=', $now);
         return $query;
     }
 
@@ -535,7 +535,7 @@ class Party extends Model implements Auditable
       ->join('users_groups', 'users_groups.group', '=', 'groups.idgroups')
       ->where(function ($query) use ($user_group_ids) {
           $query->whereNotIn('events.group', $user_group_ids)
-        ->whereDate('event_start_utc', '>=', date('Y-m-d H:i:s'));
+        ->where('event_start_utc', '>=', date('Y-m-d H:i:s'));
       })
       ->having('distance', '<=', User::NEARBY_KM)
       ->groupBy('events.idevents')

--- a/app/Search.php
+++ b/app/Search.php
@@ -22,13 +22,11 @@ class Search extends Model
         }
 
         if (! is_null($from)) {
-            // TODO Timezones
-            $eventsQuery->whereRaw('UNIX_TIMESTAMP(event_date) >= '.$from);
+            $eventsQuery->whereDate('event_start_utc', '>=', date('Y-m-d H:i:s', $from));
         }
 
         if (! is_null($to)) {
-            // TODO Timezones
-            $eventsQuery->whereRaw('UNIX_TIMESTAMP(event_date) <= '.$to);
+            $eventsQuery->whereDate('event_end_utc', '<=', date('Y-m-d H:i:s', $to));
         }
 
         if (! is_null($group_tags)) {
@@ -40,8 +38,7 @@ class Search extends Model
         }
 
         $eventsQuery->groupBy('events.idevents');
-        // TODO Timezones
-        $eventsQuery->orderBy('events.event_date', 'desc');
+        $eventsQuery->orderBy('events.event_start_utc', 'desc');
 
         // We need to explicitly select what we want to return otherwise gtag.group might overwrite events.group.
         return $eventsQuery->select(['events.*', 'gtag.group_tag'])->get();

--- a/app/Search.php
+++ b/app/Search.php
@@ -22,10 +22,12 @@ class Search extends Model
         }
 
         if (! is_null($from)) {
+            // TODO Timezones
             $eventsQuery->whereRaw('UNIX_TIMESTAMP(event_date) >= '.$from);
         }
 
         if (! is_null($to)) {
+            // TODO Timezones
             $eventsQuery->whereRaw('UNIX_TIMESTAMP(event_date) <= '.$to);
         }
 
@@ -38,6 +40,7 @@ class Search extends Model
         }
 
         $eventsQuery->groupBy('events.idevents');
+        // TODO Timezones
         $eventsQuery->orderBy('events.event_date', 'desc');
 
         // We need to explicitly select what we want to return otherwise gtag.group might overwrite events.group.

--- a/app/Search.php
+++ b/app/Search.php
@@ -22,11 +22,11 @@ class Search extends Model
         }
 
         if (! is_null($from)) {
-            $eventsQuery->whereDate('event_start_utc', '>=', date('Y-m-d H:i:s', $from));
+            $eventsQuery->where('event_start_utc', '>=', date('Y-m-d H:i:s', $from));
         }
 
         if (! is_null($to)) {
-            $eventsQuery->whereDate('event_end_utc', '<=', date('Y-m-d H:i:s', $to));
+            $eventsQuery->where('event_end_utc', '<=', date('Y-m-d H:i:s', $to));
         }
 
         if (! is_null($group_tags)) {

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -7,6 +7,7 @@ $factory->define(App\Group::class, function (Faker $faker) {
         'name' => $faker->unique()->company,
         'free_text' => $faker->sentence,
         'facebook' => '',
-        'postcode' => ''
+        'postcode' => '',
+        'timezone' => 'Europe/London'
     ];
 });

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -7,6 +7,6 @@ $factory->define(App\Group::class, function (Faker $faker) {
         'name' => $faker->unique()->company,
         'free_text' => $faker->sentence,
         'facebook' => '',
-        'postcode' => '',
+        'postcode' => ''
     ];
 });

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -6,15 +6,18 @@ use Faker\Generator as Faker;
 $factory->define(App\Party::class, function (Faker $faker) {
     // Need to force the location otherwise the random one may not be geocodable and therefore the event may not
     // get created.
+    $start = Carbon\Carbon::parse($faker->iso8601());
+    $end = $start;
+    $end->addHours(2);
+
     return [
         'location' => 'International House, 3Space, 6 Canterbury Cres, London SW9 7QD',
         'group' => function () {
             return factory(Group::class)->create()->idgroups;
         },
         'venue' => $faker->streetName,
-        'event_date' => $faker->date(),
-        'start' => $faker->time(),
-        'end' => $faker->time(),
+        'event_start_utc' => $start->toIso8601String(),
+        'event_end_utc' => $end->toIso8601String(),
         'free_text' => $faker->paragraph,
         'timezone' => 'Europe/London'
     ];

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -9,11 +9,14 @@ $factory->define(App\Party::class, function (Faker $faker, $attributes = []) {
     if (array_key_exists('event_date', $attributes)) {
         $startTime = array_key_exists('start', $attributes) ? $attributes['start'] : $faker->time();
         $endTime = array_key_exists('end', $attributes) ? $attributes['end'] : $faker->time();
-        $start = Carbon\Carbon::parse($attributes['event_date'] . ' ' . $startTime);
-        $end = Carbon\Carbon::parse($attributes['event_date'] . ' ' . $endTime);
+        $start = Carbon\Carbon::parse($attributes['event_date'] . ' ' . $startTime, 'UTC');
+        $end = Carbon\Carbon::parse($attributes['event_date'] . ' ' . $endTime, 'UTC');
         unset($attributes['event_date']);
         unset($attributes['start']);
         unset($attributes['end']);
+    } else if (array_key_exists('event_start_utc', $attributes)) {
+        $start = Carbon\Carbon::parse($attributes['event_start_utc']);
+        $end = Carbon\Carbon::parse($attributes['event_end_utc']);
     } else {
         // Fake an event that's two hours long.
         $start = Carbon\Carbon::parse($faker->iso8601());

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -16,6 +16,7 @@ $factory->define(App\Party::class, function (Faker $faker) {
         'start' => $faker->time(),
         'end' => $faker->time(),
         'free_text' => $faker->paragraph,
+        'timezone' => 'Europe/London'
     ];
 });
 

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -26,18 +26,8 @@ $factory->state(App\Party::class, 'moderated', function (Faker $faker) {
     ];
 });
 
-/*$factory->state(App\Party::class, 'with-device', function (Faker $faker) {
-    $device = factory(Device::class)->create([
-        'event' => $event->idevents,
-        'repair_status' => 1,
-        'category' => $category->idcategories,
-        'category_creation' => $category->idcategories,
-    ]);
-    return [
-        'location' => $faker->name,
-        'group' => function () {
-            return factory(Group::class)->create()->idgroups;
-        }
-    ];
+$factory->afterCreating(App\Party::class, function($model, $faker) {
+    // We want to refresh the model before returning it.  This is so that we pick up the virtual columns.
+    $model->refresh();
+    return $model;
 });
-*/

--- a/database/migrations/2022_01_24_101405_timezones.php
+++ b/database/migrations/2022_01_24_101405_timezones.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Timezones extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->string('timezone', 64)->comment('TZ database name')->nullable()->default(null);
+        });
+
+        Schema::table('events', function (Blueprint $table) {
+            $table->string('timezone', 64)->comment('TZ database name')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn('timezone');
+        });
+
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('timezone');
+        });
+    }
+}

--- a/database/migrations/2022_01_24_101405_timezones.php
+++ b/database/migrations/2022_01_24_101405_timezones.php
@@ -37,7 +37,7 @@ class Timezones extends Migration
 
         # Set up the new timestamps.  Currently event_start/time/end are all implicitly localised to the timezone
         # of the group.
-        $events = Party::all();
+        $events = Party::withTrashed();
 
         foreach ($events as $event) {
             $tz = $event->timezone;

--- a/database/migrations/2022_01_24_101405_timezones.php
+++ b/database/migrations/2022_01_24_101405_timezones.php
@@ -49,7 +49,7 @@ class Timezones extends Migration
             $event_start_utc = $startCarbon->toIso8601String();
             $endCarbon = Carbon::parse($atts['event_date'] . ' ' . $atts['end'], $tz);
             $endCarbon->setTimezone('UTC');
-            $event_end_utc = $startCarbon->toIso8601String();
+            $event_end_utc = $endCarbon->toIso8601String();
 
             error_log("Event {$event->idevents} {$atts['event_date']} {$atts['start']}-{$atts['end']} => $event_start_utc - $event_end_utc");
 

--- a/database/migrations/2022_01_24_101405_timezones.php
+++ b/database/migrations/2022_01_24_101405_timezones.php
@@ -22,9 +22,9 @@ class Timezones extends Migration
 
         # The events table changes so that we have timestamp fields for start/end which are defined to be in UTC.
         Schema::table('events', function (Blueprint $table) {
-            $table->string('timezone', 64)->comment('TZ database name')->nullable()->default(null);
-            $table->datetime('event_start_utc')->comment('Timestamp of event start in UTC')->nullable()->default(null)->index();
-            $table->datetime('event_end_utc')->comment('Timestamp of event end in UTC')->nullable()->default(null)->index();
+            $table->datetime('event_start_utc')->comment('Timestamp of event start in UTC')->nullable()->default(null)->index()->after('group');
+            $table->datetime('event_end_utc')->comment('Timestamp of event end in UTC')->nullable()->default(null)->index()->after('event_start_utc');
+            $table->string('timezone', 64)->comment('TZ database name')->nullable()->default(null)->after('event_end_utc');
             $table->date('event_date_old')->comment('Old data before RES-1624')->nullable()->default(null);
             $table->time('start_old')->comment('Old data before RES-1624')->nullable()->default(null);
             $table->time('end_old')->comment('Old data before RES-1624')->nullable()->default(null);

--- a/database/migrations/2022_01_24_101405_timezones.php
+++ b/database/migrations/2022_01_24_101405_timezones.php
@@ -37,7 +37,7 @@ class Timezones extends Migration
 
         # Set up the new timestamps.  Currently event_start/time/end are all implicitly localised to the timezone
         # of the group.
-        $events = Party::withTrashed();
+        $events = Party::withTrashed()->get();
 
         foreach ($events as $event) {
             $tz = $event->timezone;

--- a/database/migrations/2022_01_24_101405_timezones.php
+++ b/database/migrations/2022_01_24_101405_timezones.php
@@ -47,7 +47,7 @@ class Timezones extends Migration
             $startCarbon = Carbon::parse($atts['event_date'] . ' ' . $atts['start'], $tz);
             $startCarbon->setTimezone('UTC');
             $event_start_utc = $startCarbon->toIso8601String();
-            $endCarbon = Carbon::parse($atts['event_date'] . ' ' . $atts['start'], $tz);
+            $endCarbon = Carbon::parse($atts['event_date'] . ' ' . $atts['end'], $tz);
             $endCarbon->setTimezone('UTC');
             $event_end_utc = $startCarbon->toIso8601String();
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -38,7 +38,7 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="MAIL_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="mysql_testing"/>
-        <env name="DB_TEST_DATABASE" value="restarters_db"/>
+        <env name="DB_TEST_DATABASE" value="restarters_db_test"/>
         <env name="DB_TEST_USERNAME" value="restarters"/>
         <env name="DB_TEST_PASSWORD" value="s3cr3t"/>
         <env name="AUDIT_CONSOLE_EVENTS" value="true"/>

--- a/tests/Feature/Dashboard/BasicTest.php
+++ b/tests/Feature/Dashboard/BasicTest.php
@@ -99,7 +99,9 @@ class BasicTest extends TestCase
         // Admin approves the event.
         $this->loginAsTestUser(Role::ADMINISTRATOR);
 
-        $eventData = $event->getAttributes();
+        $eventData = $event->attributesToArray();
+        error_log("Ats " . var_export($eventData, TRUE));
+        error_log("Event " . var_export($event, TRUE));
         $eventData['wordpress_post_id'] = 100;
         $eventData['id'] = $event->idevents;
         $eventData['moderate'] = 'approve';

--- a/tests/Feature/Dashboard/BasicTest.php
+++ b/tests/Feature/Dashboard/BasicTest.php
@@ -99,9 +99,7 @@ class BasicTest extends TestCase
         // Admin approves the event.
         $this->loginAsTestUser(Role::ADMINISTRATOR);
 
-        $eventData = $event->attributesToArray();
-        error_log("Ats " . var_export($eventData, TRUE));
-        error_log("Event " . var_export($event, TRUE));
+        $eventData = $event->getAttributes();
         $eventData['wordpress_post_id'] = 100;
         $eventData['id'] = $event->idevents;
         $eventData['moderate'] = 'approve';

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -83,8 +83,8 @@ class CreateEventTest extends TestCase
         $eventAttributes['link'] = 'https://therestartproject.org/';
 
         // We want an upcoming event so that we can check it appears in various places.
-        $eventAttributes['event_start_utc'] = Carbon::parse('1pm tomorrow')->format('Y-m-d H:i:s');
-        $eventAttributes['event_end_utc'] = Carbon::parse('2pm tomorrow')->format('Y-m-d H:i:s');
+        $eventAttributes['event_start_utc'] = Carbon::parse('1pm tomorrow')->toIso8601String();
+        $eventAttributes['event_end_utc'] = Carbon::parse('3pm tomorrow')->toIso8601String();
 
         $this->post('/party/create/', $eventAttributes);
 

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -12,6 +12,7 @@ use App\Notifications\NotifyRestartersOfNewEvent;
 use App\Party;
 use App\Role;
 use App\User;
+use Carbon\Carbon;
 use DB;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
@@ -82,9 +83,14 @@ class CreateEventTest extends TestCase
         $eventAttributes['link'] = 'https://therestartproject.org/';
 
         // We want an upcoming event so that we can check it appears in various places.
-        $eventAttributes['event_date'] = date('Y-m-d', strtotime('tomorrow'));
+        $eventAttributes['event_start_utc'] = Carbon::parse('1pm tomorrow')->format('Y-m-d H:i:s');
+        $eventAttributes['event_end_utc'] = Carbon::parse('2pm tomorrow')->format('Y-m-d H:i:s');
 
         $this->post('/party/create/', $eventAttributes);
+
+        // The event_start_utc and event_end_utc will be in the database, but not ISO8601 formatted - that is implicit.
+        $eventAttributes['event_start_utc'] = Carbon::parse($eventAttributes['event_start_utc'])->format('Y-m-d H:i:s');
+        $eventAttributes['event_end_utc'] = Carbon::parse($eventAttributes['event_end_utc'])->format('Y-m-d H:i:s');
         $this->assertDatabaseHas('events', $eventAttributes);
 
         // Check that we can view the event, and that it shows the creation success message.

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -330,10 +330,7 @@ class CreateEventTest extends TestCase
         $eventData = factory(Party::class)->raw(['group' => $group->idgroups, 'event_date' => '1930-01-01', 'latitude'=>'1', 'longitude'=>'1']);
 
         // act
-        DB::connection()->enableQueryLog();
         $response = $this->post('/party/create/', $eventData);
-        $queries = DB::getQueryLog();
-        error_log(var_export($queries, TRUE));
         $event = Party::where('event_date', '1930-01-01')->first();
         $eventData['wordpress_post_id'] = 100;
         $eventData['id'] = $event->idevents;

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -330,7 +330,10 @@ class CreateEventTest extends TestCase
         $eventData = factory(Party::class)->raw(['group' => $group->idgroups, 'event_date' => '1930-01-01', 'latitude'=>'1', 'longitude'=>'1']);
 
         // act
+        DB::connection()->enableQueryLog();
         $response = $this->post('/party/create/', $eventData);
+        $queries = DB::getQueryLog();
+        error_log(var_export($queries, TRUE));
         $event = Party::where('event_date', '1930-01-01')->first();
         $eventData['wordpress_post_id'] = 100;
         $eventData['id'] = $event->idevents;

--- a/tests/Feature/Events/DeleteEventTest.php
+++ b/tests/Feature/Events/DeleteEventTest.php
@@ -250,7 +250,7 @@ class DeleteEventTest extends TestCase
         $network->addGroup($group);
 
         $this->assertNotNull($id);
-        $idevents = $this->createEvent($id, 'Past');
+        $idevents = $this->createEvent($id, '1981-01-01');
 
         // Add a restarter who is attending.
         $this->get('/logout');

--- a/tests/Feature/Events/WordpressEventPushTest.php
+++ b/tests/Feature/Events/WordpressEventPushTest.php
@@ -137,7 +137,11 @@ class WordpressEventPushTest extends TestCase
         ]);
         $group = factory(Group::class)->create();
         $restart->addGroup($group);
-        $event = factory(Party::class)->create(['group' => $group->idgroups]);
+        $event = factory(Party::class)->create([
+            'group' => $group->idgroups,
+            'event_start_utc' => Carbon::parse('1pm tomorrow')->toIso8601String(),
+            'event_end_utc' => Carbon::parse('3pm tomorrow')->toIso8601String()
+        ]);
         $event->wordpress_post_id = 100;
         $event->save();
 

--- a/tests/Feature/Events/WordpressEventPushTest.php
+++ b/tests/Feature/Events/WordpressEventPushTest.php
@@ -56,7 +56,11 @@ class WordpressEventPushTest extends TestCase
         ]);
         $group = factory(Group::class)->create();
         $network->addGroup($group);
-        $event = factory(Party::class)->create(['group' => $group->idgroups]);
+        $event = factory(Party::class)->create([
+            'group' => $group->idgroups,
+            'event_start_utc' => Carbon::parse('1pm tomorrow')->toIso8601String(),
+            'event_end_utc' => Carbon::parse('3pm tomorrow')->toIso8601String()
+           ]);
         $event->save();
 
         $this->mock(WordpressClient::class, function ($mock) use ($event) {
@@ -88,9 +92,8 @@ class WordpressEventPushTest extends TestCase
         # Edit event.
         $handler = app(EditWordpressPostForEvent::class);
         $handler->handle(new EditEvent($event, [
-            'event_date' => $event->date,
-            'start' => $event->start,
-            'end' => $event->end,
+            'event_start_utc' => Carbon::parse('2pm tomorrow')->toIso8601String(),
+            'event_end_utc' => Carbon::parse('4pm tomorrow')->toIso8601String(),
             'latitude' => 1,
             'longitude' => 2,
             'group' => 3,

--- a/tests/Feature/Groups/GroupViewTest.php
+++ b/tests/Feature/Groups/GroupViewTest.php
@@ -46,7 +46,7 @@ class GroupViewTest extends TestCase
 
         // Create a past event
         $event = factory(Party::class)->states('moderated')->create([
-                                                                        'event_date' => Carbon::yesterday(),
+                                                                        'event_date' => Carbon::yesterday()->toDateString(),
                                                                         'group' => $id,
                                                                     ]);
 

--- a/tests/Feature/Groups/VolunteersNearbyTest.php
+++ b/tests/Feature/Groups/VolunteersNearbyTest.php
@@ -49,9 +49,9 @@ class VolunteersNearbyTest extends TestCase
 
         // Should see the appropriate users in the list of nearby.
         $rsp = $this->get('/group/nearby/' . $group->idgroups);
-        $rsp->assertSee($user1->name);
-        $rsp->assertSee($user2->name);
-        $rsp->assertDontSee($user3->name);
+        $rsp->assertSee(htmlspecialchars($user1->name));
+        $rsp->assertSee(htmlspecialchars($user2->name));
+        $rsp->assertDontSee(htmlspecialchars($user3->name));
 
         // Invite one of them.
         $rsp = $this->get('/group/nearbyinvite/' . $group->idgroups . '/' . $user1->id);

--- a/tests/Feature/Stats/GroupStatsTest.php
+++ b/tests/Feature/Stats/GroupStatsTest.php
@@ -23,7 +23,7 @@ class GroupStatsTest extends StatsTestCase
     {
         $group = factory(Group::class)->create();
         factory(Party::class)->states('moderated')->create([
-            'event_date' => Carbon::yesterday(),
+            'event_date' => Carbon::yesterday()->toDateString(),
             'group' => $group->idgroups,
         ]);
         $expect = \App\Group::getGroupStatsArrayKeys();
@@ -42,7 +42,7 @@ class GroupStatsTest extends StatsTestCase
     {
         $group = factory(Group::class)->create();
         $event = factory(Party::class)->states('moderated')->create([
-            'event_date' => Carbon::yesterday(),
+            'event_date' => Carbon::yesterday()->toDateString(),
             'group' => $group->idgroups,
         ]);
 
@@ -195,7 +195,7 @@ class GroupStatsTest extends StatsTestCase
     {
         $group1 = factory(Group::class)->create();
         $event1 = factory(Party::class)->states('moderated')->create([
-            'event_date' => Carbon::yesterday(),
+            'event_date' => Carbon::yesterday()->toDateString(),
             'group' => $group1->idgroups,
         ]);
 
@@ -270,11 +270,11 @@ class GroupStatsTest extends StatsTestCase
 
         $group2 = factory(Group::class)->create();
         $event2 = factory(Party::class)->states('moderated')->create([
-            'event_date' => Carbon::yesterday(),
+            'event_date' => Carbon::yesterday()->toDateString(),
             'group' => $group2->idgroups,
         ]);
         $event3 = factory(Party::class)->states('moderated')->create([
-            'event_date' => Carbon::yesterday(),
+            'event_date' => Carbon::yesterday()->toDateString(),
             'group' => $group2->idgroups,
         ]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -136,9 +136,19 @@ abstract class TestCase extends BaseTestCase
         $eventAttributes = factory(Party::class)->raw();
         $eventAttributes['group'] = $idgroups;
 
+        // Use old-style event creation rather than UTC.
+        unset($eventAttributes['event_start_utc']);
+        unset($eventAttributes['event_end_utc']);
         $eventAttributes['event_date'] = date('Y-m-d', strtotime($date));
+        $eventAttributes['start'] = '13:00:00';
+        $eventAttributes['end'] = '14:00:00';
 
         $response = $this->post('/party/create/', $eventAttributes);
+
+        // The event_start_utc and event_end_utc will be in the database, but not ISO8601 formatted - that is implicit.
+//        $eventAttributes['event_start_utc'] = Carbon::parse($eventAttributes['event_start_utc'])->format('Y-m-d H:i:s');
+//        $eventAttributes['event_end_utc'] = Carbon::parse($eventAttributes['event_end_utc'])->format('Y-m-d H:i:s');
+
         $this->assertDatabaseHas('events', $eventAttributes);
         $redirectTo = $response->getTargetUrl();
         $p = strrpos($redirectTo, '/');

--- a/tests/Unit/Events/EventStateTests.php
+++ b/tests/Unit/Events/EventStateTests.php
@@ -28,10 +28,8 @@ class EventStateTests extends TestCase
     {
         // arrange
         $event = factory(Party::class)->create();
-        error_log("Created");
-        $event->event_date = Carbon::now()->toDateString();
-        $event->start = Carbon::now()->addHours(-1)->toTimeString();
-        $event->end = Carbon::now()->addHours(2)->toTimeString();
+        $event->event_start_utc = Carbon::now()->addHours(-1)->toIso8601String();
+        $event->event_end_utc = Carbon::now()->addHours(2)->toIso8601String();
 
         // assert
         $this->assertTrue($event->isInProgress());
@@ -42,9 +40,8 @@ class EventStateTests extends TestCase
     {
         // arrange
         $event = factory(Party::class)->create();
-        $event->event_date = Carbon::now()->toDateString();
-        $event->start = Carbon::now()->toTimeString();
-        $event->end = Carbon::now()->addHours(3)->toTimeString();
+        $event->event_start_utc = Carbon::now()->toIso8601String();
+        $event->event_end_utc = Carbon::now()->addHours(3)->toIso8601String();
 
         // assert
         $this->assertTrue($event->isInProgress());

--- a/tests/Unit/Events/EventStateTests.php
+++ b/tests/Unit/Events/EventStateTests.php
@@ -28,6 +28,7 @@ class EventStateTests extends TestCase
     {
         // arrange
         $event = factory(Party::class)->create();
+        error_log("Created");
         $event->event_date = Carbon::now()->toDateString();
         $event->start = Carbon::now()->addHours(-1)->toTimeString();
         $event->end = Carbon::now()->addHours(2)->toTimeString();
@@ -44,22 +45,6 @@ class EventStateTests extends TestCase
         $event->event_date = Carbon::now()->toDateString();
         $event->start = Carbon::now()->toTimeString();
         $event->end = Carbon::now()->addHours(3)->toTimeString();
-
-        // assert
-        $this->assertTrue($event->isInProgress());
-    }
-
-    // This is just temporary for Repair Together, until we have
-    // proper timezone support.
-
-    /** @test */
-    public function it_is_active_an_hour_before_the_start_time()
-    {
-        // arrange
-        $event = factory(Party::class)->create();
-        $event->event_date = Carbon::now()->toDateString();
-        $event->start = Carbon::now()->addHours(1)->toTimeString();
-        $event->end = Carbon::now()->addHours(4)->toTimeString();
 
         // assert
         $this->assertTrue($event->isInProgress());

--- a/tests/Unit/Events/TimezoneTest.php
+++ b/tests/Unit/Events/TimezoneTest.php
@@ -51,14 +51,22 @@ class TimezoneTest extends TestCase
            'timezone' => 'Asia/Samarkand'
         ]);
 
+        DB::connection()->enableQueryLog();
+
+        // Create an event in a different timezone, using local times.
         $e = factory(Party::class)->create([
             'group' => $g->idgroups,
             'event_date' => '2021-01-01',
             'start' => '10:15',
-            'end' => '13:45'
+            'end' => '13:45',
+            'timezone' => NULL // Inherit from group.
         ]);
 
-        self::assertEquals('2021-01-01T10:15:00+05:00', $e->startDateTimeISO8601);
-        self::assertEquals('2021-01-01T13:45:00+05:00', $e->endDateTimeISO8601);
+        $queries = DB::getQueryLog();
+        error_log(var_export($queries, TRUE));
+
+        // Check that the ISO times are as we would expect for this zone.
+        self::assertEquals('2021-01-01T05:15:00+00:00', $e->startDateTimeISO8601);
+        self::assertEquals('2021-01-01T08:45:00+00:00', $e->endDateTimeISO8601);
     }
 }

--- a/tests/Unit/Events/TimezoneTest.php
+++ b/tests/Unit/Events/TimezoneTest.php
@@ -56,12 +56,12 @@ class TimezoneTest extends TestCase
             'group' => $g->idgroups,
             'event_start_utc' => '2021-01-01T10:15:05+05:00',
             'event_end_utc' => '2021-01-01T13:45:05+05:00',
-            'timezone' => NULL // Inherit from group.
+            'timezone' => NULL
         ]);
 
         // Check that the ISO times are as we would expect for this zone.
-        self::assertEquals('2021-01-01T10:15:05+00:00', $e->startDateTimeISO8601);
-        self::assertEquals('2021-01-01T13:45:05+00:00', $e->endDateTimeISO8601);
+        self::assertEquals('2021-01-01T10:15:05+00:00', $e->event_start_utc);
+        self::assertEquals('2021-01-01T13:45:05+00:00', $e->event_end_utc);
 
         // Check that the local times are as we expect.
         self::assertEquals('2021-01-01', $e->event_date);

--- a/tests/Unit/Events/TimezoneTest.php
+++ b/tests/Unit/Events/TimezoneTest.php
@@ -37,9 +37,28 @@ class TimezoneTest extends TestCase
 
     public function timezoneProvider() {
         return [
-            [ NULL, 'Europe/Paris', 'Europe/Paris', FALSE ],
-            [ 'Europe/Paris', NULL, 'Europe/Paris', FALSE ],
+            [ NULL, 'Asia/Samarkand', 'Asia/Samarkand', FALSE ],
+            [ 'Asia/Samarkand', NULL, 'Asia/Samarkand', FALSE ],
             [ NULL, NULL, NULL, TRUE],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function startEnd() {
+        $g = factory(Group::class)->create([
+           'timezone' => 'Asia/Samarkand'
+        ]);
+
+        $e = factory(Party::class)->create([
+            'group' => $g->idgroups,
+            'event_date' => '2021-01-01',
+            'start' => '10:15',
+            'end' => '13:45'
+        ]);
+
+        self::assertEquals('2021-01-01T10:15:00+05:00', $e->startDateTimeISO8601);
+        self::assertEquals('2021-01-01T13:45:00+05:00', $e->endDateTimeISO8601);
     }
 }

--- a/tests/Unit/Events/TimezoneTest.php
+++ b/tests/Unit/Events/TimezoneTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use App\Group;
 use App\Party;
+use App\User;
 use DB;
 use Tests\TestCase;
 
@@ -43,10 +44,7 @@ class TimezoneTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
-    public function startEnd() {
+    public function testStartEnd() {
         $g = factory(Group::class)->create([
            'timezone' => 'Asia/Samarkand'
         ]);
@@ -75,5 +73,87 @@ class TimezoneTest extends TestCase
         self::assertEquals('2021-01-01', $e->event_date);
         self::assertEquals('18:00:00', $e->start);
         self::assertEquals('19:00:00', $e->end);
+    }
+
+    public function testOrder() {
+        // Two groups in different timezones.
+        $g1 = factory(Group::class)->create([
+                                               'timezone' => 'Asia/Samarkand'
+                                           ]);
+
+        $g2 = factory(Group::class)->create([
+                                               'timezone' => 'Europe/Amsterdam'
+                                           ]);
+
+        // A host for each.
+        $host1 = factory(User::class)->states('Host')->create();
+        $g1->addVolunteer($host1);
+        $g1->makeMemberAHost($host1);
+
+        $host2 = factory(User::class)->states('Host')->create();
+        $g1->addVolunteer($host2);
+        $g1->makeMemberAHost($host2);
+
+        // Create an event for each, using the old style local time create format.
+        $this->actingAs($host1);
+        $event = factory(Party::class)->raw();
+        unset($event['event_start_utc']);
+        unset($event['event_end_utc']);
+        unset($event['timezone']);
+        $event['group'] = $g1->idgroups;
+        $event['event_date'] = '2037-01-01';
+        $event['start'] = '11:10';
+        $event['end'] = '13:20';
+        $response = $this->post('/party/create/', $event);
+        $response->assertStatus(302);
+
+        $this->actingAs($host2);
+        $event = factory(Party::class)->raw();
+        unset($event['event_start_utc']);
+        unset($event['event_end_utc']);
+        unset($event['timezone']);
+        $event['group'] = $g2->idgroups;
+        $event['event_date'] = '2037-01-01';
+        $event['start'] = '12:15';
+        $event['end'] = '14:35';
+        $response = $this->post('/party/create/', $event);
+        $response->assertStatus(302);
+
+        // Now get them and check the ordering works.
+        $response = $this->get('/party');
+
+        $props = $this->assertVueProperties($response, [
+            [
+                'heading-level' => 'h2',
+            ],
+        ]);
+
+        $events = json_decode($props[0][':initial-events'], TRUE);
+
+        // Check the returned events:
+        // - The events should be Amsterdam first because that is the earliest actual time and therefore the soonest
+        //   starting event.
+        // - The local times (event_date, start, end) should be the same as we put in.
+        // - The UTC fields should be returned with the times converted to UTC.
+        // - The timezone should be set.
+        $this->assertEquals('Europe/Amsterdam', $events[0]['timezone']);
+        $this->assertEquals('2037-01-01T11:15:00+00:00', $events[0]['event_start_utc']);
+        $this->assertEquals('2037-01-01T13:35:00+00:00', $events[0]['event_end_utc']);
+        $this->assertEquals('2037-01-01', $events[0]['event_date']);
+        $this->assertEquals('12:15:00', $events[0]['start']);
+        $this->assertEquals('14:35:00', $events[0]['end']);
+        $this->assertEquals('Asia/Samarkand', $events[1]['timezone']);
+        $this->assertEquals('2037-01-01T06:10:00+00:00', $events[1]['event_start_utc']);
+        $this->assertEquals('2037-01-01T08:20:00+00:00', $events[1]['event_end_utc']);
+        $this->assertEquals('2037-01-01', $events[1]['event_date']);
+        $this->assertEquals('11:10:00', $events[1]['start']);
+        $this->assertEquals('13:20:00', $events[1]['end']);
+
+        // A different way of confirming the same thing is to convert the input and returned times to epoch -
+        // they should be the same.
+        $this->assertEquals(strtotime($events[0]['event_start_utc']), (new \DateTime('2037-01-01 12:15', new \DateTimeZone('Europe/Amsterdam')))->format('U'));
+        $this->assertEquals(strtotime($events[0]['event_end_utc']), (new \DateTime('2037-01-01 14:35', new \DateTimeZone('Europe/Amsterdam')))->format('U'));
+        $this->assertEquals(strtotime($events[1]['event_start_utc']), (new \DateTime('2037-01-01 11:10', new \DateTimeZone('Asia/Samarkand')))->format('U'));
+        $this->assertEquals(strtotime($events[1]['event_end_utc']), (new \DateTime('2037-01-01 13:20', new \DateTimeZone('Asia/Samarkand')))->format('U'));
     }
 }

--- a/tests/Unit/Events/TimezoneTest.php
+++ b/tests/Unit/Events/TimezoneTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Group;
+use App\Party;
+use DB;
+use Tests\TestCase;
+
+class TimezoneTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider timezoneProvider
+     */
+    public function timezone_inheritance($event, $group, $result, $exception) {
+        $g = factory(Group::class)->create([
+                                                   'timezone' => $group
+                                               ]);
+
+        $e = factory(Party::class)->create([
+           'timezone' => $event,
+           'group' => $g->idgroups
+        ]);
+
+        try {
+            $timezone = $e->timezone;
+            $this->assertEquals($result, $timezone);
+        } catch(\Exception $e) {
+            if ($exception) {
+                $this->assertTrue(true);
+            } else {
+                $this->assertFalse(true, 'Unexpected exception thrown');
+            }
+        }
+    }
+
+    public function timezoneProvider() {
+        return [
+            [ NULL, 'Europe/Paris', 'Europe/Paris', FALSE ],
+            [ 'Europe/Paris', NULL, 'Europe/Paris', FALSE ],
+            [ NULL, NULL, NULL, TRUE],
+        ];
+    }
+}

--- a/tests/Unit/Events/TimezoneTest.php
+++ b/tests/Unit/Events/TimezoneTest.php
@@ -51,22 +51,29 @@ class TimezoneTest extends TestCase
            'timezone' => 'Asia/Samarkand'
         ]);
 
-        DB::connection()->enableQueryLog();
-
         // Create an event in a different timezone, using local times.
         $e = factory(Party::class)->create([
             'group' => $g->idgroups,
-            'event_date' => '2021-01-01',
-            'start' => '10:15',
-            'end' => '13:45',
+            'event_start_utc' => '2021-01-01T10:15:05+05:00',
+            'event_end_utc' => '2021-01-01T13:45:05+05:00',
             'timezone' => NULL // Inherit from group.
         ]);
 
-        $queries = DB::getQueryLog();
-        error_log(var_export($queries, TRUE));
-
         // Check that the ISO times are as we would expect for this zone.
-        self::assertEquals('2021-01-01T05:15:00+00:00', $e->startDateTimeISO8601);
-        self::assertEquals('2021-01-01T08:45:00+00:00', $e->endDateTimeISO8601);
+        self::assertEquals('2021-01-01T10:15:05+00:00', $e->startDateTimeISO8601);
+        self::assertEquals('2021-01-01T13:45:05+00:00', $e->endDateTimeISO8601);
+
+        // Check that the local times are as we expect.
+        self::assertEquals('2021-01-01', $e->event_date);
+        self::assertEquals('15:15:05', $e->start);
+        self::assertEquals('18:45:05', $e->end);
+
+        // Update the ISO times using a different timezone and check that the local times update.
+        $e->event_start_utc = '2021-01-01T13:00:00+00:00';
+        $e->event_end_utc = '2021-01-01T14:00:00+00:00';
+
+        self::assertEquals('2021-01-01', $e->event_date);
+        self::assertEquals('18:00:00', $e->start);
+        self::assertEquals('19:00:00', $e->end);
     }
 }

--- a/tests/Unit/GroupTest.php
+++ b/tests/Unit/GroupTest.php
@@ -133,4 +133,45 @@ class GroupTest extends TestCase
 
         $this->assertFalse($shouldPush);
     }
+
+    /**
+     * @test
+     * @dataProvider timezoneProvider
+     */
+    public function timezone_inheritance($group, $network1, $network2, $result, $exception) {
+        $network1 = factory(Network::class)->create([
+            'timezone' => $network1
+        ]);
+        $network2 = factory(Network::class)->create([
+            'timezone' => $network2
+        ]);
+
+        $group = factory(Group::class)->create([
+            'timezone' => $group
+        ]);
+        $network1->addGroup($group);
+        $network2->addGroup($group);
+
+        try {
+            $timezone = $group->timezone;
+            $this->assertEquals($result, $timezone);
+        } catch(\Exception $e) {
+            if ($exception) {
+                $this->assertTrue(true);
+            } else {
+                $this->assertFalse(true, 'Unexpected exception thrown');
+            }
+        }
+    }
+
+    public function timezoneProvider() {
+        return [
+            [ NULL, 'Europe/Paris', NULL, 'Europe/Paris', FALSE ],
+            [ NULL, 'Europe/Paris', 'Europe/Paris', 'Europe/Paris', FALSE ],
+            [ NULL, 'Europe/Paris', 'Europe/London', NULL, TRUE ],
+            [ 'Europe/Brussels','Europe/Paris', 'Europe/Paris', 'Europe/Brussels', FALSE ],
+            [ 'Europe/Brussels', NULL, 'Europe/Paris', 'Europe/Brussels', FALSE ],
+            [ NULL, NULL, NULL, NULL, TRUE ],
+        ];
+    }
 }


### PR DESCRIPTION
This is the first stage in replumbing for timezone support.  Are you sitting comfortably?

- Timezone fields in event and group.  This is always set in the event at creation, but might be explicit or inherited from the group, which in turn can inherit from network(s).
- New event_start_utc / event_end_utc which will in time replace the event_date/start/end fields.  For now those fields continue for read access via virtual columns and accessors, so that most of the old code can continue unaffected...because we've not changed it yet.
- The intention is that we now never write to those old fields, only the UTC ones.  Mutators added to throw an exception if we try.
- Support both old and new field variations on event create/modify.  This allows the current client to work.
- A bit of faffing with the test environment to get the tests to run ok.
- Set CircleCI timezone to UTC, as we will be doing for our servers.
- A bunch of TODOs added for later. 
