### PR TITLE
RES-1687 sentry

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -94,6 +94,13 @@ class ApiController extends Controller
     public static function groupStats($groupId)
     {
         $group = Group::where('idgroups', $groupId)->first();
+
+        if (!$group) {
+            return response()->json([
+                                        'message' => "Invalid group id $groupId",
+                                    ], 404);
+        }
+
         $stats = $group->getGroupStats();
 
         $result = [

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -970,44 +970,6 @@ class GroupController extends Controller
 
     public function volunteersNearby($groupid)
     {
-        if (isset($_GET['action']) && isset($_GET['code'])) {
-            $actn = $_GET['action'];
-            $code = $_GET['code'];
-
-            switch ($actn) {
-                case 'gu':
-                    $response['success'] = 'Group updated.';
-
-                    break;
-                case 'pe':
-                    $response['success'] = 'Party updated.';
-
-                    break;
-                case 'pc':
-                    $response['success'] = 'Party created.';
-
-                    break;
-                case 'ue':
-                    $response['success'] = 'Profile updated.';
-
-                    break;
-                case 'de':
-                    if ($code == 200) {
-                        $response['success'] = 'Party deleted.';
-                    } elseif ($code == 403) {
-                        $response['danger'] = 'Couldn\'t delete the party!';
-                    } elseif ($code == 500) {
-                        $response['warning'] = 'The party has been deleted, but <strong>something went wrong while deleting it from WordPress</strong>. <br /> You\'ll need to do that manually!';
-                    }
-
-                    break;
-                default: {
-                        $response['danger'] = 'Unexpected arguments';
-                        break;
-                    }
-            }
-        }
-
         $user = User::find(Auth::id());
 
         //Object Instances

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -1110,10 +1110,6 @@ class PartyController extends Controller
         return redirect()->back()->with('warning', __('events.review_requested_permissions'));
     }
 
-    // TODO: is this alive?
-    // It looks like recent-ish code, but I recall James mentioned recently that
-    // he couldn't delete events.  Perhaps it's disappeared from the interface?
-
     /**
      * Called via AJAX.
      * @param id The event id.

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -798,31 +798,6 @@ class PartyController extends Controller
         ]);
     }
 
-    public function getGroupEmails($event_id, $object = false)
-    {
-        $group_user_ids = UserGroups::where('group', Party::find($event_id)->group)
-            ->pluck('user')
-            ->toArray();
-
-        // Users already associated with the event.  Normally this would include the host, unless they've been
-        // removed.
-        // (Not including those invited but not RSVPed)
-        $event_user_ids = EventsUsers::where('event', $event_id)
-            ->where('status', 'like', '1')
-            ->pluck('user')
-            ->toArray();
-
-        $unique_user_ids = array_diff($group_user_ids, $event_user_ids);
-
-        if ($object) {
-            return User::whereIn('id', $unique_user_ids)->get();
-        }
-
-        $group_users = User::whereIn('id', $unique_user_ids)->pluck('email')->toArray();
-
-        return json_encode($group_users);
-    }
-
     /**
      * This is called via ajax in the Invite Volunteers to Event modal.
      * It finds the users associated with the group that the event is for,

--- a/app/Listeners/CreateDiscourseThreadForEvent.php
+++ b/app/Listeners/CreateDiscourseThreadForEvent.php
@@ -47,12 +47,12 @@ class CreateDiscourseThreadForEvent
         }
 
         // Get the user who created the event.
-        $users = User::find(EventsUsers::where('event', $partyId)->get());
+        $users = EventsUsers::where('event', $partyId)->get();
 
         if (!count($users)) {
             Log::error("Can't find event creator");
         } else {
-            $host = $users[0]->user;
+            $host = User::find($users[0]->user);
 
             try {
                 // We want the host to create the message, so use their username.  The API key should

--- a/routes/web.php
+++ b/routes/web.php
@@ -291,7 +291,6 @@ Route::group(['middleware' => ['auth', 'verifyUserConsent', 'ensureAPIToken']], 
         Route::get('/accept-invite/{id}/{hash}', 'PartyController@confirmInvite');
         Route::get('/cancel-invite/{id}', 'PartyController@cancelInvite');
         Route::post('/remove-volunteer', 'PartyController@removeVolunteer');
-        Route::get('/get-group-emails/{event_id}', 'PartyController@getGroupEmails');
         Route::get('/get-group-emails-with-names/{event_id}', 'PartyController@getGroupEmailsWithNames');
         Route::post('/update-quantity', 'PartyController@updateQuantity');
         Route::post('/image-upload/{id}', 'PartyController@imageUpload');

--- a/tests/Feature/Events/AttendanceTest.php
+++ b/tests/Feature/Events/AttendanceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\EventsUsers;
+use App\Group;
+use App\Helpers\Geocoder;
+use App\Helpers\RepairNetworkService;
+use App\Network;
+use App\Notifications\AdminModerationEvent;
+use App\Notifications\NotifyRestartersOfNewEvent;
+use App\Party;
+use App\User;
+use DB;
+use Faker\Generator as Faker;
+use Illuminate\Support\Facades\Notification;
+use Symfony\Component\DomCrawler\Crawler;
+use Tests\TestCase;
+
+class AttendanceTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->host = factory(User::class)->states('Administrator')->create();
+        $this->actingAs($this->host);
+
+        $this->group = factory(Group::class)->create();
+        $this->group->addVolunteer($this->host);
+        $this->group->makeMemberAHost($this->host);
+
+        // Create the event
+        $this->idevents = $this->createEvent($this->group->idgroups, '2000-01-01');
+        self::assertNotNull($this->idevents);
+
+        $this->party = $this->group->parties()->latest()->first();
+    }
+
+    public function testParticipants() {
+        // Initial count will be 0.
+        self::assertEquals(0, $this->party->pax);
+
+        $rsp = $this->post('/party/update-quantity', [
+            'event_id' => $this->idevents,
+            'quantity' => 3
+        ]);
+
+        self::assertTrue($rsp['success']);
+        $this->party->refresh();
+        self::assertEquals(3, $this->party->pax);
+    }
+
+
+    public function testVolunteers() {
+        // Initial count will be 1, for the host.
+        self::assertEquals(1, $this->party->volunteers);
+
+        $rsp = $this->post('/party/update-volunteerquantity', [
+            'event_id' => $this->idevents,
+            'quantity' => 4
+        ]);
+
+        self::assertTrue($rsp['success']);
+        $this->party->refresh();
+        self::assertEquals(4, $this->party->volunteers);
+    }
+}

--- a/tests/Feature/Groups/GroupEditTest.php
+++ b/tests/Feature/Groups/GroupEditTest.php
@@ -103,6 +103,15 @@ class GroupEditTest extends TestCase
         $response = $this->json('POST', '/group/image-upload/' . $group->idgroups, []);
         $response->assertOk();
         $this->assertEquals('success - image uploaded', $response->getContent());
+
+        // Delete the image.
+        $image = \DB::select(
+        \Illuminate\Support\Facades\DB::raw("SELECT idimages, path FROM images ORDER BY idimages DESC LIMIT 1"));
+        $idimages = $image[0]->idimages;
+        $path = $image[0]->path;
+        $response = $this->get("/group/image/delete/{$group->idgroups}/$idimages/$path");
+        $response->assertOk();
+        self::assertEquals('Thank you, the image has been deleted', $response->getContent());
     }
 
     /** @test */

--- a/tests/Feature/Stats/EventStatsTest.php
+++ b/tests/Feature/Stats/EventStatsTest.php
@@ -163,6 +163,11 @@ class EventStatsTest extends StatsTestCase
             $this->assertEquals($v, $result[$k], "Wrong value for $k => $v");
         }
 
+        // Get the wide stats page.
+        $response = $this->get('/party/stats/' . $event->idevents . '/wide');
+        $response->assertSuccessful();
+        $response->assertSee('<span id="ewaste-diverted-value">23</span>');
+
         // Check that the search page loads.
         $this->loginAsTestUser(Role::ADMINISTRATOR);
         $response = $this->get('/search');


### PR DESCRIPTION
1. Fix a Sentry error caused by getting stats for an invalid group id.
2. Fix a Sentry error creating Discourse thread.
3. Remove dead code for `get-group-emails` which is not used - probably superceded by `get-group-emails-with-names`.
4. Add extra tests for coverage.