### PR TITLE
RES-1628 sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
       - run: php artisan migrate
 
       - run: wget -O phpunit https://phar.phpunit.de/phpunit-7.phar ; chmod +x phpunit
+      - run: mkidr uploads
 
       - run: export XDEBUG_MODE=coverage;./phpunit -d memory_limit=512M --bootstrap vendor/autoload.php -dxdebug.coverage_enable=1 --coverage-clover tests/clover.xml --configuration ./phpunit.xml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
       - run: php artisan migrate
 
       - run: wget -O phpunit https://phar.phpunit.de/phpunit-7.phar ; chmod +x phpunit
-      - run: mkidr uploads
+      - run: mkdir uploads
 
       - run: export XDEBUG_MODE=coverage;./phpunit -d memory_limit=512M --bootstrap vendor/autoload.php -dxdebug.coverage_enable=1 --coverage-clover tests/clover.xml --configuration ./phpunit.xml
 

--- a/app/Helpers/Fixometer.php
+++ b/app/Helpers/Fixometer.php
@@ -98,6 +98,8 @@ class Fixometer
 
     public static function userHasEditPartyPermission($partyId, $userId = null)
     {
+        $party = Party::findOrFail($partyId);
+
         if (is_null($userId)) {
             if (empty(Auth::user())) {
                 return false;
@@ -106,14 +108,14 @@ class Fixometer
             }
         }
 
-        $user = User::find($userId);
+        $user = User::findOrFail($userId);
 
         if (self::hasRole($user, 'Administrator')) {
             return true;
         }
 
         if (self::hasRole($user, 'NetworkCoordinator')) {
-            $group = Party::find($partyId)->theGroup;
+            $group = $party->theGroup;
             foreach ($group->networks as $network) {
                 if ($network->coordinators->contains($user)) {
                     return true;

--- a/app/Helpers/FixometerFile.php
+++ b/app/Helpers/FixometerFile.php
@@ -14,6 +14,16 @@ class FixometerFile extends Model
     protected $table;
 
     protected $dates = true;
+    public static $uploadTesting = false;
+
+    public function move($from, $to) {
+        // This is for phpunit tests.
+        if (FixometerFile::$uploadTesting) {
+            return copy($from, $to);
+        } else {
+            return @move_uploaded_file($from, $to);
+        }
+    }
 
     /**
      * receives the POST data from an HTML form
@@ -54,7 +64,7 @@ class FixometerFile extends Model
             $filename = $this->filename($tmp_name);
             $this->file = $filename;
             $lpath = $_SERVER['DOCUMENT_ROOT'].'/uploads/'.$filename;
-            if (! @move_uploaded_file($tmp_name, $lpath)) {
+            if (!$this->move($tmp_name, $lpath)) {
                 return false;
             }
             $data = [];

--- a/app/Helpers/FixometerFile.php
+++ b/app/Helpers/FixometerFile.php
@@ -19,7 +19,7 @@ class FixometerFile extends Model
     public function move($from, $to) {
         // This is for phpunit tests.
         if (FixometerFile::$uploadTesting) {
-            return @copy($from, $to);
+            return copy($from, $to);
         } else {
             return @move_uploaded_file($from, $to);
         }

--- a/app/Helpers/FixometerFile.php
+++ b/app/Helpers/FixometerFile.php
@@ -19,7 +19,7 @@ class FixometerFile extends Model
     public function move($from, $to) {
         // This is for phpunit tests.
         if (FixometerFile::$uploadTesting) {
-            return copy($from, $to);
+            return @copy($from, $to);
         } else {
             return @move_uploaded_file($from, $to);
         }

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -145,17 +145,6 @@ class ApiController extends Controller
     }
 
     /**
-     * THIS METHOD HAS NOT BEEN REFACTORED FOR UNPOWERED DEVICES!!
-     * An attempt was made, see \app\Helpers\LcaStats::getWasteStatsFiltered().
-     * Deemed too time-consuming and possibly redundant.
-     * It was eventually found to be called from a Vue that rendered the search table on the Fixometer landing page.
-     * Stats produced by this method were subsequently removed from that table.
-     *
-     * Possibly called externally!
-     * See \routes\api.php.
-     *
-     * @ToDo Determine usage and refactor or deprecate (stats) as appropriate.
-     *
      * List/search devices.
      *
      * @param  Request  $request
@@ -242,47 +231,8 @@ class ApiController extends Controller
             $item['category'] = $item['deviceCategory'];
         }
 
-        if ($status && $status !== env('DEVICE_FIXED')) {
-            // We only count savings from fixed items.  So if we are filtering on repair status other than fixed, then
-            // there can be no savings to return, so don't bother querying.
-            $weight = 0;
-            $co2 = 0;
-        } else {
-            // We need the total weight/CO2 impact for this filtering.
-            $d = new Device();
-
-            DB::enableQueryLog();
-
-            $wheres[] = ['repair_status', '=', env('DEVICE_FIXED')];
-
-            // We select the powered and unpowered weights separately and then add them afterwards just because
-            // this keeps the logic separate and is easier to compare with other code.
-            $counts = Device::select(
-                DB::raw(
-                    'sum(case when (categories.powered = 1) then (case when (devices.category = 46) then (devices.estimate + 0.0) else categories.weight end) else 0 end) as ewaste'
-                ),
-                DB::raw(
-                    'sum(case when (categories.powered = 0) then devices.estimate + 0.0 else 0 end) as unpowered_waste'
-                ),
-                DB::raw(
-                    "sum(case when (devices.category = 46) then (devices.estimate + 0.0) *
-                     (select (sum(`categories`.`footprint`) * {$d->getDisplacementFactor()}) / sum(`categories`.`weight` + 0.0) from `devices`, `categories` where `categories`.`idcategories` = `devices`.`category` and `devices`.`repair_status` = 1 and categories.idcategories != 46)
-                     else (categories.footprint * {$d->getDisplacementFactor()}) end) as `total_footprint`"
-                )
-            )->join('events', 'events.idevents', '=', 'devices.event')
-                ->join('groups', 'events.group', '=', 'groups.idgroups')
-                ->join('categories', 'devices.category', '=', 'categories.idcategories')
-                ->where($wheres)
-                ->first();
-
-            $weight = round($counts->ewaste + $counts->unpowered_waste);
-            $co2 = round($counts->total_footprint);
-        }
-
         return response()->json([
             'count' => $count,
-            'weight' => $weight,
-            'co2' => $co2,
             'items' => $items,
         ]);
     }

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -934,9 +934,7 @@ class GroupController extends Controller
             if (isset($_FILES) && ! empty($_FILES)) {
                 $existing_image = Fixometer::hasImage($id, 'groups', true);
                 if (! empty($existing_image)) {
-                    // TODO This can't work.  But it's hard to test given that we use raw file uploads
-                    // rather than the Laravel mechanism.
-                    $Group->removeImage($id, $existing_image[0]);
+                    Fixometer::removeImage($id, env('TBL_GROUPS'), $existing_image[0]);
                 }
                 $file = new FixometerFile;
                 $file->upload('file', 'image', $id, env('TBL_GROUPS'), false, true, true);
@@ -944,7 +942,7 @@ class GroupController extends Controller
 
             return 'success - image uploaded';
         } catch (\Exception $e) {
-            return 'fail - image could not be uploaded';
+            return 'fail - image could not be uploaded' . $e->getMessage();
         }
     }
 

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -942,7 +942,7 @@ class GroupController extends Controller
 
             return 'success - image uploaded';
         } catch (\Exception $e) {
-            return 'fail - image could not be uploaded' . $e->getMessage();
+            return 'fail - image could not be uploaded ' . $e->getMessage();
         }
     }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -353,13 +353,6 @@ class UserController extends Controller
         }
 
         if (isset($_FILES) && ! empty($_FILES)) {
-            // $file = $request->file('profilePhoto');
-            // $path = 'images/' . $file->getClientOriginalName();
-            // $image = Image::make($file)
-            // // ->resize(320, 240)
-            // ->orientate()
-            // ->save($path);
-
             $file = new FixometerFile;
             $file->upload('profilePhoto', 'image', $id, env('TBL_USERS'), false, true);
 

--- a/app/Listeners/DiscourseUserEventSubscriber.php
+++ b/app/Listeners/DiscourseUserEventSubscriber.php
@@ -5,13 +5,15 @@ namespace App\Listeners;
 use App\Events\UserEmailUpdated;
 use App\Events\UserLanguageUpdated;
 use App\Events\UserRegistered;
+use App\Services\DiscourseService;
 use Illuminate\Support\Facades\Log;
 
 class DiscourseUserEventSubscriber
 {
     private $discourseClient;
+    private $discourseService;
 
-    public function __construct()
+    public function __construct(DiscourseService $discourseService)
     {
         // NGM: preferable to switch to https://github.com/pnoeric/discourse-api-php ?
         if (! config('restarters.features.discourse_integration')) {
@@ -19,6 +21,7 @@ class DiscourseUserEventSubscriber
         }
 
         $this->discourseClient = app('discourse-client');
+        $this->discourseService = $discourseService;
     }
 
     public function onUserEmailUpdated(UserEmailUpdated $event)
@@ -35,7 +38,7 @@ class DiscourseUserEventSubscriber
 
             try
             {
-                $this->syncSso($user);
+                $this->discourseService->syncSso($user);
             } catch (\Exception $ex)
             {
                 Log::error('Could not sync ' . $user->id . ' to Discourse: ' . $ex->getMessage());
@@ -106,48 +109,11 @@ class DiscourseUserEventSubscriber
 
             try
             {
-                $this->syncSso($user);
+                $this->discourseService->syncSso($user);
             } catch (\Exception $ex)
             {
                 Log::error('Could not sync ' . $user->id . ' to Discourse: ' . $ex->getMessage());
             }
-        }
-    }
-
-    protected function syncSso($user)
-    {
-        $endpoint = '/admin/users/sync_sso';
-
-        // see https://meta.discourse.org/t/sync-sso-user-data-with-the-sync-sso-route/84398 for details on the sync_sso route.
-        $sso_secret = config('discourse-api.sso_secret');
-
-        // We have to send all these details, even if they are not
-        // being updated, as otherwise they are blanked in the Discourse
-        // SSO values.  Discourse is currently configured to take only email from SSO values, but better not to blank them regardless.
-        $sso_params = [
-            'external_id' => $user->id,
-            'email' => $user->email,
-            'username' => $user->username,
-            'name' => $user->name,
-        ];
-        $sso_payload = base64_encode(http_build_query($sso_params));
-        $sig = hash_hmac('sha256', $sso_payload, $sso_secret);
-
-        $response = $this->discourseClient->request(
-            'POST',
-            $endpoint,
-            [
-                'form_params' => [
-                    'sso' => $sso_payload,
-                    'sig' => $sig,
-                ],
-            ]
-        );
-
-        if ($response->getStatusCode() !== 200) {
-            Log::error('Could not sync user '.$user->id.' to Discourse: '.$response->getReasonPhrase());
-        } else {
-            Log::debug('Sync '.$user->id.' to Discourse OK');
         }
     }
 

--- a/app/Providers/ScheduleServiceProvider.php
+++ b/app/Providers/ScheduleServiceProvider.php
@@ -11,8 +11,8 @@ class ScheduleServiceProvider extends ServiceProvider
     {
         $this->app->booted(function () {
             $schedule = $this->app->make(Schedule::class);
-            $schedule->command('language:sync')->everyFiveMinutes();
-            $schedule->command('discourse:syncgroups')->everyFiveMinutes();
+            $schedule->command('language:sync')->everyFiveMinutes()->withoutOverlapping();
+            $schedule->command('discourse:syncgroups')->everyFiveMinutes()->withoutOverlapping();
         });
     }
 

--- a/resources/js/components/FixometerPage.vue
+++ b/resources/js/components/FixometerPage.vue
@@ -78,8 +78,6 @@
               :from_date="from_date"
               :to_date="to_date"
               :total.sync="impactData.total_powered"
-              :weight.sync="impactData.waste_powered"
-              :co2.sync="impactData.co2_powered"
           />
         </b-tab>
         <b-tab title-item-class="w-50" title-link-class="smallpad" class="pt-2">
@@ -106,8 +104,6 @@
               :from_date="from_date"
               :to_date="to_date"
               :total.sync="impactData.total_unpowered"
-              :weight.sync="impactData.waste_unpowered"
-              :co2.sync="impactData.co2_unpowered"
           />
         </b-tab>
       </b-tabs>
@@ -116,24 +112,6 @@
       <CollapsibleSection collapsed :count="impactData.total_powered" heading-level="h6" count-class="small">
         <template slot="title">
           {{ __('devices.title_powered') }}
-        </template>
-        <template slot="title-right">
-          <div class="small mt-2">
-            <div class="d-flex text-brand font-weight-bold small">
-              <div class="mr-3 lower d-flex align-content-center">
-                <b-img src="/images/trash_brand.svg" class="iconsmall" />
-                <span class="mb-1">
-                  {{ Math.round(impactData.waste_powered).toLocaleString() }}
-                </span>
-              </div>
-              <div class="mr-1 lower d-flex">
-                <b-img src="/images/co2_brand.svg" class="iconsmall" />
-                <span class="mb-1">
-                  {{ Math.round(impactData.co2_powered).toLocaleString() }}
-                </span>
-              </div>
-            </div>
-          </div>
         </template>
         <template slot="content">
           <FixometerRecordsTable
@@ -152,32 +130,12 @@
               :from_date="from_date"
               :to_date="to_date"
               :total.sync="total_powered"
-              :weight.sync="waste_powered"
-              :co2.sync="co2_powered"
           />
         </template>
       </CollapsibleSection>
       <CollapsibleSection collapsed :count="impactData.total_unpowered" heading-level="h6" count-class="small">
         <template slot="title">
           {{ __('devices.title_unpowered') }}
-        </template>
-        <template slot="title-right">
-          <div class="small mt-2">
-            <div class="d-flex text-brand font-weight-bold small">
-              <div class="mr-3 lower d-flex align-content-center">
-                <b-img src="/images/trash_brand.svg" class="iconsmall" />
-                <span class="mb-1">
-                  {{ Math.round(impactData.waste_unpowered).toLocaleString() }}
-                </span>
-              </div>
-              <div class="mr-1 lower d-flex">
-                <b-img src="/images/co2_brand.svg" class="iconsmall" />
-                <span class="mb-1">
-                  {{ Math.round(impactData.co2_unpowered).toLocaleString() }}
-                </span>
-              </div>
-            </div>
-          </div>
         </template>
         <template slot="content">
           <FixometerRecordsTable
@@ -196,8 +154,6 @@
               :from_date="from_date"
               :to_date="to_date"
               :total.sync="total_unpowered"
-              :weight.sync="waste_unpowered"
-              :co2.sync="co2_unpowered"
           />
         </template>
       </CollapsibleSection>
@@ -267,10 +223,6 @@ export default {
 
       total_powered: 0,
       total_unpowered: 0,
-      waste_powered: 0,
-      waste_unpowered: 0,
-      co2_powered: 0,
-      co2_unpowered: 0,
 
       startExpandedItems: false,
       startExpandedEvents: false,
@@ -341,10 +293,6 @@ export default {
 
     this.total_powered = this.impactData.total_powered
     this.total_unpowered = this.impactData.total_unpowered
-    this.waste_powered = this.impactData.waste_powered
-    this.waste_unpowered = this.impactData.waste_unpowered
-    this.co2_powered = this.impactData.co2_powered
-    this.co2_unpowered = this.impactData.co2_unpowered
   },
   watch: {
     url(newVal) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -77,9 +77,4 @@ Route::group(['middleware' => 'auth:api'], function () {
 
 Route::get('/groups/{group}/events', 'API\GroupController@getEventsForGroup');
 
-/**
- * @ToDo Determine usage and deprecate if redundant.
- *
- * See app\Http\Controllers\ApiController::getDevices() for more info.
- */
 Route::get('/devices/{page}/{size}', [App\Http\Controllers\ApiController::class, 'getDevices']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -190,7 +190,6 @@ Route::group(['middleware' => ['auth', 'verifyUserConsent']], function () {
     });
 
     Route::prefix('user')->group(function () {
-        Route::get('/create', 'UserController@create');
         Route::post('/create', 'UserController@create');
         Route::get('/all', 'UserController@all')->name('users');
         Route::get('/all/search', 'UserController@search');

--- a/tests/Feature/Devices/EditTest.php
+++ b/tests/Feature/Devices/EditTest.php
@@ -6,6 +6,7 @@ use App\Device;
 use App\Party;
 use App\User;
 use DB;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class EditTest extends TestCase
@@ -49,5 +50,71 @@ class EditTest extends TestCase
             'HTTP_X-Requested-With' => 'XMLHttpRequest'
         ]);
         self::assertFalse($rsp['success']);
+    }
+
+    public function testImage() {
+        Storage::fake('avatars');
+        $user = factory(User::class)->states('Administrator')->create();
+        $this->actingAs($user);
+
+        $rsp = $this->post('/device/create', $this->device_inputs);
+        self::assertTrue($rsp['success']);
+        $iddevices = $rsp['devices'][0]['iddevices'];
+        self::assertNotNull($iddevices);
+
+        // Try with no file.
+        $response = $this->json('POST', '/device/image-upload/' . $iddevices, []);
+        $this->assertEquals(json_decode($response->getContent(), TRUE), [
+            'success' => true,
+            'iddevices' => $iddevices,
+            'images' => []
+        ]);
+
+        // We don't upload files in a standard Laravel way, so testing upload is a bit of a hack.
+        $_SERVER['DOCUMENT_ROOT'] = getcwd();
+        \FixometerFile::$uploadTesting = TRUE;
+        file_put_contents('/tmp/UT.jpg', file_get_contents('public/images/community.jpg'));
+
+        $_FILES = [
+            'file' => [
+                'error'    => "0",
+                'name'     => 'UT.jpg',
+                'size'     => 123,
+                'tmp_name' => [ '/tmp/UT.jpg' ],
+                'type'     => 'image/jpg'
+            ]
+        ];
+
+        $params = [];
+
+        $response = $this->json('POST', '/device/image-upload/' . $iddevices, $params);
+        $ret = json_decode($response->getContent(), TRUE);
+        self::assertEquals(true, $ret['success']);
+        self::assertEquals($iddevices, $ret['iddevices']);
+        self::assertEquals(1, count($ret['images']));
+
+        // And again, which will test we can upload two.
+        file_put_contents('/tmp/UT2.jpg', file_get_contents('public/images/community.jpg'));
+
+        $_FILES = [
+            'file' => [
+                'error'    => "0",
+                'name'     => 'UT2.jpg',
+                'size'     => 123,
+                'tmp_name' => [ '/tmp/UT2.jpg' ],
+                'type'     => 'image/jpg'
+            ]
+        ];
+        $response2 = $this->json('POST', '/device/image-upload/' . $iddevices, $params);
+        $ret = json_decode($response2->getContent(), TRUE);
+        self::assertEquals(true, $ret['success']);
+        self::assertEquals($iddevices, $ret['iddevices']);
+        self::assertEquals(2, count($ret['images']));
+
+        // Delete one
+        $response3 = $this->json('GET', '/device/image/delete/' . $iddevices . '/' . $ret['images'][0]['idimages'] . '/' . $ret['images'][0]['path'], $params);
+        $this->assertTrue($response3->isRedirection());
+        $response3->assertSessionHas('message');
+        $this->assertEquals('Thank you, the image has been deleted', \Session::get('message'));
     }
 }

--- a/tests/Feature/Devices/NullProblemTest.php
+++ b/tests/Feature/Devices/NullProblemTest.php
@@ -36,8 +36,9 @@ class NullProblemTest extends TestCase
     {
         $this->device_inputs['problem'] = null;
         $this->post('/device/create', $this->device_inputs);
+        $iddevices = Device::latest()->first()->iddevices;
 
-        $device = Device::find(1);
+        $device = Device::find($iddevices);
         $this->assertEquals('', $device->problem);
     }
 }

--- a/tests/Feature/Devices/SparePartsTest.php
+++ b/tests/Feature/Devices/SparePartsTest.php
@@ -37,8 +37,9 @@ class SparePartsTest extends TestCase
         $this->device_inputs['repair_status'] = Device::REPAIR_STATUS_FIXED;
         $this->device_inputs['spare_parts'] = $this->input_spare_parts_from_manufacturer;
         $response = $this->post('/device/create', $this->device_inputs);
+        $iddevices = Device::latest()->first()->iddevices;
 
-        $device = Device::find(1);
+        $device = Device::find($iddevices);
         $this->assertEquals(Device::SPARE_PARTS_NEEDED, $device->spare_parts);
         $this->assertEquals(Device::PARTS_PROVIDER_MANUFACTURER, $device->parts_provider);
     }
@@ -50,8 +51,9 @@ class SparePartsTest extends TestCase
         $this->device_inputs['spare_parts'] = $this->input_spare_parts_from_third_party;
 
         $response = $this->post('/device/create', $this->device_inputs);
+        $iddevices = Device::latest()->first()->iddevices;
 
-        $device = Device::find(1);
+        $device = Device::find($iddevices);
         $this->assertEquals(Device::SPARE_PARTS_NEEDED, $device->spare_parts);
         $this->assertEquals(Device::PARTS_PROVIDER_THIRD_PARTY, $device->parts_provider);
     }
