### PR TITLE
RES-1345 upload photos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,9 @@ jobs:
       # Coveralls is pernickety about the location it uploads from existing.
       - run: mkdir build; mkdir build/logs; php vendor/bin/php-coveralls -v -x tests/clover.xml
 
+      # Zap groups set up by the UT; this can confuse Playwright tests.
+      - run: mysql --host="127.0.0.1" -u root -ps3cr3t -e "use restarters_db;SET foreign_key_checks=0;DELETE FROM groups WHERE location IS NULL;SET foreign_key_checks=1;"
+
       # Run the Playwright tests.
       # Ignore the return code from the tinker; the user might exist from the phpunit tests.  If it doesn't and
       # the create fails, the tests will fail too.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       - run: php artisan migrate
 
       - run: wget -O phpunit https://phar.phpunit.de/phpunit-7.phar ; chmod +x phpunit
-      - run: mkdir uploads
+      - run: mkdir public/uploads
 
       # Wait for Discourse to finish initialising.
       - run: while ! nc -z restarters_discourse 80; do sleep 1 ; done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,10 @@ jobs:
       - run: php artisan migrate
 
       - run: wget -O phpunit https://phar.phpunit.de/phpunit-7.phar ; chmod +x phpunit
+
+      # The phpunit and playwright tests require an uploads directory in a slightly different place.  Not really
+      # worth fixing.
+      - run: mkdir uploads
       - run: mkdir public/uploads
 
       # Wait for Discourse to finish initialising.

--- a/app/Helpers/FixometerFile.php
+++ b/app/Helpers/FixometerFile.php
@@ -25,6 +25,11 @@ class FixometerFile extends Model
         }
     }
 
