### PR TITLE
RES-1627 unapproved events display

### DIFF
--- a/app/Helpers/Fixometer.php
+++ b/app/Helpers/Fixometer.php
@@ -96,6 +96,50 @@ class Fixometer
         return date('D, j M Y, H:i', $timestamp);
     }
 
+    public static function userHasViewPartyPermission($partyId, $userId = null)
+    {
+        $party = Party::findOrFail($partyId);
+        $group = $party->theGroup;
+
+        if ($group->approved) {
+            // Events on approved groups are always visible, whether or not the event has been approved.
+            return true;
+        }
+
+        // The group is not approved.  Events are only visible to:
+        // - administrators
+        // - (relevant) network coordinators
+        // - hosts of the relevant group
+        if (is_null($userId)) {
+            if (empty(Auth::user())) {
+                return false;
+            } else {
+                $userId = Auth::user()->id;
+            }
+        }
+
+        $user = User::findOrFail($userId);
+
+        if (self::hasRole($user, 'Administrator')) {
+            return true;
+        }
+
+        if (self::hasRole($user, 'NetworkCoordinator')) {
+            $group = $party->theGroup;
+            foreach ($group->networks as $network) {
+                if ($network->coordinators->contains($user)) {
+                    return true;
+                }
+            }
+        }
+
+        if (self::hasRole($user, 'Host') && self::userIsHostOfGroup($group->idgroups, $userId)) {
+            return true;
+        }
+
+        return false;
+    }
+
     public static function userHasEditPartyPermission($partyId, $userId = null)
     {
         $party = Party::findOrFail($partyId);

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -116,21 +116,26 @@ class PartyController extends Controller
                     ->get();
 
                 foreach ($upcoming_events_in_area as $event) {
-                    $e = self::expandEvent($event, NULL);
-                    $e['nearby'] = TRUE;
-                    $e['all'] = TRUE;
-                    $events[] = $e;
+                    if (Fixometer::userHasViewPartyPermission($event->idevents)) {
+                        $e = self::expandEvent($event, null);
+                        $e['nearby'] = true;
+                        $e['all'] = true;
+                        $events[] = $e;
+                    }
                 }
             }
 
-            // ...and any other upcoming events
+            // ...and any other upcoming approved events
             $other_upcoming_events = Party::future()->
-                whereNotIn('idevents', \Illuminate\Support\Arr::pluck($events, 'idevents'))->get();
+                whereNotIn('idevents', \Illuminate\Support\Arr::pluck($events, 'idevents'))->
+                get();
 
             foreach ($other_upcoming_events as $event) {
-                $e = self::expandEvent($event, NULL);
-                $e['all'] = TRUE;
-                $events[] = $e;
+                if (Fixometer::userHasViewPartyPermission($event->idevents)) {
+                    $e = self::expandEvent($event, NULL);
+                    $e['all'] = TRUE;
+                    $events[] = $e;
+                }
             }
 
             $group = null;
@@ -600,8 +605,8 @@ class PartyController extends Controller
         $Party = new Party;
         $event = Party::find($id);
 