@@ -63,8 +65,9 @@ class SparePartsTest extends TestCase
         $this->device_inputs['spare_parts'] = $this->input_no_spare_parts_needed;
 
         $response = $this->post('/device/create', $this->device_inputs);
+        $iddevices = Device::latest()->first()->iddevices;
 
-        $device = Device::find(1);
+        $device = Device::find($iddevices);
         $this->assertEquals(Device::SPARE_PARTS_NOT_NEEDED, $device->spare_parts);
         $this->assertNull($device->parts_provider);
     }
@@ -76,8 +79,9 @@ class SparePartsTest extends TestCase
         $this->device_inputs['barrier'] = [1];
 
         $response = $this->post('/device/create', $this->device_inputs);
+        $iddevices = Device::latest()->first()->iddevices;
 
-        $device = Device::find(1);
+        $device = Device::find($iddevices);
         $this->assertEquals(Device::SPARE_PARTS_NEEDED, $device->spare_parts);
         $this->assertNull($device->parts_provider);
     }
@@ -89,8 +93,9 @@ class SparePartsTest extends TestCase
         $this->device_inputs['barrier'] = [4];
 
         $response = $this->post('/device/create', $this->device_inputs);
+        $iddevices = Device::latest()->first()->iddevices;
 
-        $device = Device::find(1);
+        $device = Device::find($iddevices);
         $this->assertEquals(Device::SPARE_PARTS_NOT_NEEDED, $device->spare_parts);
         $this->assertNull($device->parts_provider);
     }

