### PR TITLE
RES-1673 Can't delete a group which has a deleted event.

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -236,9 +236,8 @@ class Group extends Model implements Auditable
         // Groups are deletable unless they have an event with a device.
         $ret = true;
 
-        $allEvents = Party::where('events.group', $this->idgroups)
+        $allEvents = Party::withTrashed()->where('events.group', $this->idgroups)
             ->get();
-
 
         // Send these to getEventStats() to speed things up a bit.
         $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -741,7 +741,7 @@ class GroupController extends Controller
         if (Auth::user()->hasRole('Administrator') && $group->canDelete()) {
             // We know we can delete the group; if it has any past events they must be empty, so delete all
             // events (including future).
-            $allEvents = Party::where('events.group', $id)->get();
+            $allEvents = Party::withTrashed()->where('events.group', $id)->get();
 
             foreach ($allEvents as $event) {
                 // Delete any users - these are not cascaded in the DB.

--- a/tests/Feature/Groups/GroupDeleteTest.php
+++ b/tests/Feature/Groups/GroupDeleteTest.php
@@ -63,13 +63,19 @@ class GroupDeleteTest extends TestCase
 
         // Add an event with a device - should not  be able to delete.
         $idevents = $this->createEvent($id, 'yesterday');
-        $this->createDevice($idevents, 'misc');
+        $iddevices = $this->createDevice($idevents, 'misc');
 
         $user = factory(\App\User::class)->states('Administrator')->create();
         $this->actingAs($user);
         $this->followingRedirects();
         $response = $this->get("/group/delete/$id");
         $this->assertContains('Sorry, but you do not have the permissions to perform that action.', $response->getContent());
+
+        // Delete the event - still shouldn't be deletable as a device exists.
+        Party::find($idevents)->delete();
+
+        $response = $this->get("/group/delete/$id");
+        $response->assertRedirect('/user/forbidden');
     }
 
     public function testCanDeleteWithDeletedEvent()
@@ -84,6 +90,8 @@ class GroupDeleteTest extends TestCase
                                                                         'event_end_utc' => '2000-01-0113:45:05+05:00',
                                                                         'group' => $id,
                                                                     ]);
+
+        // Should
         $event->delete();
         $response = $this->get("/group/delete/$id");
         $response->assertRedirect();


### PR DESCRIPTION
We have a check on whether groups are deletable - they're not if they have an event with a device.  But this check, and the code which processes the delete (to delete events, since we don't have cascading foreign keys) was ignoring deleted events.  So the group was showing as deletable but the delete was failing.