### PR TITLE
RES-1751 Invited attendees missing from event

### DIFF
--- a/resources/js/components/EventPage.vue
+++ b/resources/js/components/EventPage.vue
@@ -151,7 +151,7 @@ export default {
 
     this.$store.dispatch('attendance/set', {
       idevents: this.idevents,
-      attendees: this.attendance
+      attendees: [...this.attendance, ...this.invitations]
     })
 
     if (window && window.location && window.location.hash) {


### PR DESCRIPTION
The client side code tries to deal with attendees as a single list with a flag that says whether they are confirmed.  The server passes back two lists, and the client forgot to use the invited one.