--- a/tests/Feature/Events/AddRemoveVolunteerTest.php
+++ b/tests/Feature/Events/AddRemoveVolunteerTest.php
@@ -169,6 +169,6 @@ class AddRemoveVolunteerTest extends TestCase
         // Should now see the group.
         $response = $this->get('/user/edit/' . $host->id);
         $response->assertStatus(200);
-        $response->assertSee('<option value="1" selected>Test Group0</option>');
+        $response->assertSee('<option value="' . $idgroups . '" selected>Test Group0</option>');
     }
 }

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -432,7 +432,6 @@ class CreateEventTest extends TestCase
         $response->assertSessionHas('success');
         $this->assertTrue($response->isRedirection());
 
-
         // Check the notification appears on the web.
         $this->actingAs($host);
         $response = $this->get('/profile/notifications');

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -431,11 +431,6 @@ class CreateEventTest extends TestCase
 
         $response->assertSessionHas('success');
         $this->assertTrue($response->isRedirection());
-
-        // Check the notification appears on the web.
-        $this->actingAs($host);
-        $response = $this->get('/profile/notifications');
-        $response->assertSeeText('New event created');
     }
 
     public function provider()

--- a/tests/Feature/Events/DeleteEventTest.php
+++ b/tests/Feature/Events/DeleteEventTest.php
@@ -20,6 +20,7 @@ use Auth;
 use Carbon\Carbon;
 use DB;
 use HieuLe\WordpressXmlrpcClient\WordpressClient;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