+    public function copy($from, $to) {
+        // This is for phpunit tests.
+        copy($from, $to);
+    }
+
     /**
      * receives the POST data from an HTML form
      * processes file upload and saves
@@ -184,25 +189,12 @@ class FixometerFile extends Model
         }
     }
 
-    public function deleteImage($id, $path)
+    public function deleteImage($idxref)
     {
-        unlink($_SERVER['DOCUMENT_ROOT'].'/uploads/'.basename($path));
-
-        $sql = 'DELETE FROM `images` WHERE `idimages` = :id';
-
-        try {
-            return DB::delete(DB::raw($sql), ['id' => $id]);
-        } catch (\Illuminate\Database\QueryException $e) {
-            return db($e);
-        }
-
-        $sql = 'DELETE FROM `xref` WHERE `object` = :id AND `object_type` = '.env('TBL_IMAGES');
-
-        try {
-            return DB::delete(DB::raw($sql), ['id' => $id]);
-        } catch (\Illuminate\Database\QueryException $e) {
-            return db($e);
-        }
+        // Delete the xref.  This is sufficient to stop the image being attached to the device.  We leave the
+        // file in existence in case we want it later for debugging/mining.
+        $sql = 'DELETE FROM `xref` WHERE `idxref` = :id AND `object_type` = '.env('TBL_IMAGES');
+        DB::delete(DB::raw($sql), ['id' => $idxref]);
     }
 
     public function simpleUpload($file, $object_id, $object = 'device', $title = null)
@@ -230,5 +222,126 @@ class FixometerFile extends Model
                 $xref->createXref(true);
             }
         }
+    }
+
+    /**
+     * @param $tmp_name
+     * @param string $lpath
+     * @param bool $filename
+     * @param $type
+     * @param $profile
+     * @param $crop
+     * @param $reference
+     * @param $referenceType
+     * @return bool
+     */
+    private function createImage(
+        $tmp_name,
+        $copy,
+        $lpath,
+        $filename,
+        $type,
+        $profile,
+        $crop,
+        $reference,
+        $referenceType
+    ): bool {
+        if ($copy) {
+            if (!$this->copy($tmp_name, $lpath)) {
+                return false;
+            }
+        } else {
+            if (!$this->move($tmp_name, $lpath)) {
+                return false;
+            }
+        }
+
+        $data = [];
+        $this->path = $lpath;
+        $data['path'] = $this->file;
+
+        // Fix orientation
+        Image::make($lpath)->orientate()->save($lpath);
+
+        if ($type === 'image')
+        {
+            $size = getimagesize($this->path);
+            $data['width'] = $size[0];
+            $data['height'] = $size[1];
+
+            if ($profile)
+            {
+                $data['alt_text'] = 'Profile Picture';
+            }
+
+            if ($data['width'] > $data['height'])
+            {
+                $resize_height = true;
+            } else
+            {
+                $resize_height = false;
+            }
+
+            $thumbSize = 80;
+            $midSize = 260;
+
+            // Let's make images, which we will resize or crop
+            $thumb = Image::make($lpath);
+            $mid = Image::make($lpath);
+
+            if ($resize_height)
+            { // Resize before crop
+                $thumb->resize(null, $thumbSize, function ($constraint)
+                {
+                    $constraint->aspectRatio();
+                });
+
+                $mid->resize(null, $midSize, function ($constraint)
+                {
+                    $constraint->aspectRatio();
+                });
+            } else
+            {
+                $thumb->resize($thumbSize, null, function ($constraint)
+                {
+                    $constraint->aspectRatio();
+                });
+
+                $mid->resize($midSize, null, function ($constraint)
+                {
+                    $constraint->aspectRatio();
+                });
+            }
+
+            if ($crop)
+            {
+                $thumb->crop($thumbSize, $thumbSize);
+                $mid->crop($midSize, $midSize);
+            }
+
+            $thumb->save($_SERVER['DOCUMENT_ROOT'] . '/uploads/' . 'thumbnail_' . $filename, 85);
+            $mid->save($_SERVER['DOCUMENT_ROOT'] . '/uploads/' . 'mid_' . $filename, 85);
+
+            $this->table = 'images';
+            $Images = new Images;
+
+            $image = $Images->create($data)->id;
+
+            if (is_numeric($image) && !is_null($reference) && !is_null($referenceType))
+            {
+                Xref::create([
+                                 'object' => $image,
+                                 'object_type' => env('TBL_IMAGES'),
+                                 'reference' => $reference,
+                                 'reference_type' => $referenceType,
+                             ]);
+            }
+        }
+
+        return $filename;
+    }
+
+    public function copyImage($idimages) {
+
     }
 }

--- a/app/Helpers/FixometerFile.php
+++ b/app/Helpers/FixometerFile.php
@@ -146,6 +146,8 @@ class FixometerFile extends Model
 
             return $filename;
         }
