### PR TITLE
RES-1646 Users with underscores don't get logged in to the wiki immediately

### DIFF
--- a/app/Listeners/LogInToWiki.php
+++ b/app/Listeners/LogInToWiki.php
@@ -48,6 +48,7 @@ class LogInToWiki
         if ($user->wiki_sync_status == WikiSyncStatus::CreateAtLogin) {
             Log::info("Need to create " . $user->name);
             $this->createUserInWiki($user);
+            $user->refresh();
         }
 
         if (! is_null($user->mediawiki) && ! empty($user->mediawiki) &&


### PR DESCRIPTION
We change the underscore to a dash, but the login hasn't done a `refresh()` and therefore uses the initial username and fails.