@@ -82,6 +83,71 @@ class DeleteEventTest extends TestCase
         // Check that getting the outbound info behaves gracefully.
         $this->expectException(NotFoundHttpException::class);
         $this->get("/outbound/info/party/{$event->idevents}");
+    }
+
+    /**
+     * @test
+     * @dataProvider roleProvider
+     */
+    public function view_edit_deleted_event($role)
+    {
+        $this->withoutExceptionHandling();
+
+        switch ($role) {
+            case Role::ADMINISTRATOR: $roleToCreate = 'Administrator'; break;
+            case Role::NETWORK_COORDINATOR: $roleToCreate = 'NetworkCoordinator'; break;
+            case Role::HOST: $roleToCreate = 'Host'; break;
+        }
+        $host = factory(User::class)->states($roleToCreate)->create();
+        $this->actingAs($host);
+
+        $group = factory(Group::class)->create();
+        $group->addVolunteer($host);
+        $group->makeMemberAHost($host);
+
+        $event = factory(Party::class)->create(['group' => $group->idgroups]);
+        $event->save();
+
+        // View the event
+        $response = $this->get("/party/view/{$event->idevents}");
+        $props = $this->assertVueProperties($response, [
+            [
+                ':idevents' => $event->idevents
+            ]
+        ]);
+        $initialEvent = json_decode($props[0][':initial-event'], TRUE);
+        $this->assertEquals($event->venue, $initialEvent['venue']);
+        $this->assertFalse($initialEvent['approved']);
+
+        // Now delete the event.
+        $response = $this->post('/party/delete/'.$event->idevents);
+        $response->assertRedirect('/party/');
+        $this->assertSoftDeleted('events', ['idevents' => $event['idevents']]);
+
+        // View page should fail.
+        try {
+            $response = $this->get('/party/view/'.$event->idevents);
+            $this->assertTrue(false, "Failed to throw exception");
+        } catch (NotFoundHttpException $e) {
+            $this->assertTrue(true);
+        }
+
+        // Edit also.
+        try {
+            $response2 = $this->get('/party/edit/'.$event->idevents);
+            error_log($response->getContent());
+            $this->assertTrue(false, "Failed to throw exception");
+        } catch (ModelNotFoundException $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function roleProvider() {
+        return [
+            [ Role::ADMINISTRATOR ],
+            [ Role::NETWORK_COORDINATOR ],
+            [ Role::HOST ],
+        ];
     }
 
     /** @test */

--- a/tests/Feature/Events/DeleteEventTest.php
+++ b/tests/Feature/Events/DeleteEventTest.php
@@ -261,7 +261,7 @@ class DeleteEventTest extends TestCase
     {
         $this->loginAsTestUser(Role::ADMINISTRATOR);
         $id = $this->createGroup();
-        $group = Group::find($id);
+        $group = Group::findOrFail($id);
 
         $network = factory(Network::class)->create([
            'events_push_to_wordpress' => false,
@@ -288,7 +288,7 @@ class DeleteEventTest extends TestCase
 
         $this->actingAs($user);
 
-        $response = $this->get("/party/view/$id");
+        $response = $this->get("/party/view/$idevents");
 
         $this->assertVueProperties($response, [
             [

--- a/tests/Feature/Events/OnlineEventsTest.php
+++ b/tests/Feature/Events/OnlineEventsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Device;
 use App\EventsUsers;
 use App\Group;
 use App\Helpers\Geocoder;
@@ -43,9 +44,10 @@ class OnlineEventsTest extends TestCase
         // act
         $eventAttributes = factory(Party::class)->raw(['online' => true]);
         $response = $this->post('/party/create/', $eventAttributes);
+        $idevents = Party::latest()->first()->idevents;
 
         // assert
-        $event = Party::find(1);
+        $event = Party::find($idevents);
         $this->assertTrue($event->online == true);
     }
 }

--- a/tests/Feature/Groups/BasicTest.php
+++ b/tests/Feature/Groups/BasicTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Groups;
 
 use App\Group;
+use App\Network;
 use App\User;
 use DB;
 use Hash;
@@ -34,10 +35,10 @@ class BasicTest extends TestCase
                 // Can't assert on all-group-tags dev systems might have varying info.
                 'your-area' => 'London',
                 ':can-create' => 'false',
-                ':user-id' => '1',
+                ':user-id' => $user->id,
                 'tab' => 'mine',
                 ':network' => 'null',
-                ':networks' => '[{"id":1,"name":"Restarters","description":null,"website":null,"default_language":"en","timezone":"Europe\\/London","created_at":"2021-05-24 12:19:37","updated_at":"2021-05-24 12:19:37","events_push_to_wordpress":0,"include_in_zapier":0,"users_push_to_drip":0,"shortname":"restarters","discourse_group":null,"auto_approve_events":0}]',
+                ':networks' => '[{"id":' . Network::first()->id . ',"name":"Restarters","description":null,"website":null,"default_language":"en","timezone":"Europe\\/London","created_at":"2021-05-24 12:19:37","updated_at":"2021-05-24 12:19:37","events_push_to_wordpress":0,"include_in_zapier":0,"users_push_to_drip":0,"shortname":"restarters","discourse_group":null,"auto_approve_events":0}]',
                 ':show-tags' => 'false',
             ],
         ]);

--- a/tests/Feature/Groups/GroupByKeyTest.php
+++ b/tests/Feature/Groups/GroupByKeyTest.php
@@ -94,7 +94,7 @@ class GroupByKeyTest extends TestCase
         $this->assertEquals($eventpast->idevents, $ret['past_parties'][0]['event_id']);
 
         // Get stats
-        $response = $this->get('/api/group-tag/stats/'.$group->idgroups);
+        $response = $this->get('/api/group-tag/stats/'.$tag1->id);
         $stats = json_decode($response->getContent(), true);
         $this->assertEquals(1, $stats['parties']);
 

--- a/tests/Feature/Groups/GroupEditTest.php
+++ b/tests/Feature/Groups/GroupEditTest.php
@@ -81,12 +81,16 @@ class GroupEditTest extends TestCase
         $this->actingAs($host);
 
         // We don't upload files in a standard Laravel way, so testing upload is a bit of a hack.
+        $_SERVER['DOCUMENT_ROOT'] = getcwd();
+        \FixometerFile::$uploadTesting = TRUE;
+        file_put_contents('/tmp/UT.jpg', file_get_contents('public/images/community.jpg'));
+
         $_FILES = [
             'file' => [
                 'error'    => "0",
-                'name'     => 'avatar.jpg',
+                'name'     => 'UT.jpg',
                 'size'     => 123,
-                'tmp_name' => __FILE__,   // use THIS file - a real file
+                'tmp_name' => [ '/tmp/UT.jpg' ],
                 'type'     => 'image/jpg'
             ]
         ];

--- a/tests/Feature/Groups/GroupJoinTest.php
+++ b/tests/Feature/Groups/GroupJoinTest.php
@@ -71,7 +71,7 @@ class GroupJoinTest extends TestCase
         $this->actingAs($host);
         $userGroupAssociation = UserGroups::where('user', $host->id)
             ->where('group', $group->idgroups)->first();
-        $url = '/api/usersgroups/'.$userGroupAssociation->idusers_groups.'?api_token=1234';
+        $url = '/api/usersgroups/'.$userGroupAssociation->group.'?api_token=1234';
         $response = $this->call('DELETE', $url);
         $response->assertSee('"success":true');
 

--- a/tests/Feature/Groups/GroupViewTest.php
+++ b/tests/Feature/Groups/GroupViewTest.php
@@ -6,6 +6,7 @@ use App\Device;
 use App\Party;
 use App\Role;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\TestCase;
 
@@ -61,6 +62,8 @@ class GroupViewTest extends TestCase
         ]);
 
         $response = $this->post('/device/create', factory(Device::class)->raw([
+                                                                                  'category' => env('MISC_CATEGORY_ID_POWERED'),
+                                                                                  'category_creation' => env('MISC_CATEGORY_ID_POWERED'),
                                                                                   'event_id' => $event->idevents,
                                                                                   'quantity' => 1,
                                                                               ]));
@@ -72,6 +75,13 @@ class GroupViewTest extends TestCase
                 ':can-perform-delete' => 'false',
             ],
         ]);
