### PR TITLE
RES-1746 Group still shows after leaving until refresh

### DIFF
--- a/resources/js/components/GroupsTable.vue
+++ b/resources/js/components/GroupsTable.vue
@@ -175,7 +175,8 @@ export default {
       searchCountry: null,
       searchShow: false,
       searchTags: null,
-      show: 3
+      show: 3,
+      left: []
     }
   },
   computed: {
@@ -214,6 +215,10 @@ export default {
 
             match &= tagsInCommon.length > 0
           }
+        }
+
+        if (this.left.includes(g.idgroups)) {
+          match = false
         }
 
         return match
@@ -306,10 +311,12 @@ export default {
     leaveGroup(idgroups) {
       this.$refs['confirmLeave-' + idgroups].show()
     },
-    leaveConfirmed(idgroups) {
-      this.$store.dispatch('groups/unfollow', {
+    async leaveConfirmed(idgroups) {
+      await this.$store.dispatch('groups/unfollow', {
         idgroups: idgroups
       })
+
+      this.left.push(idgroups)
     },
     distance(dist ) {
       if (dist < 5) {


### PR DESCRIPTION
This is unrelated to the previous case.

Until we make more progress on using an API, we pass data via props.  This means that we don't get the full benefit of a reactive store - in cases like this we'd leave the group, remove it from the store, and then the table would update.  I've added a workaround for now, as moving to an API for our list of groups is a bit bigger than this bug can support.