### PR TITLE
RES-1723 new API endpoints

### DIFF
--- a/app/Faultcat.php
+++ b/app/Faultcat.php
@@ -111,7 +111,7 @@ AND o.iddevices IS NULL
 SELECT COUNT(DISTINCT results.iddevices) as total FROM
 (SELECT
 o.iddevices,
-(SELECT o1.fault_type FROM devices_faults_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC LIMIT 1) AS winning_opinion,
+(SELECT o1.fault_type FROM devices_faults_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC, o1.fault_type ASC LIMIT 1) AS winning_opinion,
 ROUND((SELECT COUNT(o2.fault_type) as top_crowd_opinion_count FROM devices_faults_opinions o2 WHERE o2.iddevices = o.iddevices GROUP BY o2.fault_type ORDER BY top_crowd_opinion_count DESC LIMIT 1) /
 (SELECT COUNT(o2.fault_type) as all_votes FROM devices_faults_opinions o2 WHERE o2.iddevices = o.iddevices) * 100) AS top_crowd_opinion_percentage,
 COUNT(o.fault_type) AS all_crowd_opinions_count
@@ -141,7 +141,7 @@ WHERE a.fault_type != 'Misc'
 SELECT results.winning_opinion, COUNT(*) AS total FROM
 (SELECT
 o.iddevices,
-(SELECT o1.fault_type FROM devices_faults_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC LIMIT 1) AS winning_opinion,
+(SELECT o1.fault_type FROM devices_faults_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC, o1.fault_type ASC LIMIT 1) AS winning_opinion,
 ROUND((SELECT COUNT(o2.fault_type) as top_crowd_opinion_count FROM devices_faults_opinions o2 WHERE o2.iddevices = o.iddevices GROUP BY o2.fault_type ORDER BY top_crowd_opinion_count DESC LIMIT 1) /
 (SELECT COUNT(o2.fault_type) as all_votes FROM devices_faults_opinions o2 WHERE o2.iddevices = o.iddevices) * 100) AS top_crowd_opinion_percentage,
 COUNT(o.fault_type) AS all_crowd_opinions_count
@@ -172,7 +172,7 @@ ORDER BY total DESC
         $result['list_splits'] = DB::select("
 SELECT
 d.iddevices,
-(SELECT o1.fault_type FROM devices_faults_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC LIMIT 1) AS top_crowd_opinion,
+(SELECT o1.fault_type FROM devices_faults_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC, o1.fault_type ASC LIMIT 1) AS top_crowd_opinion,
 ROUND((SELECT COUNT(o2.fault_type) as top_crowd_opinion_count FROM devices_faults_opinions o2 WHERE o2.iddevices = o.iddevices GROUP BY o2.fault_type ORDER BY top_crowd_opinion_count DESC LIMIT 1) /
 (SELECT COUNT(o2.fault_type) as all_votes FROM devices_faults_opinions o2 WHERE o2.iddevices = o.iddevices) * 100) AS top_crowd_opinion_percentage,
 COUNT(o.fault_type) AS all_crowd_opinions_count,
@@ -203,7 +203,7 @@ HAVING
         DB::statement("CREATE TEMPORARY TABLE IF NOT EXISTS `devices_faults_temporary` AS
 SELECT
 o.iddevices,
-(SELECT o1.fault_type FROM devices_faults_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC LIMIT 1) AS winning_opinion,
+(SELECT o1.fault_type FROM devices_faults_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC, o1.fault_type ASC LIMIT 1) AS winning_opinion,
 ROUND((SELECT COUNT(o2.fault_type) as top_crowd_opinion_count FROM devices_faults_opinions o2 WHERE o2.iddevices = o.iddevices GROUP BY o2.fault_type ORDER BY top_crowd_opinion_count DESC LIMIT 1) /
 (SELECT COUNT(o2.fault_type) as all_votes FROM devices_faults_opinions o2 WHERE o2.iddevices = o.iddevices) * 100) AS top_crowd_opinion_percentage,
 COUNT(o.fault_type) AS all_crowd_opinions_count

--- a/app/Http/Controllers/API/NetworkController.php
+++ b/app/Http/Controllers/API/NetworkController.php
@@ -62,11 +62,14 @@ class NetworkController extends Controller
         $start = Carbon::parse($request->get('updated_start', '1970-01-01'))->setTimezone('UTC')->format('Y-m-d H:i:s');
         $end = Carbon::parse($request->get('updated_end', '3000-01-01'))->setTimezone('UTC')->format('Y-m-d H:i:s');
 
+        // We need to explicity select events.*, otherwise the updated_at values we get back are from the group_network
+        // table, which is mightily confusing.
         $events = Party::join('groups', 'groups.idgroups', '=', 'events.group')
             ->join('group_network', 'group_network.group_id', '=', 'groups.idgroups')
             ->where('group_network.network_id', $id)
             ->where('events.updated_at', '>=', $start)
             ->where('events.updated_at', '<=', $end)
+            ->select('events.*')
             ->get();
 
         return \App\Http\Resources\PartySummaryCollection::make($events);

--- a/app/Http/Controllers/API/NetworkController.php
+++ b/app/Http/Controllers/API/NetworkController.php
@@ -2,9 +2,14 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Group;
 use App\Http\Controllers\Controller;
 use App\Network;
+use App\Party;
 use Auth;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class NetworkController extends Controller
 {
@@ -29,9 +34,41 @@ class NetworkController extends Controller
         return \App\Http\Resources\Network::make($network);
     }
 
-    public function getNetworkGroupsv2($id)
+    public function getNetworkGroupsv2(Request $request, $id)
     {
         $network = Network::findOrFail($id);
-        return \App\Http\Resources\GroupSummaryCollection::make($network->groups);
+
+        // Get date filters.  We default to far past and far future so that we don't need multiple code branches.  We
+        // don't need to validate the date format - if they put junk in then they'll get junk matches back.
+        $start = Carbon::parse($request->get('updated_start', '1970-01-01'))->setTimezone('UTC')->toIso8601String();
+        $end = Carbon::parse($request->get('updated_end', '3000-01-01'))->setTimezone('UTC')->toIso8601String();
+
+        // We use a query rather than $network->groups so that the filtering by date is done in the database rather
+        // than getting all groups and filtering in PHP.  This is faster.
+        $groups = Group::join('group_network', 'group_network.group_id', '=', 'groups.idgroups')
+            ->where('group_network.network_id', $id)
+            ->where('groups.updated_at', '>=', $start)
+            ->where('groups.updated_at', '<=', $end)->get();
+
+        return \App\Http\Resources\GroupSummaryCollection::make($groups);
+    }
+
+    public function getNetworkEventsv2(Request $request, $id)
+    {
+        Network::findOrFail($id);
+
+        // Get date filters.  We default to far past and far future so that we don't need multiple code branches.  We
+        // don't need to validate the date format - if they put junk in then they'll get junk matches back.
+        $start = Carbon::parse($request->get('updated_start', '1970-01-01'))->setTimezone('UTC')->format('Y-m-d H:i:s');
+        $end = Carbon::parse($request->get('updated_end', '3000-01-01'))->setTimezone('UTC')->format('Y-m-d H:i:s');
+
+        $events = Party::join('groups', 'groups.idgroups', '=', 'events.group')
+            ->join('group_network', 'group_network.group_id', '=', 'groups.idgroups')
+            ->where('group_network.network_id', $id)
+            ->where('events.updated_at', '>=', $start)
+            ->where('events.updated_at', '<=', $end)
+            ->get();
+
+        return \App\Http\Resources\PartySummaryCollection::make($events);
     }
 }

--- a/app/Http/Resources/PartySummary.php
+++ b/app/Http/Resources/PartySummary.php
@@ -16,6 +16,10 @@ class PartySummary extends JsonResource
     public function toArray($request)
     {
         // We return information which can be public, and we rename fields to look more consistent.
+        //
+        // The updated_at field is always being returned NULL, even though it's set.  This will be some Eloquent
+        // peculiarity which I can't get to the bottom of.  So pull it from the resource.
+
         return [
             'id' => $this->idevents,
             'start' => $this->event_start_utc,
@@ -27,7 +31,7 @@ class PartySummary extends JsonResource
             'lat' => $this->latitude,
             'lng' => $this->longitude,
             'group' => \App\Http\Resources\GroupSummary::make($this->theGroup),
-            'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
+            'updated_at' => Carbon::parse($this->resource->updated_at)->toIso8601String(),
         ];
     }
 }

--- a/app/Http/Resources/PartySummary.php
+++ b/app/Http/Resources/PartySummary.php
@@ -19,7 +19,6 @@ class PartySummary extends JsonResource
         //
         // The updated_at field is always being returned NULL, even though it's set.  This will be some Eloquent
         // peculiarity which I can't get to the bottom of.  So pull it from the resource.
-
         return [
             'id' => $this->idevents,
             'start' => $this->event_start_utc,
@@ -31,7 +30,7 @@ class PartySummary extends JsonResource
             'lat' => $this->latitude,
             'lng' => $this->longitude,
             'group' => \App\Http\Resources\GroupSummary::make($this->theGroup),
-            'updated_at' => Carbon::parse($this->resource->updated_at)->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
         ];
     }
 }