+
+        # Check the device shows in the API.
+        $rsp2 = $this->get('/api/devices/1/10?sortBy=iddevices&sortDesc=asc&powered=true');
+        $ret = json_decode($rsp2->getContent(), true);
+        self::assertEquals(1, $ret['count']);
+        self::assertEquals(1, count($ret['items']));
+        self::assertEquals($event->idevents, $ret['items'][0]['event']);
 
         // Only administrators can delete.
         foreach (['Restarter', 'Host', 'NetworkCoordinator'] as $role) {

--- a/tests/Feature/Groups/VolunteersNearbyTest.php
+++ b/tests/Feature/Groups/VolunteersNearbyTest.php
@@ -49,9 +49,9 @@ class VolunteersNearbyTest extends TestCase
 
         // Should see the appropriate users in the list of nearby.
         $rsp = $this->get('/group/nearby/' . $group->idgroups);
-        $rsp->assertSee(htmlspecialchars($user1->name));
-        $rsp->assertSee(htmlspecialchars($user2->name));
-        $rsp->assertDontSee(htmlspecialchars($user3->name));
+        $rsp->assertSee(htmlspecialchars($user1->name, ENT_QUOTES));
+        $rsp->assertSee(htmlspecialchars($user2->name, ENT_QUOTES));
+        $rsp->assertDontSee(htmlspecialchars($user3->name, ENT_QUOTES));
 
         // Invite one of them.
         $rsp = $this->get('/group/nearbyinvite/' . $group->idgroups . '/' . $user1->id);

--- a/tests/Feature/Stats/EventStatsTest.php
+++ b/tests/Feature/Stats/EventStatsTest.php
@@ -23,10 +23,11 @@ class EventStatsTest extends StatsTestCase
         $this->_setupCategoriesWithUnpoweredWeights();
 
         // #1 add a powered non-misc device
+        $event = factory(Party::class)->create();
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idPoweredNonMisc,
             'category_creation' => $this->_idPoweredNonMisc,
-            'event' => 1,
+            'event' => $event->idevents,
         ]);
         $expect = \App\Party::getEventStatsArrayKeys();
         $expect['co2_powered'] = 14.4 * $this->_displacementFactor;
