### PR TITLE
RES-1630 group hosts not owners

### DIFF
--- a/app/Console/Commands/SyncDiscourseGroups.php
+++ b/app/Console/Commands/SyncDiscourseGroups.php
@@ -40,6 +40,6 @@ class SyncDiscourseGroups extends Command
      */
     public function handle()
     {
-        $this->discourseService->syncUsersToGroups();
+        $this->discourseService->syncGroups();
     }
 }

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -21,6 +21,7 @@ use App\Notifications\NewGroupMember;
 use App\Notifications\NewGroupWithinRadius;
 use App\Notifications\GroupConfirmed;
 use App\Party;
+use App\Role;
 use App\User;
 use App\UserGroups;
 use Auth;
@@ -895,7 +896,7 @@ class GroupController extends Controller
             event(new UserFollowedGroup($user, $group));
 
             // A new User has joined your group
-            $groupHostLinks = UserGroups::where('group', $group->idgroups)->where('role', 3)->get();
+            $groupHostLinks = UserGroups::where('group', $group->idgroups)->where('role', Role::HOST)->get();
 
             foreach ($groupHostLinks as $groupHostLink) {
                 $host = User::where('id', $groupHostLink->user)->first();

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -401,9 +401,7 @@ class DiscourseService
                             if ($d['owner'] && !$shouldBeOwner) {
                                 Log::info("Remove $discourseMember as admin of {$discourseId} {$discourseName}");
                                 $response = $client->request('DELETE', "/admin/groups/$discourseId/owners.json", [
-                                    'form_params' => [
-                                        'user_id' => $d['id']
-                                    ]
+                                    'user_id' => $d['id']
                                 ]);
 
                                 Log::info('Response status: ' . $response->getStatusCode());
@@ -414,12 +412,13 @@ class DiscourseService
                                     Log::error("Failed to remove $discourseMember as owner of {$discourseId} {$discourseName}");
                                     throw new \Exception("Failed to remove $discourseMember as owner of {$discourseId} {$discourseName}");
                                 }
-                                exit(0);
                             } else if (!$d['owner'] && $shouldBeOwner) {
                                 Log::info("Add $discourseMember as admin of {$discourseId} {$discourseName}");
                                 $response = $client->request('PUT', "/admin/groups/$discourseId/owners.json", [
                                     'form_params' => [
-                                        'user_names' => [ $discourseMember ]
+                                        'group' => [
+                                            'usernames' => $discourseMember
+                                        ]
                                     ]
                                 ]);
 
@@ -431,12 +430,11 @@ class DiscourseService
                                     Log::error("Failed to add $discourseMember as owner of {$discourseId} {$discourseName}");
                                     throw new \Exception("Failed to add $discourseMember as owner of {$discourseId} {$discourseName}");
                                 }
-                                exit(0);
                             }
                         }
                     }
 
-                    foreach ($restartersMembers as $restartersMember)
+                    foreach ($restartersMembers as $restartersMember => $r)
                     {
                         if (!array_key_exists($restartersMember, $discourseMembers))
                         {

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -331,8 +331,7 @@ class DiscourseService
                 {
                     Log::error("Failed to get list of members for {$discourseId}");
                     throw new \Exception("Failed to get list of members for {$discourseId}");
-                } else
-                {
+                } else {
                     $discourseResult = json_decode($response->getBody(), true);
                     $total = $discourseResult['meta']['total'];
                     Log::debug("Total $total");
@@ -373,8 +372,7 @@ class DiscourseService
                     Log::debug("Discourse Members " . json_encode($discourseMembers));
                     Log::debug("Restarter Members " . json_encode($restartersMembers));
 
-                    foreach ($discourseMembers as $discourseMember => $d)
-                    {
+                    foreach ($discourseMembers as $discourseMember => $d) {
                         if (!array_key_exists($discourseMember, $restartersMembers)) {
                             Log::debug("Remove user $discourseMember from Discourse group $discourseName");
 
@@ -434,10 +432,8 @@ class DiscourseService
                         }
                     }
 
-                    foreach ($restartersMembers as $restartersMember => $r)
-                    {
-                        if (!array_key_exists($restartersMember, $discourseMembers))
-                        {
+                    foreach ($restartersMembers as $restartersMember => $r) {
+                        if (!array_key_exists($restartersMember, $discourseMembers)) {
                             Log::debug("Add Restarter user $restartersMember to Discourse group $discourseName");
 
                             // We add these one by one, rather than in a single call.  This is because if our Restarters


### PR DESCRIPTION
Rework the syncing to promote/demote hosts on Restarters w.r.t. owners on Discourse.

Rename the sync method as it's now browser than just users.