+
+        return null;
     }
 
     /**

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -404,8 +404,13 @@ class DeviceController extends Controller
                     // We are adding a photo for a device that hasn't yet been added.  Upload the file. We will add
                     // them to the device once the device is created.
                     $fn = $file->upload('file', 'image', $id, env('TBL_DEVICES'), true, false, true);
-                    $File = new \FixometerFile;
-                    $images = $File->findImages(env('TBL_DEVICES'), $id);
+
+                    if ($fn) {
+                        $File = new \FixometerFile;
+                        $images = $File->findImages(env('TBL_DEVICES'), $id);
+                    } else {
+                        return 'fail - image could not be uploaded';
+                    }
                 }
             }
 

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -3,11 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Brands;
-use App\Category;
 use App\Cluster;
 use App\Device;
-use App\DeviceList;
-use App\DeviceUrl;
 use App\Events\DeviceCreatedOrUpdated;
 use App\EventsUsers;
 use App\Group;
@@ -16,6 +13,7 @@ use App\Notifications\AdminAbnormalDevices;
 use App\Party;
 use App\User;
 use App\UserGroups;
+use App\Xref;
 use Auth;
 use FixometerFile;
 use Illuminate\Http\Request;
@@ -95,6 +93,8 @@ class DeviceController extends Controller
         $quantity = $request->input('quantity');
         $event_id = $request->input('event_id');
         $barrier = $request->input('barrier');
+
+        $iddevices = $request->input('iddevices');
 
         // Get party for later
         $event = Party::find($event_id);
@@ -196,6 +196,22 @@ class DeviceController extends Controller
             }
 
             $device[$i]->barrier = $barriers;
+
+            if ($iddevices && $iddevices < 0) {
+                // We might have some photos uploaded for this device.  Record them against this device instance.
+                // Each instance of a device shares the same underlying photo file.
+                $File = new \FixometerFile;
+                $images = $File->findImages(env('TBL_DEVICES'), $iddevices);
+                error_log("Find draft iamges for $iddevices " . count($images));
+                foreach ($images as $image) {
+                    error_log("Get xref {$image->idxref}");
+                    $xref = Xref::findOrFail($image->idxref);
+                    error_log("Copy for {$device[$i]->iddevices}");
+                    $xref->copy($device[$i]->iddevices);
+                }
+
+                $device[$i]->images = $device[$i]->getImages();
+            }
         }
         // end quantity loop
 
@@ -381,9 +397,19 @@ class DeviceController extends Controller
 
             if (isset($_FILES) && ! empty($_FILES)) {
                 $file = new FixometerFile;
-                $fn = $file->upload('file', 'image', $id, env('TBL_DEVICES'), true, false, true);
-                $device = Device::find($id);
-                $images = $device->getImages();
+
+                if ($id > 0) {
+                    // We are adding a photo to an existing device.
+                    $fn = $file->upload('file', 'image', $id, env('TBL_DEVICES'), true, false, true);
+                    $device = Device::find($id);
+                    $images = $device->getImages();
+                } else {
+                    // We are adding a photo for a device that hasn't yet been added.  Upload the file. We will add
+                    // them to the device once the device is created.
+                    $fn = $file->upload('file', 'image', $id, env('TBL_DEVICES'), true, false, true);
+                    $File = new \FixometerFile;
+                    $images = $File->findImages(env('TBL_DEVICES'), $id);
+                }
             }
 
             // Return the current set of images for this device so that the client doesn't need to merge.
@@ -393,23 +419,39 @@ class DeviceController extends Controller
                 'images' => $images,
             ]);
         } catch (\Exception $e) {
+            error_log("Exception  " . $e->getMessage());
             return 'fail - image could not be uploaded';
         }
     }
 
-    public function deleteImage($device_id, $id, $path)
+    public function deleteImage($device_id, $idxref)
     {
         $user = Auth::user();
+        error_log("Delete image $idxref for device $device_id");
 
-        $event_id = Device::find($device_id)->event;
-        $in_event = EventsUsers::where('event', $event_id)->where('user', Auth::user()->id)->first();
-        if (Fixometer::hasRole($user, 'Administrator') || is_object($in_event)) {
+        if ($device_id > 0) {
+            // We are deleting a photo from an existing device.
+            $event_id = Device::find($device_id)->event;
+            $in_event = EventsUsers::where('event', $event_id)->where('user', Auth::user()->id)->first();
+            error_log("Event id $event_id in event " . print_r($in_event, true));
+            if (Fixometer::hasRole($user, 'Administrator') || is_object($in_event)) {
+                $Image = new FixometerFile;
+                $Image->deleteImage($idxref);
+
+                return redirect()->back()->with('message', 'Thank you, the image has been deleted');
+            }
+
+            return redirect()->back()->with('message', 'Sorry, but the image can\'t be deleted');
+        } else {
+            // We are deleting a photo from a device which has not yet been added.
+            //
+            // There is a slight security issue here, in that one user could delete the photos from devices which
+            // are in the process of being added by another user.  The chances of this being a real issue are very low.
+            error_log("Delete from not added");
             $Image = new FixometerFile;
-            $Image->deleteImage($id, basename($path));
+            $Image->deleteImage($idxref);
 
             return redirect()->back()->with('message', 'Thank you, the image has been deleted');
         }
-
-        return redirect()->back()->with('message', 'Sorry, but the image can\'t be deleted');
     }
 }

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -202,11 +202,8 @@ class DeviceController extends Controller
                 // Each instance of a device shares the same underlying photo file.
                 $File = new \FixometerFile;
                 $images = $File->findImages(env('TBL_DEVICES'), $iddevices);
-                error_log("Find draft iamges for $iddevices " . count($images));
                 foreach ($images as $image) {
-                    error_log("Get xref {$image->idxref}");
                     $xref = Xref::findOrFail($image->idxref);
-                    error_log("Copy for {$device[$i]->iddevices}");
                     $xref->copy($device[$i]->iddevices);
                 }
 
@@ -427,13 +424,11 @@ class DeviceController extends Controller
     public function deleteImage($device_id, $idxref)
     {
         $user = Auth::user();
-        error_log("Delete image $idxref for device $device_id");
 
         if ($device_id > 0) {
             // We are deleting a photo from an existing device.
             $event_id = Device::find($device_id)->event;
             $in_event = EventsUsers::where('event', $event_id)->where('user', Auth::user()->id)->first();
-            error_log("Event id $event_id in event " . print_r($in_event, true));
             if (Fixometer::hasRole($user, 'Administrator') || is_object($in_event)) {
                 $Image = new FixometerFile;
                 $Image->deleteImage($idxref);
@@ -447,7 +442,6 @@ class DeviceController extends Controller
             //
             // There is a slight security issue here, in that one user could delete the photos from devices which
             // are in the process of being added by another user.  The chances of this being a real issue are very low.
-            error_log("Delete from not added");
             $Image = new FixometerFile;
             $Image->deleteImage($idxref);
 

--- a/app/Xref.php
+++ b/app/Xref.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Xref extends Model
 {
     protected $table = 'xref';
+    protected $primaryKey = 'idxref';
 
     public $timestamps = false;
 
@@ -17,8 +18,6 @@ class Xref extends Model
     protected $refType;
 
     private $index;
-    private $search_id;
-    private $search_type;
 
     /**
      * The attributes that are mass assignable.
@@ -26,34 +25,6 @@ class Xref extends Model
      * @var array
      */
     protected $fillable = ['object', 'object_type', 'reference', 'reference_type'];
