### PR TITLE
RES-1761 Network coordinator artisan command doesn't set role

### DIFF
--- a/app/Network.php
+++ b/app/Network.php
@@ -30,6 +30,12 @@ class Network extends Model
     public function addCoordinator($coordinator)
     {
         $this->coordinators()->syncWithoutDetaching($coordinator->id);
+
+        // Set us to a network coordinator (but don't demote us from admin).
+        if ($coordinator->role != Role::ADMINISTRATOR) {
+            $coordinator->role = Role::NETWORK_COORDINATOR;
+            $coordinator->save();
+        }
     }
 
     public function eventsRequiringModeration()

--- a/tests/Unit/Events/CoordinatorTest.php
+++ b/tests/Unit/Events/CoordinatorTest.php
@@ -6,6 +6,7 @@ use App\Group;
 use App\Helpers\Fixometer;
 use App\Network;
 use App\Party;
+use App\Role;
 use App\User;
 use DB;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -46,4 +47,26 @@ class CoordinatorTest extends TestCase
 
         $this->assertContains($coordinator->id, $coordinators->pluck('id'));
     }
+
+    /** @test */
+    public function promote_to_coordinator()
+    {
+        // arrange
+        $network = factory(Network::class)->create();
+        $group = factory(Group::class)->create();
+        $coordinator = factory(User::class)->state('Restarter')->create();
+        $network->addGroup($group);
+
+        // Check we promote.
+        $network->addCoordinator($coordinator);
+        $coordinator->refresh();
+        self::assertEquals(Role::NETWORK_COORDINATOR, $coordinator->role);
+
+        // Check we don't demote.
+        $admin = factory(User::class)->state('Administrator')->create();
+        $network->addCoordinator($admin);
+        $admin->refresh();
+        self::assertEquals(Role::ADMINISTRATOR, $admin->role);
+    }
+
 }


### PR DESCRIPTION
Promote to network coordinator when adding.  Don't demote.