### PR TITLE
RES-1685 email notifications

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -646,4 +646,31 @@ class Group extends Model implements Auditable
 
         return $timezone;
     }
+
+    // TODO We've started to refactor into scopes, but this isn't complete yet.
+    public function scopeMembers() {
+        return User::join('users_groups', 'users_groups.user', '=', 'users.id')
+            ->where('users_groups.group', $this->idgroups)
+            ->select('users.*');
+    }
+
+    public function scopeMembersUndeleted($query) {
+        $query = $query->members();
+        return $query->whereNull('users_groups.deleted_at');
+    }
+
+    public function scopeMembersJoined($query) {
+        $query = $query->membersUndeleted();
+        return $query->where('users_groups.status', 'like', 1);
+    }
+
+    public function scopeMembersRestarters($query) {
+        $query = $query->membersJoined();
+        return $query->where('users_groups.role', Role::RESTARTER);
+    }
+
+    public function scopeMembersHosts($query) {
+        $query = $query->membersJoined();
+        return $query->where('users_groups.role', Role::HOST);
+    }
 }

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -515,17 +515,14 @@ class GroupController extends Controller
         // Send emails to hosts of group to let them know.
         // (only those that have opted in to receiving emails).
         $user = User::find($user_group->user);
+        $group = Group::find($group_id);
 
-        $group_hosts = User::join('users_groups', 'users_groups.user', '=', 'users.id')
-            ->where('users_groups.group', $group_id)
-            ->where('users_groups.role', 3)
-            ->select('users.*')
-            ->get();
+        $group_hosts = $group->membersHosts();
 
-        if (! empty($group_hosts)) {
+        if ($group_hosts->count()) {
             Notification::send($group_hosts, new NewGroupMember([
                 'user_name' => $user->name,
-                'group_name' => Group::find($group_id)->name,
+                'group_name' => $group->name,
                 'group_url' => url('/group/view/'.$group_id),
             ]));
         }

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -520,7 +520,7 @@ class GroupController extends Controller
         $group_hosts = $group->membersHosts();
 
         if ($group_hosts->count()) {
-            Notification::send($group_hosts, new NewGroupMember([
+            Notification::send($group_hosts->get(), new NewGroupMember([
                 'user_name' => $user->name,
                 'group_name' => $group->name,
                 'group_url' => url('/group/view/'.$group_id),

--- a/app/Party.php
+++ b/app/Party.php
@@ -456,7 +456,7 @@ class Party extends Model implements Auditable
     }
 
     public function scopeMemberOfGroup($query, $userids = null) {
-        // Any approved events for groups that this user has joined (not just been invited to) and not left.
+
         $this->defaultUserIds($userids);
         $query = $query->approved();
         $query = $query->join('users_groups AS hfgug', 'hfgug.group', '=', 'events.group')
@@ -982,23 +982,17 @@ class Party extends Model implements Auditable
 
     public function approve()
     {
-        $group = Group::find($this->group);
+        $group = Group::findOrFail($this->group);
 
         // Only send notifications if the event is in the future.
         // We don't want to send emails to Restarters about past events being added.
         if ($this->isUpcoming()) {
-            // Retrieving all users from the User model whereby they allow you send emails but their role must not include group admins
-            $group_restarters = User::join('users_groups', 'users_groups.user', '=', 'users.id')
-                ->where('users_groups.group', $this->group)
-                ->where('users_groups.role', 4)
-                ->where('users_groups.status', 'like', 1)
-                ->select('users.*')
-                ->get();
+            $group_restarters = $group->membersRestarters();
 
             // If there are restarters against the group
-            if (! $group_restarters->isEmpty()) {
+            if (!$group_restarters->count()) {
                 // Send user a notification and email
-                Notification::send($group_restarters, new NotifyRestartersOfNewEvent([
+                Notification::send($group_restarters->get(), new NotifyRestartersOfNewEvent([
                                                                                          'event_venue' => $this->venue,
                                                                                          'event_url' => url('/party/view/'.$this->idevents),
                                                                                          'event_group' => $group->name,

--- a/app/Party.php
+++ b/app/Party.php
@@ -990,7 +990,7 @@ class Party extends Model implements Auditable
             $group_restarters = $group->membersRestarters();
 
             // If there are restarters against the group
-            if (!$group_restarters->count()) {
+            if ($group_restarters->count()) {
                 // Send user a notification and email
                 Notification::send($group_restarters->get(), new NotifyRestartersOfNewEvent([
                                                                                          'event_venue' => $this->venue,

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -306,6 +306,8 @@ class CreateEventTest extends TestCase
     /** @test */
     public function emails_sent_to_restarters_when_upcoming_event_approved()
     {
+        DB::connection()->enableQueryLog();
+
         $this->withoutExceptionHandling();
         $admin = factory(User::class)->state('Administrator')->create();
         $this->actingAs($admin);
@@ -558,5 +560,51 @@ class CreateEventTest extends TestCase
         $upcoming_events = Party::futureForUser()->get();
         self::assertEquals(1, $upcoming_events->count());
         self::assertEquals($idevents, $upcoming_events[0]->idevents);
+    }
+
+    /**
+     * @test
+     */
+    public function no_notification_after_leaving() {
+        Notification::fake();
+        $this->withoutExceptionHandling();
+
+        $host = factory(User::class)->states('Host')->create();
+        $this->actingAs($host);
+
+        $restarter = factory(User::class)->states('Restarter')->create();
+
+        $group = factory(Group::class)->create([
+            'wordpress_post_id' => '99999'
+        ]);
+
+        $group->addVolunteer($host);
+        $group->makeMemberAHost($host);
+        $group->addVolunteer($restarter);
+
+        // Remove volunteer.
+        $response = $this->get("/group/remove-volunteer/{$group->idgroups}/{$restarter->id}");
+        $response->assertSessionHas('success');
+
+        $eventData = factory(Party::class)->raw([
+                                                    'group' => $group->idgroups,
+                                                    'event_start_utc' => '2100-01-01T10:15:05+05:00',
+                                                    'event_end_utc' => '2100-01-0113:45:05+05:00',
+                                                    'latitude'=>'1',
+                                                    'longitude'=>'1'
+                                                ]);
+
+        // Create and approve an event.
+        $response = $this->post('/party/create/', $eventData);
+        $event = Party::latest()->first();
+        $eventData['wordpress_post_id'] = 100;
+        $eventData['id'] = $event->idevents;
+        $eventData['moderate'] = 'approve';
+        $response = $this->post('/party/edit/'.$event->idevents, $eventData);
+
+        // Shouldn't notify
+        Notification::assertNotSentTo(
+            [$restarter], NotifyRestartersOfNewEvent::class
+        );
     }
 }


### PR DESCRIPTION
Sorry, bad branch name - this is RES-1675.

Tests and fixes the case for this story, by introducing scopes to use rather than raw queries.  Also fixes another similar but less important case.

The various methods in `Group`, and raw queries which access `groups`/`user_groups`, could benefit from refactoring into scopes in the same way we did with `Party` a while back, but I think that's out of scope (pun intended).