-
-    /**
-     * returns object with cross-references to selected
-     * ID and TABLE.
-     * @ $index can be 'object' || 'reference'
-     *   this selects in which direction to look
-     * */
-    public function findXref()
-    {
-        if ($this->index !== false) {
-            $sql = 'SELECT * FROM `'.$this->table.'`
-                    WHERE `'.$this->index.'` = :id
-                    AND `'.$this->index.'_type` = :type';
-
-            try {
-                return DB::select(DB::raw($sql), ['id' => $this->search_id, 'type' => $this->search_type]);
-            } catch (\Illuminate\Database\QueryException $e) {
-                return false;
-            }
-        } else {
-            return false;
-        }
-    }
-
-    public function findFullXref()
-    {
-        //switch ($table
-    }
 
     public function createXref($clear = true)
     {
@@ -102,5 +73,17 @@ class Xref extends Model
     public function image()
     {
         return $this->hasOne(\App\Images::class, 'idimages', 'object');
+    }
+
+
+    public function copy($reference) {
+        error_log("Copy {$this->idxref} to {$reference}");
+
+        return Xref::create([
+                         'object' => $this->object,
+                         'object_type' => $this->object_type,
+                         'reference' => $reference,
+                         'reference_type' => $this->reference_type,
+                     ]);
     }
 }

--- a/resources/js/components/DeviceImage.vue
+++ b/resources/js/components/DeviceImage.vue
@@ -32,7 +32,6 @@ export default {
       this.$refs.confirm.show()
     },
     zoom() {
-      console.log("Zoom")
       this.$refs.modal.show()
     }
   }