-        // If event no longer exists
-        if (empty($event)) {
+        // If event no longer exists or is not visible
+        if (empty($event) || !Fixometer::userHasViewPartyPermission($id)) {
             abort(404);
         }
 

--- a/app/Party.php
+++ b/app/Party.php
@@ -531,7 +531,7 @@ class Party extends Model implements Auditable
         $exclude_group_ids = UserGroups::where('user', $user->id)->where('status', 1)->pluck('group')->toArray();
 
         // We also want to exclude any groups which are not yet approved.
-        $exclude_group_ids = array_merge($exclude_group_ids, Groups::whereNull('wordpress_post_id')->pluck('idgroups')->toArray());
+        $exclude_group_ids = array_merge($exclude_group_ids, Group::whereNull('wordpress_post_id')->pluck('idgroups')->toArray());
 
         return $this
       ->select(DB::raw('`events`.*, ( 6371 * acos( cos( radians('.$user->latitude.') ) * cos( radians( events.latitude ) ) * cos( radians( events.longitude ) - radians('.$user->longitude.') ) + sin( radians('.$user->latitude.') ) * sin( radians( events.latitude ) ) ) ) AS distance'))

--- a/resources/js/components/EventDescription.vue
+++ b/resources/js/components/EventDescription.vue
@@ -5,6 +5,9 @@
     </template>
     <template slot="content">
       <read-more :html="event.free_text" class="mt-2 readmore small" :max-chars="440" :more-str="__('events.read_more')" :less-str="__('events.read_less')" />
+      <p v-if="!event.approved" class="small text-muted">
+        {{ __('partials.event_requires_moderation_by_an_admin') }}.
+      </p>
     </template>
   </CollapsibleSection>
 </template>

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -70,7 +70,9 @@ class CreateEventTest extends TestCase
         $host = factory(User::class)->states('Host')->create();
         $this->actingAs($host);
 
-        $group = factory(Group::class)->create();
+        $group = factory(Group::class)->create([
+            'wordpress_post_id' => '99999'
+        ]);
         $group->addVolunteer($host);
         $group->makeMemberAHost($host);
 

--- a/tests/Feature/Events/DeleteEventTest.php
+++ b/tests/Feature/Events/DeleteEventTest.php
@@ -101,7 +101,9 @@ class DeleteEventTest extends TestCase
         $host = factory(User::class)->states($roleToCreate)->create();
         $this->actingAs($host);
 
-        $group = factory(Group::class)->create();
+        $group = factory(Group::class)->create([
+                                                   'wordpress_post_id' => '99999'
+                                               ]);
         $group->addVolunteer($host);
         $group->makeMemberAHost($host);
 

--- a/tests/Feature/Events/InviteEventTest.php
+++ b/tests/Feature/Events/InviteEventTest.php
@@ -20,7 +20,9 @@ class InviteEventTest extends TestCase
 
         $this->withoutExceptionHandling();
 
-        $group = factory(Group::class)->create();
+        $group = factory(Group::class)->create([
+                                                   'wordpress_post_id' => '99999'
+                                               ]);
         $event = factory(Party::class)->create([
                                                    'group' => $group,
                                                    'event_date' => '2130-01-01',
@@ -121,7 +123,9 @@ class InviteEventTest extends TestCase
     {
         $this->withoutExceptionHandling();
 
-        $group = factory(Group::class)->create();
+        $group = factory(Group::class)->create([
+                                                   'wordpress_post_id' => '99999'
+                                               ]);
         $host = factory(User::class)->states('Host')->create();
         $event = factory(Party::class)->create([
                                                    'group' => $group,

--- a/tests/Feature/Events/JoinEventTest.php
+++ b/tests/Feature/Events/JoinEventTest.php
@@ -20,7 +20,9 @@ class JoinEventTest extends TestCase
     {
         $this->withoutExceptionHandling();
 
-        $group = factory(Group::class)->create();
+        $group = factory(Group::class)->create([
+                                                   'wordpress_post_id' => '99999'
+                                               ]);
         $event = factory(Party::class)->create(['group' => $group->idgroups]);
 
         $user = factory(User::class)->states('Restarter')->create();

--- a/tests/Feature/Groups/GroupCreateTest.php
+++ b/tests/Feature/Groups/GroupCreateTest.php
@@ -3,9 +3,13 @@
 namespace Tests\Feature\Groups;
 
 use App\Group;
+use App\Network;
 use App\Notifications\GroupConfirmed;
+use App\Party;
 use App\Role;
 use App\User;
+use Carbon\Carbon;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Notification;
 
@@ -81,5 +85,63 @@ class GroupCreateTest extends TestCase
         );
 
         $this->assertContains('Group updated!', $response->getContent());
+    }
+
+    public function testEventVisibility() {
+        // Create a network.
+        $network = factory(Network::class)->create();
+
+        // Create an unapproved group in that network.
+        $admin1 = factory(User::class)->state('Administrator')->create();
+        $this->actingAs($admin1);
+        $idgroups = $this->createGroup('Test Group', 'https://therestartproject.org', 'London', 'Some text.', true, false);
+        $group = Group::find($idgroups);
+        $network->addGroup($group);
+
+        // Create a host for the group.
+        $host = factory(User::class)->states('Host')->create();
+        $group->addVolunteer($host);
+        $group->makeMemberAHost($host);
+        $this->actingAs($host);
+
+        // Create an event on this as yet unapproved group.
+        $eventAttributes = factory(Party::class)->raw();
+        $eventAttributes['group'] = $idgroups;
+        $eventAttributes['link'] = 'https://therestartproject.org/';
+        $eventAttributes['event_start_utc'] = Carbon::parse('1pm tomorrow')->toIso8601String();
+        $eventAttributes['event_end_utc'] = Carbon::parse('3pm tomorrow')->toIso8601String();
+
+        $this->post('/party/create/', $eventAttributes);
+        $event = Party::latest()->first();
+        $this->assertEquals($host->id, $event->user_id);
+
+        // The event should be visible to the host.
+        $this->get('/party/view/'.$event->idevents)->assertSee($eventAttributes['venue']);
+        $this->get('/party')->assertSee($eventAttributes['venue']);
+
+        // And to a network coordinator
+        $coordinator = factory(User::class)->state('NetworkCoordinator')->create();
+        $network->addCoordinator($coordinator);
+        $this->actingAs($coordinator);
+        $this->get('/party/view/'.$event->idevents)->assertSee($eventAttributes['venue']);
+        $this->get('/party')->assertSee($eventAttributes['venue']);
+
+        // This event should not be visible to a Restarter, as the group is not yet approved.
+        $restarter = factory(User::class)->states('Restarter')->create();
+        $this->actingAs($restarter);
+        try {
+            $this->get('/party/view/'.$event->idevents)->assertDontSee($eventAttributes['venue']);
+            $this->assertTrue(false);
+        } catch (NotFoundHttpException $e) {}
+
+        $this->get('/party')->assertDontSee($eventAttributes['venue']);
+
+        // Now approve the group.
+        $group->wordpress_post_id = '99999';
+        $group->save();
+
+        // Should now be visible.
+        $this->get('/party/view/'.$event->idevents)->assertSee($eventAttributes['venue']);
+        $this->get('/party')->assertSee($eventAttributes['venue']);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -129,7 +129,7 @@ abstract class TestCase extends BaseTestCase
         Auth::user()->role = $role;
     }
 
-    public function createGroup($name = 'Test Group', $website = 'https://therestartproject.org', $location = 'London', $text = 'Some text.', $assert = true)
+    public function createGroup($name = 'Test Group', $website = 'https://therestartproject.org', $location = 'London', $text = 'Some text.', $assert = true, $approve = true)
     {
         $idgroups = null;
 
@@ -146,9 +146,12 @@ abstract class TestCase extends BaseTestCase
             $this->assertNotFalse(strpos($redirectTo, '/group/edit'));
             $p = strrpos($redirectTo, '/');
             $idgroups = substr($redirectTo, $p + 1);
-            $group = Group::find($idgroups);
-            $group->wordpress_post_id = '99999';
-            $group->save();
+
+            if ($approve) {
+                $group = Group::find($idgroups);
+                $group->wordpress_post_id = '99999';
+                $group->save();
+            }
 
             // Currently logged in user should be present, with status 1 = approved.
             $member = UserGroups::where('group', $idgroups)->first();


### PR DESCRIPTION
Add a method for view event permissions.  We should probably be using Laravel gates rather than Fixometer methods - tech debt?