--- a/app/Mobifix.php
+++ b/app/Mobifix.php
@@ -95,7 +95,7 @@ AND o.iddevices IS NULL
 SELECT COUNT(DISTINCT results.iddevices) as total FROM
 (SELECT
 o.iddevices,
-(SELECT o1.fault_type FROM devices_faults_mobiles_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC LIMIT 1) AS winning_opinion,
+(SELECT o1.fault_type FROM devices_faults_mobiles_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC, o1.fault_type ASC LIMIT 1) AS winning_opinion,
 ROUND((SELECT COUNT(o2.fault_type) as top_crowd_opinion_count FROM devices_faults_mobiles_opinions o2 WHERE o2.iddevices = o.iddevices GROUP BY o2.fault_type ORDER BY top_crowd_opinion_count DESC LIMIT 1) /
 (SELECT COUNT(o2.fault_type) as all_votes FROM devices_faults_mobiles_opinions o2 WHERE o2.iddevices = o.iddevices) * 100) AS top_crowd_opinion_percentage,
 COUNT(o.fault_type) AS all_crowd_opinions_count
@@ -117,7 +117,7 @@ FROM devices_faults_mobiles_adjudicated a
 SELECT results.winning_opinion, COUNT(*) AS total FROM
 (SELECT
 o.iddevices,
-(SELECT o1.fault_type FROM devices_faults_mobiles_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC LIMIT 1) AS winning_opinion,
+(SELECT o1.fault_type FROM devices_faults_mobiles_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC, o1.fault_type ASC LIMIT 1) AS winning_opinion,
 ROUND((SELECT COUNT(o2.fault_type) as top_crowd_opinion_count FROM devices_faults_mobiles_opinions o2 WHERE o2.iddevices = o.iddevices GROUP BY o2.fault_type ORDER BY top_crowd_opinion_count DESC LIMIT 1) /
 (SELECT COUNT(o2.fault_type) as all_votes FROM devices_faults_mobiles_opinions o2 WHERE o2.iddevices = o.iddevices) * 100) AS top_crowd_opinion_percentage,
 COUNT(o.fault_type) AS all_crowd_opinions_count
@@ -141,7 +141,7 @@ ORDER BY total DESC
         $result['list_splits'] = DB::select("
 SELECT
 d.iddevices,
-(SELECT o1.fault_type FROM devices_faults_mobiles_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC LIMIT 1) AS top_crowd_opinion,
+(SELECT o1.fault_type FROM devices_faults_mobiles_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC, o1.fault_type ASC LIMIT 1) AS top_crowd_opinion,
 ROUND((SELECT COUNT(o2.fault_type) as top_crowd_opinion_count FROM devices_faults_mobiles_opinions o2 WHERE o2.iddevices = o.iddevices GROUP BY o2.fault_type ORDER BY top_crowd_opinion_count DESC LIMIT 1) /
 (SELECT COUNT(o2.fault_type) as all_votes FROM devices_faults_mobiles_opinions o2 WHERE o2.iddevices = o.iddevices) * 100) AS top_crowd_opinion_percentage,
 COUNT(o.fault_type) AS all_crowd_opinions_count,
@@ -172,7 +172,7 @@ HAVING
         DB::statement("CREATE TEMPORARY TABLE IF NOT EXISTS `devices_faults_mobiles_temporary` AS
 SELECT
 o.iddevices,
-(SELECT o1.fault_type FROM devices_faults_mobiles_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC LIMIT 1) AS winning_opinion,
+(SELECT o1.fault_type FROM devices_faults_mobiles_opinions o1 WHERE o1.iddevices = o.iddevices GROUP BY o1.fault_type ORDER BY COUNT(o1.fault_type) DESC, o1.fault_type ASC LIMIT 1) AS winning_opinion,
 ROUND((SELECT COUNT(o2.fault_type) as top_crowd_opinion_count FROM devices_faults_mobiles_opinions o2 WHERE o2.iddevices = o.iddevices GROUP BY o2.fault_type ORDER BY top_crowd_opinion_count DESC LIMIT 1) /
 (SELECT COUNT(o2.fault_type) as all_votes FROM devices_faults_mobiles_opinions o2 WHERE o2.iddevices = o.iddevices) * 100) AS top_crowd_opinion_percentage,
 COUNT(o.fault_type) AS all_crowd_opinions_count

--- a/app/Party.php
+++ b/app/Party.php
@@ -46,7 +46,7 @@ class Party extends Model implements Auditable
         'timezone',
         'user_id'
     ];
-    protected $hidden = ['created_at', 'updated_at', 'deleted_at', 'frequency', 'group', 'group', 'user_id', 'wordpress_post_id', 'cancelled', 'devices_updated_at'];
+    protected $hidden = ['created_at', 'deleted_at', 'frequency', 'group', 'group', 'user_id', 'wordpress_post_id', 'cancelled', 'devices_updated_at'];
 
     // Append data to Model
     protected $appends = ['participants', 'ShareableLink', 'event_date_local', 'start_local', 'end_local'];

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,5 +83,6 @@ Route::group(['prefix' => 'v2'], function() {
         Route::get('/', 'API\NetworkController@getNetworksv2');
         Route::get('{id}', 'API\NetworkController@getNetworkv2');
         Route::get('{id}/groups', 'API\NetworkController@getNetworkGroupsv2');
+        Route::get('{id}/events', 'API\NetworkController@getNetworkEventsv2');
     });
 });

--- a/tests/Feature/Networks/APIv2NetworkTest.php
+++ b/tests/Feature/Networks/APIv2NetworkTest.php
@@ -133,24 +133,28 @@ class APIv2NetworkTest extends TestCase
                                                                         'group' => $group->idgroups,
                                                                     ]);
 
