### PR TITLE
RES-1647 Event edit broken for timezones.

### DIFF
--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -451,8 +451,10 @@ class PartyController extends Controller
                 $end = $request->input('end');
 
                 $startCarbon = Carbon::parse($event_date . ' ' . $start, $timezone);
+                $startCarbon->setTimezone('UTC');
                 $event_start_utc = $startCarbon->toIso8601String();
                 $endCarbon = Carbon::parse($event_date . ' ' . $end, $timezone);
+                $endCarbon->setTimezone('UTC');
                 $event_end_utc = $endCarbon->toIso8601String();
             }
 

--- a/tests/Feature/Events/DeleteEventTest.php
+++ b/tests/Feature/Events/DeleteEventTest.php
@@ -135,7 +135,6 @@ class DeleteEventTest extends TestCase
         // Edit also.
         try {
             $response2 = $this->get('/party/edit/'.$event->idevents);
-            error_log($response->getContent());
             $this->assertTrue(false, "Failed to throw exception");
         } catch (ModelNotFoundException $e) {
             $this->assertTrue(true);


### PR DESCRIPTION
The edit code was missing a key stage in the handling of times, which the create code did correctly.

This is superseded by the later timezone work, but this PR is worth releasing as it beefs up the testing in this area.