### PR TITLE
RES-1770 Firewall invalid emails

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -436,6 +436,18 @@ class GroupController extends Controller
             return redirect()->back()->with('warning', 'You have not entered any emails!');
         }
 
+        $invalid = [];
+
+        foreach ($emails as $email) {
+            if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                $invalid[] = $email;
+            }
+        }
+
+        if (count($invalid)) {
+            return redirect()->back()->with('warning', 'Invalid emails: ' . implode(', ', $invalid));
+        }
+
         $users = User::whereIn('email', $emails)->get();
 
         $non_users = array_diff($emails, User::whereIn('email', $emails)->pluck('email')->toArray());

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -445,7 +445,7 @@ class GroupController extends Controller
         }
 
         if (count($invalid)) {
-            return redirect()->back()->with('warning', 'Invalid emails: ' . implode(', ', $invalid));
+            return redirect()->back()->with('warning', 'Invalid emails were entered, so no notifications were sent - please send your invitation again.  The invalid emails were: ' . implode(', ', $invalid));
         }
 
         $users = User::whereIn('email', $emails)->get();

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -917,7 +917,7 @@ class PartyController extends Controller
             }
 
             if (count($invalid)) {
-                return redirect()->back()->with('warning', 'Invalid emails: ' . implode(', ', $invalid));
+                return redirect()->back()->with('warning', 'Invalid emails were entered, so no notifications were sent - please send your invitation again.  The invalid emails were: ' . implode(', ', $invalid));
             } else {
                 $users = User::whereIn('email', $emails)->get();
 

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -908,90 +908,102 @@ class PartyController extends Controller
         $message = $request->input('message_to_restarters');
 
         if (! empty($emails)) {
-            $users = User::whereIn('email', $emails)->get();
+            $invalid = [];
 
-            $non_users = array_diff($emails, User::whereIn('email', $emails)->pluck('email')->toArray());
-            $from = User::find($from_id);
+            foreach ($emails as $email) {
+                if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                    $invalid[] = $email;
+                }
+            }
 
-            foreach ($users as $user) {
-                $user_event = EventsUsers::where('user', $user->id)->where('event', $event_id)->first();
+            if (count($invalid)) {
+                return redirect()->back()->with('warning', 'Invalid emails: ' . implode(', ', $invalid));
+            } else {
+                $users = User::whereIn('email', $emails)->get();
 
-                if (is_null($user_event) || $user_event->status != '1') {
-                    $hash = substr(bin2hex(openssl_random_pseudo_bytes(32)), 0, 24);
-                    $url = url('/party/accept-invite/'.$event_id.'/'.$hash);
+                $non_users = array_diff($emails, User::whereIn('email', $emails)->pluck('email')->toArray());
+                $from = User::find($from_id);
 
-                    if (! is_null($user_event)) {
-                        $user_event->update([
-                            'status' => $hash,
-                        ]);
-                    } else {
-                        EventsUsers::create([
-                            'user' => $user->id,
-                            'event' => $event_id,
-                            'status' => $hash,
-                            'role' => 4,
-                        ]);
-                    }
+                foreach ($users as $user) {
+                    $user_event = EventsUsers::where('user', $user->id)->where('event', $event_id)->first();
 
-                    $event = Party::find($event_id);
+                    if (is_null($user_event) || $user_event->status != '1') {
+                        $hash = substr(bin2hex(openssl_random_pseudo_bytes(32)), 0, 24);
+                        $url = url('/party/accept-invite/'.$event_id.'/'.$hash);
 
-                    $arr = [
-                        'name' => $from->name,
-                        'group' => $group_name,
-                        'url' => $url,
-                        'view_url' => url('/party/view/'.$event->idevents),
-                        'message' => $message,
-                        'event' => $event,
-                    ];
+                        if (! is_null($user_event)) {
+                            $user_event->update([
+                                                    'status' => $hash,
+                                                ]);
+                        } else {
+                            EventsUsers::create([
+                                                    'user' => $user->id,
+                                                    'event' => $event_id,
+                                                    'status' => $hash,
+                                                    'role' => 4,
+                                                ]);
+                        }
 
-                    // Get Creator of Event
-                    if (! empty($userCreator = User::find($event->user_id))) {
-                        $event_details = [
-                            'event_venue' => $event->venue,
-                            'event_url' => url('/party/edit/'.$event->idevents),
+                        $event = Party::find($event_id);
+
+                        $arr = [
+                            'name' => $from->name,
+                            'group' => $group_name,
+                            'url' => $url,
+                            'view_url' => url('/party/view/'.$event->idevents),
+                            'message' => $message,
+                            'event' => $event,
                         ];
+
+                        // Get Creator of Event
+                        if (! empty($userCreator = User::find($event->user_id))) {
+                            $event_details = [
+                                'event_venue' => $event->venue,
+                                'event_url' => url('/party/edit/'.$event->idevents),
+                            ];
+                        }
+
+                        // Send Invites
+                        Notification::send($user, new JoinEvent($arr, $user));
+                    } else {
+                        $not_sent[] = $user->email;
                     }
-
-                    // Send Invites
-                    Notification::send($user, new JoinEvent($arr, $user));
-                } else {
-                    $not_sent[] = $user->email;
                 }
-            }
 
-            if (! empty($non_users)) {
-                foreach ($non_users as $non_user) {
-                    $hash = substr(bin2hex(openssl_random_pseudo_bytes(32)), 0, 24);
-                    $url = url('/user/register/'.$hash);
+                if (! empty($non_users)) {
+                    foreach ($non_users as $non_user) {
+                        $hash = substr(bin2hex(openssl_random_pseudo_bytes(32)), 0, 24);
+                        $url = url('/user/register/'.$hash);
 
-                    $invite = Invite::create([
-                        'record_id' => $event_id,
-                        'email' => $non_user,
-                        'hash' => $hash,
-                        'type' => 'event',
-                    ]);
+                        $invite = Invite::create([
+                                                     'record_id' => $event_id,
+                                                     'email' => $non_user,
+                                                     'hash' => $hash,
+                                                     'type' => 'event',
+                                                 ]);
 
-                    $event = Party::find($event_id);
+                        $event = Party::find($event_id);
 
-                    $arr = [
-                        'name' => $from->name,
-                        'group' => $group_name,
-                        'url' => $url,
-                        'view_url' => url('/party/view/'.$event->idevents),
-                        'message' => $message,
-                        'event' => $event,
-                    ];
+                        $arr = [
+                            'name' => $from->name,
+                            'group' => $group_name,
+                            'url' => $url,
+                            'view_url' => url('/party/view/'.$event->idevents),
+                            'message' => $message,
+                            'event' => $event,
+                        ];
 
-                    Notification::send($invite, new JoinEvent($arr));
+                        Notification::send($invite, new JoinEvent($arr));
+                    }
                 }
-            }
 
-            if (! isset($not_sent)) {
-                return redirect()->back()->with('success', 'Invites Sent!');
-            }
+                if (! isset($not_sent)) {
+                    return redirect()->back()->with('success', 'Invites Sent!');
+                }
 
-            // Don't log to Sentry - legitimate user error.
-            return redirect()->back()->with('warning', 'Invites Sent - apart from these ('.implode(',', $not_sent).') who were already part of the event');
+                // Don't log to Sentry - legitimate user error.
+                return redirect()->back()->with('warning', 'Invites Sent - apart from these ('.implode(',', $not_sent).') who were already part of the event');
+            }
         }
 
         \Sentry\CaptureMessage('You have not entered any emails!');

--- a/tests/Feature/Groups/InviteGroupTest.php
+++ b/tests/Feature/Groups/InviteGroupTest.php
@@ -152,4 +152,28 @@ class InviteGroupTest extends TestCase
         $redirectTo = $response->getTargetUrl();
         $this->assertNotFalse(strpos($redirectTo, '/user/register'));
     }
+
+    public function testInviteInvalid()
+    {
+        Notification::fake();
+        $this->withoutExceptionHandling();
+
+        $group = factory(Group::class)->create();
+        $host = factory(User::class)->states('Host')->create();
+        $group->addVolunteer($host);
+        $group->makeMemberAHost($host);
+        $this->actingAs($host);
+
+        // Invite a user.
+        $user = factory(User::class)->states('Restarter')->create();
+
+        $response = $this->post('/group/invite', [
+            'group_name' => $group->name,
+            'group_id' => $group->idgroups,
+            'manual_invite_box' => '@invalidmail',
+            'message_to_restarters' => 'Join us, but not in a creepy zombie way',
+        ]);
+
+        $response->assertSessionHas('warning');
+    }
 }


### PR DESCRIPTION
This checks that emails are valid when we invite to groups/events.

As with many error messages, the error text is not translated.  This isn't great, but I want to get this one in quickly because of the system impact.  