### PR TITLE
RES-1726 Notification counts wrong when marking notifications as read

### DIFF
--- a/resources/js/misc/notifications.js
+++ b/resources/js/misc/notifications.js
@@ -2,7 +2,7 @@ function toggleRead(event) {
     event.preventDefault();
 
     $button = $(this);
-    $counter = $('button.badge.badge-pill.badge-info span');
+    $counter = $('#notifications-badge .chat-count');
 
     $notificationsBadge = $('#notifications-badge');
 


### PR DESCRIPTION
I think the classes changed, so I've fixed the jQuery selector.

In the longer term this code should die and be replaced with an API call.  So I've not bothered fixing the very minor issue that if you have > 99 unread notifications, and you mark one as read, then it'll show 98 whereas it should really still show 99 (and would on a refresh)..