--- a/resources/js/components/DeviceImages.vue
+++ b/resources/js/components/DeviceImages.vue
@@ -1,17 +1,14 @@
 <template>
   <div>
-    <div class="device-photo-layout" v-if="!add">
-      <label v-if="!add">
+    <div class="device-photo-layout">
+      <label>
         {{ __('devices.images') }}
       </label>
       <div class="d-flex flex-wrap device-photos dropzone-previews">
-        <FileUploader :url="'/device/image-upload/' + device.iddevices" v-if="edit && !disabled" previews-container=".device-photos" @uploaded="uploaded($event)" />
+        <FileUploader :url="uploadURL" v-if="(edit || add) && !disabled" previews-container=".device-photos" @uploaded="uploaded($event)" />
         <DeviceImage v-for="image in images" :key="'img-' + image.path" :image="image" @remove="$emit('remove', image)" :disabled="disabled" />
       </div>
     </div>
-    <p class="p-1 form-text" v-else>
-      {{ __('devices.images_on_edit') }}
-    </p>
   </div>
 </template>
 <script>
@@ -47,21 +44,27 @@ export default {
     },
   },
   computed: {
+    idtouse() {
+      return this.device ? this.device.iddevices : null
+    },
     images() {
       // TODO LATER The images are currently added/removed/deleted immediately, and so we get them from the store.
       // This should be deferred until the save.
-      if (this.device) {
-        return this.$store.getters['devices/imagesByDevice'](this.device.iddevices)
+      if (this.idtouse) {
+        return this.$store.getters['devices/imagesByDevice'](this.idtouse)
       } else {
         return []
       }
     },
+    uploadURL() {
+      return '/device/image-upload/' + this.idtouse
+    }
   },
   methods: {
     uploaded(images) {
       // We have uploaded some images.  Add them to the store.
       this.$store.dispatch('devices/setImages', {
-        iddevices: this.device.iddevices,
+        iddevices: this.idtouse,
         images: images
       })
     }

--- a/resources/js/components/DeviceImages.vue
+++ b/resources/js/components/DeviceImages.vue
@@ -5,7 +5,7 @@
         {{ __('devices.images') }}
       </label>
       <div class="d-flex flex-wrap device-photos dropzone-previews">
-        <FileUploader :url="uploadURL" v-if="(edit || add) && !disabled" previews-container=".device-photos" @uploaded="uploaded($event)" />
+        <FileUploader :url="uploadURL" v-if="(edit || add) && !disabled && images.length < maxFiles" previews-container=".device-photos" @uploaded="uploaded($event)" :max-files="maxFiles" />
         <DeviceImage v-for="image in images" :key="'img-' + image.path" :image="image" @remove="$emit('remove', image)" :disabled="disabled" />
       </div>
     </div>
@@ -42,6 +42,11 @@ export default {
       required: false,
       default: false
     },
+  },
+  data () {
+    return {
+      maxFiles: 5
+    }
   },
   computed: {
     idtouse() {

--- a/resources/js/components/EventDevice.vue
+++ b/resources/js/components/EventDevice.vue
@@ -191,6 +191,9 @@ export default {
     }
   },
   computed: {
+    idtouse() {
+      return this.currentDevice ? this.currentDevice.iddevices : null
+    },
     disabled () {
       return !this.edit && !this.add
     },
@@ -274,6 +277,13 @@ export default {
 
       this.nextSteps()
       this.partsProvider()
+    }
+
+    if (this.add) {
+      // Use a -ve id to give us something to track uploaded photos against.
+      //
+      // Need to ensure this isn't too large as the xref table has an int value.
+      this.currentDevice.iddevices = -Math.round(new Date().getTime() / 1000)
     }
   },
   methods: {
@@ -387,8 +397,11 @@ export default {
       // TODO LATER The remove of the image should not happen until the edit completes.  At the moment we do it
       // immediately.  The way we set ids here is poor, but this is because the underlying API call for images
       // is weak.
-      image.iddevices = this.currentDevice.iddevices
-      this.$store.dispatch('devices/deleteImage', image)
+      console.log("Remove imnage", image, this.idtouse, this.device, this.currentDevice)
+      this.$store.dispatch('devices/deleteImage', {
+        iddevices: this.idtouse,
+        idxref: image.idxref
+      })
     },
     confirmDeleteDevice () {
       this.$refs.confirm.show()

--- a/resources/js/components/EventDevice.vue
+++ b/resources/js/components/EventDevice.vue
@@ -23,6 +23,7 @@
           </div>
           <DeviceWeight v-if="showWeight" :weight.sync="currentDevice.estimate" :disabled="disabled"/>
           <DeviceAge :age.sync="currentDevice.age" :disabled="disabled"/>
+          Add
           <DeviceImages :idevents="idevents" :device="currentDevice" :add="add" :edit="edit" :disabled="disabled"
                         class="mt-2" @remove="removeImage($event)"/>
         </b-card>

--- a/resources/js/components/EventDeviceSummary.vue
+++ b/resources/js/components/EventDeviceSummary.vue
@@ -18,8 +18,8 @@
       <b-td v-if="powered">
         {{ device.model }}
         <div class="d-block d-md-none">
-          <span class="pl-0 pl-md-2 pr-2 clickme" @click="editDevice">
-            <b-img class="icon" src="/icons/edit_ico_green.svg" />
+          <span class="pl-0 pl-md-2 pr-2 clickme edit" @click="editDevice">
+            <b-img class="icon edit" src="/icons/edit_ico_green.svg" />
           </span>
           <span class="pl-2 pr-2 clickme" @click="deleteConfirm">
             <b-img class="icon" src="/icons/delete_ico_red.svg" />
@@ -29,7 +29,7 @@
       <b-td v-if="!powered">
         {{ device.item_type }}
         <div class="d-block d-md-none">
-          <span class="pl-0 pl-md-2 pr-2 clickme" @click="editDevice">
+          <span class="pl-0 pl-md-2 pr-2 clickme edit" @click="editDevice">
             <b-img class="icon" src="/icons/edit_ico_green.svg" />
           </span>
           <span class="pl-2 pr-2 clickme" @click="deleteConfirm">
@@ -53,7 +53,7 @@
       </b-td>
       <b-td v-if="canedit" class="text-right d-none d-md-table-cell">
         <div class="d-flex">
-          <span class="pl-0 pl-md-2 pr-2 clickme" @click="editDevice">
+          <span class="pl-0 pl-md-2 pr-2 clickme edit" @click="editDevice">
             <b-img class="icon" src="/icons/edit_ico_green.svg" />
           </span>
             <span class="pl-2 pr-2 clickme" @click="deleteConfirm">

--- a/resources/js/components/FileUploader.vue
+++ b/resources/js/components/FileUploader.vue
@@ -19,7 +19,12 @@ export default {
     previewsContainer: {
       type: String,
       required: true
-    }
+    },
+    maxFiles: {
+      type: Number,
+      required: false,
+      default: 1
+    },
   },
   components: {
     vueDropzone: vue2Dropzone
@@ -35,9 +40,13 @@ export default {
         addRemoveLinks: false,
         thumbnailWidth: 120,
         thumbnailHeight: 120,
+        maxFiles: this.maxFiles,
+        resizeWidth: 800,
+        resizeHeight: 800,
         thumbnailMethod: 'contain',
         previewsContainer: this.previewsContainer,
         dictRemoveFile: null,
+        acceptedFiles: ".jpeg,.jpg,.png,.gif",
         previewTemplate:
             '<div>' +
             ' <div class="dz-preview dz-file-preview">' +

--- a/resources/js/store/devices.js
+++ b/resources/js/store/devices.js
@@ -113,7 +113,7 @@ export default {
     },
     removeImage(state, params) {
       Vue.set(state.images, params.iddevices, state.images[params.iddevices].filter(u => {
-        return u.idimages !== params.idimages
+        return u.idxref !== params.idxref
       }))
     },
   },
@@ -260,17 +260,19 @@ export default {
       commit('setImages', params)
     },
     async deleteImage({commit, rootGetters}, params) {
-      params.idimages = params.idxref
-      const url = '/device/image/delete/' + params.iddevices + '/' + params.idimages + '/' + params.path
-      const ret = await axios.get(url, {
-        headers: {
-          'X-CSRF-TOKEN': rootGetters['auth/CSRF']
-        }
-      })
+      console.log("Delete image", params)
+      if (params.iddevices && params.idxref) {
+        const url = '/device/image/delete/' + params.iddevices + '/' + params.idxref
+        const ret = await axios.get(url, {
+          headers: {
+            'X-CSRF-TOKEN': rootGetters['auth/CSRF']
+          }
+        })
 
-      // This isn't a proper API call, and returns success/failure via a redirect to another page.  Assume
-      // it works until we have a better API.
-      commit('removeImage', params)
+        // This isn't a proper API call, and returns success/failure via a redirect to another page.  Assume
+        // it works until we have a better API.
+        commit('removeImage', params)
+      }
     }
   },
 }

--- a/resources/js/store/devices.js
+++ b/resources/js/store/devices.js
@@ -16,7 +16,7 @@ export default {
       return state.devices[idevents]
     },
     imagesByDevice: state => (iddevices) => {
-      return state.images[iddevices]
+      return state.images[iddevices] || []
     }
   },
   mutations: {

--- a/resources/lang/en/devices.php
+++ b/resources/lang/en/devices.php
@@ -65,7 +65,6 @@ return [
   'confirm_delete' => 'Clicking confirm will delete this item from the event.',
   'status' => 'Status',
   'spare_parts' => 'Spare parts',
-  'images_on_edit' => 'Currently images can only be added by editing an item after it has been added.',
   'latest_data' => 'Latest Data',
   'table_intro' => 'Press the ‘i’ icons for details.  Click a column head to sort by that column - click again to reverse sort order.',
   'assessment' => 'Assessment',

--- a/resources/lang/fr-BE/devices.php
+++ b/resources/lang/fr-BE/devices.php
@@ -63,7 +63,6 @@ return [
   'unpowered_items' => 'Objets non électriques',
   'weight' => 'Poids',
   'confirm_delete' => 'Cliquer sur confirmer supprimera cet appareil de l\'événement',
-  'images_on_edit' => 'Pour le moment, les images peuvent uniquement être ajoutées en éditant un appareil, après que celui-ci ait été ajouté.',
   'spare_parts' => 'Pièces détachées',
   'status' => 'Statut',
   'latest_data' => 'Dernières données',

--- a/resources/lang/fr-BE/notifications.php
+++ b/resources/lang/fr-BE/notifications.php
@@ -11,6 +11,7 @@ return [
     'notifications' => 'Notifications',
     'view_event' => 'Voir l\'événement',
     'view_group' => 'Voir le Repair Café',
+    'view_profile' => 'Voir profil',
     'view_all' => 'Voir toutes les notifications',
     'event_confirmed_title' => 'Événement confirmé',
     'event_confirmed_subject' => 'Événement confirmé',

--- a/resources/lang/fr/devices.php
+++ b/resources/lang/fr/devices.php
@@ -63,7 +63,6 @@ return [
   'unpowered_items' => 'Objets non électriques',
   'weight' => 'Poids',
   'confirm_delete' => 'Cliquer sur confirmer supprimera cet appareil de l\'événement',
-  'images_on_edit' => 'Pour le moment, les images peuvent uniquement être ajoutées en éditant un appareil, après que celui-ci ait été ajouté.',
   'spare_parts' => 'Pièces détachées',
   'status' => 'Statut',
   'latest_data' => 'Dernières données',

--- a/resources/lang/fr/notifications.php
+++ b/resources/lang/fr/notifications.php
@@ -11,6 +11,7 @@ return [
     'notifications' => 'Notifications',
     'view_event' => 'Voir l\'événement',
     'view_group' => 'Voir le Repair Café',
+    'view_profile' => 'Voir profil',
     'view_all' => 'Voir toutes les notifications',
     'event_confirmed_title' => 'Événement confirmé',
     'event_confirmed_subject' => 'Événement confirmé',

--- a/routes/web.php
+++ b/routes/web.php
@@ -249,7 +249,7 @@ Route::group(['middleware' => ['auth', 'verifyUserConsent', 'ensureAPIToken']], 
         Route::post('/create', 'DeviceController@ajaxCreate');
         Route::get('/delete/{id}', 'DeviceController@delete');
         Route::post('/image-upload/{id}', 'DeviceController@imageUpload');
-        Route::get('/image/delete/{iddevices}/{id}/{path}', 'DeviceController@deleteImage');
+        Route::get('/image/delete/{iddevices}/{idxref}', 'DeviceController@deleteImage');
     });
 
     Route::resource('networks', 'NetworkController')->only([

--- a/tests/Integration/device.test.js
+++ b/tests/Integration/device.test.js
@@ -8,3 +8,11 @@ test('Can create misc powered device', async ({page, baseURL}) => {
   await approveEvent(page, baseURL, eventid)
   await addDevice(page, baseURL, eventid, true)
 })
+
+test('Can create device with photo', async ({page, baseURL}) => {
+  await login(page, baseURL)
+  const groupid = await createGroup(page, baseURL)
+  const eventid = await createEvent(page, baseURL, groupid, true)
+  await approveEvent(page, baseURL, eventid)
+  await addDevice(page, baseURL, eventid, true, true)
+})

--- a/tests/Unit/NotificationsTest.php
+++ b/tests/Unit/NotificationsTest.php
@@ -263,7 +263,7 @@ class NotificationsTest extends TestCase
         $this->outputs['App\\Notifications\\AdminNewUser']['mail']['fr']['introLines'][0] = 'A new user "Name" has joined the Restarters community.';
         $this->outputs['App\\Notifications\\AdminNewUser']['mail']['fr']['outroLines'] = [];
         $this->outputs['App\\Notifications\\AdminNewUser']['mail']['fr']['outroLines'][0] = 'If you would like to stop receiving these emails, please visit <a href="http://restarters.test:8000/user/edit/10002#list-email-preferences">your preferences</a> on your account.';
-        $this->outputs['App\\Notifications\\AdminNewUser']['mail']['fr']['actionText'] = 'View profile';
+        $this->outputs['App\\Notifications\\AdminNewUser']['mail']['fr']['actionText'] = 'Voir profil';
         $this->outputs['App\\Notifications\\AdminNewUser']['mail']['fr']['actionUrl'] = 'http://restarters.test:8000/profile/456';
         $this->outputs['App\\Notifications\\AdminNewUser']['mail']['fr']['displayableActionUrl'] = 'http://restarters.test:8000/profile/456';
         $this->outputs['App\\Notifications\\AdminNewUser']['array'] = [];


### PR DESCRIPTION
When we implemented the new design, we deferred adding photos until the item was created.  This fixes that.

When we are in the Add flow, we upload images using a unique negative device id.  Then when we add the device, we attach those photos to the correct device id.  

Because when we're adding we might be adding multiple copies of the device, we copy the image file.  This means we have potentially multiple copies of the same photo.  I considered having a single copy with references to it, but that's a bit complex, and this whole Xref area is ripe for some improvement anyway.  For similar reasons I don't delete the underlying file when we delete a photo from a device - that's rare.

Also:

- Restrict uploads to image files.
- Add a limit of 5 photos.
- Resize files on client to a max of 800x800.
- Add basic playwright test for uploading an image.