+        // Manually set the updated_at fields so that we can check they are returned correctly.
+        DB::statement(DB::raw("UPDATE events SET updated_at = '2011-01-01 12:34'"));
+        DB::statement(DB::raw("UPDATE `groups` SET updated_at = '2011-01-02 12:34'"));
+
         $response = $this->get("/api/v2/networks/{$network->id}/events");
         $response->assertSuccessful();
         $json = json_decode($response->getContent(), true)['data'];
         $this->assertEquals(1, count($json));
         $this->assertEquals($event->idevents, $json[0]['id']);
-        $this->assertTrue(array_key_exists('updated_at', $json[0]));
-        $this->assertTrue(array_key_exists('updated_at', $json[0]['group']));
+        $this->assertEquals('2011-01-01T12:34:00+00:00', $json[0]['updated_at']);
+        $this->assertEquals('2011-01-02T12:34:00+00:00', $json[0]['group']['updated_at']);
 
         # Test updated filters.
-        $start = Carbon::now()->subDays(1)->toIso8601String();
-        $end = Carbon::now()->addDays(1)->toIso8601String();
+        $start = '2011-01-01T10:34:00+00:00';
+        $end = '2011-01-01T14:34:00+00:00';
         $response = $this->get("/api/v2/networks/{$network->id}/events?updated_start=" . urlencode($start) . "&updated_end=" . urlencode($end));
         $response->assertSuccessful();
         $json = json_decode($response->getContent(), true)['data'];
         $this->assertEquals(1, count($json));
 
