### PR TITLE
RES-1729 typo in email preference string

### DIFF
--- a/app/Notifications/NewDiscourseMember.php
+++ b/app/Notifications/NewDiscourseMember.php
@@ -22,7 +22,7 @@ class NewDiscourseMember extends BaseNotification
             ->line(__('groups.talk_group_add_body', [
                 'group_name' => $this->arr['group_name']
             ]))
-            ->line(__('notifications.email_preference', [
+            ->line(__('notifications.email_preferences', [
                 'url' => url('/user/edit/' . $notifiable->id)
             ]));
     }

--- a/app/Notifications/RSVPEvent.php
+++ b/app/Notifications/RSVPEvent.php
@@ -26,7 +26,7 @@ class RSVPEvent extends BaseNotification
               'event' => $this->arr['event_venue']
           ], $locale))
           ->action(__('notifications.rsvp_action', [], $locale), $this->arr['event_url'])
-          ->line(__('notifications.email_preference', [
+          ->line(__('notifications.email_preferences', [
               'url' => url('/user/edit/' . $notifiable->id)
           ]));
     }


### PR DESCRIPTION
Was `email_preference` rather than `email_preferences`.

I don't think it's worth adding a test for the text in this case..  We are considering revamping notifications, and if we did that, then we might want to introduce standard headers and footers which are set in a single base notification class.