@@ -48,7 +49,7 @@ class EventStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idPoweredMisc,
             'category_creation' => $this->_idPoweredMisc,
-            'event' => 1,
+                                                                      'event' => $event->idevents,
         ]);
         $expect['fixed_devices']++;
         $expect['fixed_powered']++;
@@ -65,7 +66,7 @@ class EventStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => 5,
             'category_creation' => 5,
-            'event' => 1,
+            'event' => $event->idevents,
         ]);
         $expect['fixed_devices']++;
         $expect['fixed_unpowered']++;
@@ -85,7 +86,7 @@ class EventStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idUnpoweredMisc,
             'category_creation' => $this->_idUnpoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
         ]);
         $expect['fixed_devices']++;
         $expect['fixed_unpowered']++;
@@ -102,7 +103,7 @@ class EventStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idPoweredMisc,
             'category_creation' => $this->_idPoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
             'estimate' => 1.23,
         ]);
         $expect['fixed_devices']++;
@@ -123,7 +124,7 @@ class EventStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idUnpoweredMisc,
             'category_creation' => $this->_idUnpoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
             'estimate' => 4.56,
         ]);
         $expect['fixed_devices']++;
@@ -144,7 +145,7 @@ class EventStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idUnpoweredMisc,
             'category_creation' => $this->_idUnpoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
             'estimate' => 7.89,
         ]);
         $expect['fixed_devices']++;

