### PR TITLE
RES-1617 Change messageable_level on Discourse groups.

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -601,7 +601,7 @@ class Group extends Model implements Auditable
                         'name' => "$name$unique",
                         'full_name' => $this->name,
                         'mentionable_level' => 4,
-                        'messageable_level' => 99,
+                        'messageable_level' => 4,
                         'visibility_level' => 0,
                         'members_visibility_level' => 0,
                         'automatic_membership_email_domains' => null,

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -230,6 +230,23 @@ class DiscourseService
                 $discourseId = $discourseResult['group']['id'];
                 Log::debug("Sync members for Restarters group $restartId, {$group->discourse_group}, Discourse group $discourseId");
 
+                if ($discourseResult['group']['messageable_level'] != 4) {
+                    Log::debug("Update messageable_level for Restarters group $restartId, {$group->discourse_group}, Discourse group $discourseId");
+                    $response = $client->request('PUT', "/g/$discourseId.json", [
+                        'form_params' => [
+                            'group' => [
+                                'messageable_level' => 4
+                            ]
+                        ]
+                    ]);
+
+                    if ($response->getStatusCode() === 200) {
+                        Log::debug("...succeeded");
+                    } else {
+                        Log::debug("...failed with " . $response->getStatusCode() . ", " . $response->getBody());
+                    }
+                }
+
                 if ($group->groupimage && $group->groupimage->idimages) {
                     // Check if the flair_url needs updating.  This keeps the logo in sync with changes on Restarters.
                     Log::debug("Check Discourse logo {$group->discourse_logo} vs {$group->groupimage->idimages}");

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -232,11 +232,11 @@ class DiscourseService
 
                 if ($discourseResult['group']['messageable_level'] != 4) {
                     Log::debug("Update messageable_level for Restarters group $restartId, {$group->discourse_group}, Discourse group $discourseId");
+                    $gData = $discourseResult['group'];
+                    $gData['messageable_level'] = 4;
                     $response = $client->request('PUT', "/g/$discourseId.json", [
                         'form_params' => [
-                            'group' => [
-                                'messageable_level' => 4
-                            ]
+                            'group' => $gData
                         ]
                     ]);
 


### PR DESCRIPTION
Change from "Everyone" to "Only group owners, moderators and admins".  Update the setting in the regular sync.