### PR TITLE
RES-1689 Don't notify users of group events if they are only invited.

### DIFF
--- a/app/Party.php
+++ b/app/Party.php
@@ -991,6 +991,7 @@ class Party extends Model implements Auditable
             $group_restarters = User::join('users_groups', 'users_groups.user', '=', 'users.id')
                 ->where('users_groups.group', $this->group)
                 ->where('users_groups.role', 4)
+                ->where('users_groups.status', 'like', 1)
                 ->select('users.*')
                 ->get();
 

--- a/tests/Feature/Groups/InviteGroupTest.php
+++ b/tests/Feature/Groups/InviteGroupTest.php
@@ -6,6 +6,8 @@ use App\Group;
 use App\Notifications\JoinGroup;
 use App\Notifications\NewGroupMember;
 use App\Helpers\Fixometer;
+use App\Notifications\NotifyRestartersOfNewEvent;
+use App\Party;
 use App\User;
 use DB;
 use Illuminate\Support\Facades\Notification;
@@ -51,7 +53,15 @@ class InviteGroupTest extends TestCase
             }
         );
 
-        // We should see that we have been invited.
+        // Create an event.  Should not generate a notification to users who are invited but not yet accepted.
+        $idevents = $this->createEvent($group->idgroups, 'tomorrow');
+        Party::find($idevents)->approve();
+
+        Notification::assertNotSentTo(
+            [$user], NotifyRestartersOfNewEvent::class
+        );
+
+        // We should see that we have been invited to the group.
         $this->actingAs($user);
         $response2 = $this->get('/group/view/'.$group->idgroups);
         $response2->assertSee('You have an invitation to this group.');
@@ -106,6 +116,15 @@ class InviteGroupTest extends TestCase
         $this->assertEquals(1, $initialGroup['all_confirmed_hosts_count']);
         $this->assertEquals(1, $initialGroup['all_restarters_count']);
         $this->assertEquals(1, $initialGroup['all_confirmed_restarters_count']);
+
+        // Create another event.  Should now generate a notification.
+        $this->actingAs($host);
+        $idevents = $this->createEvent($group->idgroups, '+7 day');
+        Party::find($idevents)->approve();
+
+        Notification::assertSentTo(
+            [$user], NotifyRestartersOfNewEvent::class
+        );
     }
 
     public function testInviteViaLink() {


### PR DESCRIPTION
We should not notify users of new events if they have been invited to a group but not yet accepted.