### PR TITLE
RES-1700 In progress events not showing on group page.

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -339,12 +339,14 @@ class GroupController extends Controller
         $upcoming_events = Party::future()
             ->forGroup($group->idgroups)
             ->get();
-
+        $active_events = Party::active()
+            ->forGroup($group->idgroups)
+            ->get();
         $past_events = Party::past()
             ->forGroup($group->idgroups)
             ->get();
 
-        //Checking user for validatity
+        //Checking user for validity
         $in_group = ! empty(UserGroups::where('group', $groupid)
             ->where('user', $user->id)
             ->where(function ($query) {
@@ -375,7 +377,7 @@ class GroupController extends Controller
         $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
         $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
 
-        foreach (array_merge($upcoming_events->all(), $past_events->all()) as $event) {
+        foreach (array_merge($upcoming_events->all(), $active_events->all(), $past_events->all()) as $event) {
             $expanded_event = \App\Http\Controllers\PartyController::expandEvent($event, $group);
             // TODO: here we seem to expect group to be the group id, not the group object.
             // expandEvent seems to expect the object.
@@ -393,7 +395,6 @@ class GroupController extends Controller
             'userGroups' => $groups,
             'group' => $group,
             'profile' => $User->getProfile($user->id),
-            'upcomingparties' => $Party->findNextParties($group->idgroups),
             'allparties' => $allPastEvents,
             'devices' => $Device->ofThisGroup($group->idgroups),
             'device_count_status' => $Device->statusCount(),

--- a/resources/js/components/GroupEvents.vue
+++ b/resources/js/components/GroupEvents.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <CollapsibleSection class="lineheight" collapsed :count="upcoming.length" count-badge :heading-level="headingLevel">
+    <CollapsibleSection class="lineheight" collapsed :count="upcomingOrActive.length" count-badge :heading-level="headingLevel">
       <template slot="title">
         <div class="d-flex justify-content-between w-100">
         <div>
@@ -18,12 +18,12 @@
       </template>
       <template slot="content">
         <b-tabs class="ourtabs w-100">
-          <GroupEventsTab active :limit="limit" :events="upcoming" :canedit="canedit" :add-group-name="addGroupName" title="groups.upcoming_active" noneMessage="groups.no_upcoming_events" />
+          <GroupEventsTab active :limit="limit" :events="upcomingOrActive" :canedit="canedit" :add-group-name="addGroupName" title="groups.upcoming_active" noneMessage="groups.no_upcoming_events" />
           <GroupEventsTab :limit="limit" :events="past" :canedit="canedit" :add-group-name="addGroupName" title="groups.past" noneMessage="groups.no_past_events" past />
         </b-tabs>
       </template>
     </CollapsibleSection>
-    <CollapsibleSection class="lineheight mt-4" collapsed :count="upcoming.length" count-badge :heading-level="headingLevel" v-if="showOther">
+    <CollapsibleSection class="lineheight mt-4" collapsed :count="upcomingOrActive.length" count-badge :heading-level="headingLevel" v-if="showOther">
       <template slot="title">
         <div class="d-flex justify-content-between w-100">
           <div>
@@ -111,7 +111,8 @@ export default {
     },
     location: {
       type: String,
-      required: true
+      required: false,
+      default: null
     },
   },
   computed: {
@@ -124,8 +125,8 @@ export default {
     past() {
       return this.reverse.filter(e => e.finished && !e.nearby && !e.all)
     },
-    upcoming() {
-      return this.events.filter(e => e.upcoming && !e.nearby && !e.all)
+    upcomingOrActive() {
+      return this.events.filter(e => (e.upcoming || e.inprogress) && !e.nearby && !e.all)
     },
     nearby() {
       return this.events.filter(e => e.nearby)

--- a/tests/Feature/Groups/GroupViewTest.php
+++ b/tests/Feature/Groups/GroupViewTest.php
@@ -115,4 +115,22 @@ class GroupViewTest extends TestCase
             self::assertEquals(1, $stats['co2']);
         }
     }
+
+    public function testInProgressVisible() {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+        $id = $this->createGroup();
+        $this->assertNotNull($id);
+
+        factory(Party::class)->states('moderated')->create([
+                                                                    'event_start_utc' => Carbon::parse('1 hour ago')->toIso8601String(),
+                                                                    'event_end_utc' => Carbon::parse('4pm tomorrow')->toIso8601String(),
+                                                                    'group' => $id,
+                                                                ]);
+
+        // Event should show in list for group.
+        $response = $this->get("/group/view/$id");
+        $props = $this->getVueProperties($response);
+        $events = json_decode($props[1][':events'], true);
+        self::assertEquals(Party::latest()->first()->idevents, $events[0]['idevents']);
+    }
 }


### PR DESCRIPTION
The group page claims to show upcoming and active events, but in fact only shows upcoming.