-        $start = Carbon::now()->addDays(1)->toIso8601String();
-        $end = Carbon::now()->addDays(2)->toIso8601String();
+        $start = '2011-01-01T15:34:00+00:00';
+        $end = '2011-01-01T16:34:00+00:00';
         $response = $this->get("/api/v2/networks/{$network->id}/events?updated_start=" . urlencode($start) . "&updated_end=" . urlencode($end));
         $response->assertSuccessful();
         $json = json_decode($response->getContent(), true)['data'];

--- a/tests/Feature/Networks/APIv2NetworkTest.php
+++ b/tests/Feature/Networks/APIv2NetworkTest.php
@@ -6,6 +6,7 @@ use App\Group;
 use App\Network;
 use App\Party;
 use App\User;
+use Carbon\Carbon;
 use DB;
 use Tests\TestCase;
 
@@ -93,6 +94,21 @@ class APIv2NetworkTest extends TestCase
         } catch (\Exception $e) {
             error_log($e->getMessage());
         }
+
+        // Test updated_at filters.
+        $start = Carbon::now()->subDays(1)->toIso8601String();
+        $end = Carbon::now()->addDays(1)->toIso8601String();
+        $response = $this->get("/api/v2/networks/{$network->id}/groups?updated_start=" . urlencode($start) . "&updated_end=" . urlencode($end));
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true)['data'];
+        $this->assertEquals(1, count($json));
+
+        $start = Carbon::now()->addDays(1)->toIso8601String();
+        $end = Carbon::now()->addDays(2)->toIso8601String();
+        $response = $this->get("/api/v2/networks/{$network->id}/groups?updated_start=" . urlencode($start) . "&updated_end=" . urlencode($end));
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true)['data'];
+        $this->assertEquals(0, count($json));
     }
 
     public function providerTrueFalse() {
@@ -100,5 +116,44 @@ class APIv2NetworkTest extends TestCase
             [false],
             [true],
         ];