--- a/tests/Feature/Stats/GroupStatsTest.php
+++ b/tests/Feature/Stats/GroupStatsTest.php
@@ -172,7 +172,7 @@ class GroupStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idUnpoweredMisc,
             'category_creation' => $this->_idUnpoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
             'estimate' => 7.89,
         ]);
         $expect['fixed_devices']++;

--- a/tests/Feature/Stats/LcaStatsTest.php
+++ b/tests/Feature/Stats/LcaStatsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Stats;
 
 use App\Device;
 use App\Helpers\LcaStats;
+use App\Party;
 use DB;
 use Tests\Feature\Stats\StatsTestCase;
 
@@ -175,6 +176,7 @@ class LcaStatsTest extends StatsTestCase
     public function get_waste_stats_group()
     {
         $this->_setupCategoriesWithUnpoweredWeights();
+        $event = factory(Party::class)->create();
 
         DB::statement("UPDATE categories SET weight=0, footprint=0 WHERE idcategories IN (' . $this->_idPoweredMisc . ',' . $this->_idUnpoweredMisc .')");
 
@@ -184,7 +186,7 @@ class LcaStatsTest extends StatsTestCase
         factory(Device::class)->states('fixed')->create([
             'category' => $this->_idPoweredNonMisc,
             'category_creation' => $this->_idPoweredNonMisc,
-            'event' => 1,
+            'event' => $event->idevents,
         ]);
         $expect = [
             'powered_waste' => 4,
@@ -203,7 +205,7 @@ class LcaStatsTest extends StatsTestCase
         factory(Device::class)->states('fixed')->create([
             'category' => $this->_idPoweredMisc,
             'category_creation' => $this->_idPoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
         ]);
         $expect = [
             'powered_waste' => 4,
@@ -222,7 +224,7 @@ class LcaStatsTest extends StatsTestCase
         factory(Device::class)->states('fixed')->create([
             'category' => $this->_idUnpoweredNonMisc,
             'category_creation' => $this->_idUnpoweredNonMisc,
-            'event' => 1,
+            'event' => $event->idevents,
         ]);
         $expect = [
             'powered_waste' => 4,
@@ -241,7 +243,7 @@ class LcaStatsTest extends StatsTestCase
         factory(Device::class)->states('fixed')->create([
             'category' => $this->_idUnpoweredMisc,
             'category_creation' => $this->_idUnpoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
         ]);
         $expect = [
             'powered_waste' => 4,
@@ -260,7 +262,7 @@ class LcaStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idPoweredMisc,
             'category_creation' => $this->_idPoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
             'estimate' => 1.23,
         ]);
         $expect = [
@@ -280,7 +282,7 @@ class LcaStatsTest extends StatsTestCase
         $device = factory(Device::class)->states('fixed')->create([
             'category' => $this->_idUnpoweredMisc,
             'category_creation' => $this->_idUnpoweredMisc,
-            'event' => 1,
+            'event' => $event->idevents,
             'estimate' => 4.56,
         ]);
         $expect = [

--- a/tests/Feature/Stats/LcaStatsTest.php
+++ b/tests/Feature/Stats/LcaStatsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Stats;
 
 use App\Device;
+use App\Group;
 use App\Helpers\LcaStats;
 use App\Party;
 use DB;
@@ -176,11 +177,12 @@ class LcaStatsTest extends StatsTestCase
     public function get_waste_stats_group()
     {
         $this->_setupCategoriesWithUnpoweredWeights();
-        $event = factory(Party::class)->create();
 
         DB::statement("UPDATE categories SET weight=0, footprint=0 WHERE idcategories IN (' . $this->_idPoweredMisc . ',' . $this->_idUnpoweredMisc .')");
 
-        $group = 1;
+        $groupObj = factory(Group::class)->create();
+        $group = $groupObj->idgroups;
+        $event = factory(Party::class)->create([ 'group' => $group ]);
 
         // #1 add a single powered non-misc device
         factory(Device::class)->states('fixed')->create([

--- a/tests/Feature/Users/EditProfileTests.php
+++ b/tests/Feature/Users/EditProfileTests.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Events\UserUpdated;
+use App\Group;
 use App\Helpers\Fixometer;
 use App\Role;
 use App\Skills;
@@ -12,6 +13,7 @@ use DB;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class EditProfileTests extends TestCase
@@ -123,8 +125,18 @@ class EditProfileTests extends TestCase
         $this->assertNull($user->longitude);
     }
 
-    /** test */
-    public function test_tags_update() {
+    public function idProvider() {
+        return [
+            [ TRUE ],
+            [ FALSE ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider idProvider
+     */
+    public function test_tags_update($id) {
         $user = factory(User::class)->create();
         $this->actingAs($user);
 
@@ -140,9 +152,15 @@ class EditProfileTests extends TestCase
                                 ]);
 
         // Add this skill.
-        $response = $this->post('/profile/edit-tags', [
+        $params = [
             'tags' => [ $skill1->id, $skill2->id ]
-        ]);
+        ];
+
+        if ($id) {
+            $params['id'] = $user->id;
+        };
+
+        $response = $this->post('/profile/edit-tags', $params);
 
         $this->assertTrue($response->isRedirection());
         $response->assertSessionHas('message');
@@ -155,5 +173,46 @@ class EditProfileTests extends TestCase
         // Should have promoted to host because we have a category 1 skill.
         $user->refresh();
         self::assertEquals(Role::HOST, $user->role);
+    }
+
+    /**
+     * @test
+     * @dataProvider idProvider
+     */
+    public function image_upload($id) {
+        Storage::fake('avatars');
+        $user = factory(User::class)->create();
+        $this->actingAs($user);
+
+        // Try with no file.
+        $response = $this->json('POST', '/profile/edit-photo', []);
+        $this->assertTrue($response->isRedirection());
+        $response->assertSessionHas('error');
+
+        // We don't upload files in a standard Laravel way, so testing upload is a bit of a hack.
+        $_FILES = [
+            'profilePhoto' => [
+                'error'    => "0",
+                'name'     => 'avatar.jpg',
+                'size'     => 123,
+                'tmp_name' => __FILE__,   // use THIS file - a real file
+                'type'     => 'image/jpg'
+            ]
+        ];
+
+        $params = [];
+
+        if ($id) {
+            $params['id'] = $id;
+        }
+
+        $response = $this->json('POST', '/profile/edit-photo', $params);
+        $this->assertTrue($response->isRedirection());
+        $response->assertSessionHas('message');
+
+        // And again, which will test the case of overwriting.
+        $response = $this->json('POST', '/profile/edit-photo', $params);
+        $this->assertTrue($response->isRedirection());
+        $response->assertSessionHas('message');
     }
 }

--- a/tests/Feature/Users/EditProfileTests.php
+++ b/tests/Feature/Users/EditProfileTests.php
@@ -185,8 +185,6 @@ class EditProfileTests extends TestCase
         $this->actingAs($user);
 
         // Try with no file.
-        unset($_FILES);
-
         $response = $this->json('POST', '/profile/edit-photo', []);
         $this->assertTrue($response->isRedirection());
         $response->assertSessionHas('error');

--- a/tests/Feature/Users/EditProfileTests.php
+++ b/tests/Feature/Users/EditProfileTests.php
@@ -185,6 +185,8 @@ class EditProfileTests extends TestCase
         $this->actingAs($user);
 
         // Try with no file.
+        unset($_FILES);
+
         $response = $this->json('POST', '/profile/edit-photo', []);
         $this->assertTrue($response->isRedirection());
         $response->assertSessionHas('error');

--- a/tests/Integration/utils.js
+++ b/tests/Integration/utils.js
@@ -37,8 +37,10 @@ exports.createGroup = async function(page, baseURL) {
 
   await page.click('button[type=submit]')
 
-  // Get redirected to Edit form which should have details section.
-  await expect(page.locator('#details'))
+  // Should get redirected to Edit form.  We used to wait on #details, but this stopped working for reasons we don't
+  // understand.  It may be as design in Playwright.  However the page URL will have been updated and we can use that
+  // to check that the create redirected to edit.
+  await page.waitForURL('**/edit/**');
 
   // Return id from URL
   const p = page.url().lastIndexOf('/')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -71,6 +71,11 @@ abstract class TestCase extends BaseTestCase
         factory(Category::class, 1)->states('Mobile')->create();
         factory(Category::class, 1)->states('Misc')->create();
         factory(Category::class, 1)->states('Desktop computer')->create();
+
+        if (isset($_FILES)) {
+            // We manipulate this for image upload testing.
+            unset($_FILES);
+        }
     }
 
     public function userAttributes()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,11 +10,13 @@ use App\EventsUsers;
 use App\Group;
 use App\GroupNetwork;
 use App\GroupTags;
+use App\Images;
 use App\Network;
 use App\Party;
 use App\Role;
 use App\User;
 use App\UserGroups;
+use App\Xref;
 use Auth;
 use Carbon\Carbon;
 use DB;
@@ -48,6 +50,8 @@ abstract class TestCase extends BaseTestCase
         Category::truncate();
         Brands::truncate();
         GroupTags::truncate();
+        Xref::truncate();
+        Images::truncate();
         DB::statement('delete from audits');
         DB::delete('delete from user_network');
         DB::delete('delete from grouptags_groups');
@@ -72,8 +76,8 @@ abstract class TestCase extends BaseTestCase
         factory(Category::class, 1)->states('Misc')->create();
         factory(Category::class, 1)->states('Desktop computer')->create();
 
+        // We manipulate some globals for image upload testing.
         if (isset($_FILES)) {
-            // We manipulate this for image upload testing.
             unset($_FILES);
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -77,6 +77,8 @@ abstract class TestCase extends BaseTestCase
         factory(Category::class, 1)->states('Desktop computer')->create();
 
         // We manipulate some globals for image upload testing.
+        \FixometerFile::$uploadTesting = FALSE;
+
         if (isset($_FILES)) {
             unset($_FILES);
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,6 +58,19 @@ abstract class TestCase extends BaseTestCase
         DB::table('notifications')->truncate();
         DB::statement('SET foreign_key_checks=1');
 
+        // Set up random auto increment values.  This avoids tests working because everything is 1.
+        $tables = DB::select('SHOW TABLES');
+        foreach ($tables as $table)
+        {
+            foreach ($table as $field => $tablename) {
+                try {
+                    // This will throw an exception if the table doesn't have auto increment.
+                    DB::update("ALTER TABLE $tablename AUTO_INCREMENT = " . rand(1, 1000) . ";");
+                } catch (\Exception $e) {
+                }
+            }
+        }
+
         $network = new Network();
         $network->name = 'Restarters';
         $network->shortname = 'restarters';


### PR DESCRIPTION
Sentry error if we are a network coordinator who creates an event, then deletes it, and then fetches the edit page.  Be more careful about whether the event id is valid, and add some tests.

Remove some dead code and add some more tests, especially for file uploads.

Randomise auto-increment ids on tables for better testing, and fix some tests.

This is built on top of RES-1630, so the diffs may be confusing until that's integrated.