+    }
+
+    public function testListEvents() {
+        $network = factory(Network::class)->create([
+                                                       'name' => 'Restart',
+                                                       'events_push_to_wordpress' => true,
+                                                   ]);
+        $group = factory(Group::class)->create();
+        $network->addGroup($group);
+
+        // Create event for group
+        $event = factory(Party::class)->states('moderated')->create([
+                                                                        'event_start_utc' => '2038-01-01T00:00:00Z',
+                                                                        'event_end_utc' => '2038-01-01T02:00:00Z',
+                                                                        'group' => $group->idgroups,
+                                                                    ]);
+
+        $response = $this->get("/api/v2/networks/{$network->id}/events");
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true)['data'];
+        $this->assertEquals(1, count($json));
+        $this->assertEquals($event->idevents, $json[0]['id']);
+        $this->assertTrue(array_key_exists('updated_at', $json[0]));
+        $this->assertTrue(array_key_exists('updated_at', $json[0]['group']));
+
+        # Test updated filters.
+        $start = Carbon::now()->subDays(1)->toIso8601String();
+        $end = Carbon::now()->addDays(1)->toIso8601String();
+        $response = $this->get("/api/v2/networks/{$network->id}/events?updated_start=" . urlencode($start) . "&updated_end=" . urlencode($end));
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true)['data'];
+        $this->assertEquals(1, count($json));
+
+        $start = Carbon::now()->addDays(1)->toIso8601String();
+        $end = Carbon::now()->addDays(2)->toIso8601String();
+        $response = $this->get("/api/v2/networks/{$network->id}/events?updated_start=" . urlencode($start) . "&updated_end=" . urlencode($end));
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true)['data'];
+        $this->assertEquals(0, count($json));
     }
 }


### PR DESCRIPTION
1. Add an endpoint to list events of a network.
2. Add `updated_start` and `updated_end` to that plus listing the groups of a network.
3. Possible fix for some test flakiness - add an extra ORDER BY to query on fault opinions to make it deterministic in cases where there are equal numbers of opinions.