### PR TITLE
RES-1736 Add commands to create hosts for MRES

### DIFF
--- a/app/Console/Commands/ImportMRES.php
+++ b/app/Console/Commands/ImportMRES.php
@@ -4,6 +4,9 @@ namespace App\Console\Commands;
 
 use App\User;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+use function Symfony\Component\VarDumper\Dumper\esc;
 
 class ImportMRES extends Command
 {
@@ -12,7 +15,7 @@ class ImportMRES extends Command
      *
      * @var string
      */
-    protected $signature = 'import:mres {input} {output} {--networks=CSV list of ids}';
+    protected $signature = 'import:mres {input} {output} {commands} {--networks=CSV list of ids}';
 
 
     /**
@@ -20,7 +23,7 @@ class ImportMRES extends Command
      *
      * @var string
      */
-    protected $description = 'One-off script to import MRES groups.  This takes a CSV of the groups in MRES format and outputs a CSV in our standard import format.  You can convert from the ODS file to CSV; make sure you select "Western Europe (ISO08859-15/EURO)" as the Character set.';
+    protected $description = 'One-off script to import MRES groups.  This takes a CSV of the groups in MRES format and outputs a CSV in our standard import format.  You can convert from the ODS file to CSV; make sure you select "Western Europe (ISO08859-15/EURO)" as the Character set.  It also outputs a command script with user creation commands.';
 
     /**
      * Create a new command instance.
@@ -41,10 +44,12 @@ class ImportMRES extends Command
     {
         $input = $this->argument('input');
         $output = $this->argument('output');
+        $commands = $this->argument('commands');
         $networks = $this->option('networks');
 
         $inputFile = fopen($input, 'r');
         $outputFile = fopen($output, 'w');
+        $commandsFile = fopen($commands, 'w');
 
         // First three lines are headers.
         fgetcsv($inputFile);
@@ -53,6 +58,8 @@ class ImportMRES extends Command
 
         // Write headers to output.
         fputcsv($outputFile, ['Name', 'Location', 'Postcode', 'Area', 'Country', 'Latitude', 'Longitude', 'Website', 'Phone', 'Networks', 'Description']);
+
+        $creating = [];
 
         while (!feof($inputFile))
         {
@@ -153,6 +160,28 @@ class ImportMRES extends Command
                             $networks,
                             $description,
                         ]);
+
+                // Now the host, if any.
+                if (!$email) {
+                    // We default to Enzo.
+                    $email = "e.mandrin@mres-asso.fr";
+                    $hostname = "Enzo Mandrin";
+                }
+
+                if (!$hostname) {
+                    // We use the LHS of the email.
+                    $hostname = explode("@", $email)[0];
+                }
+
+                // Random password.
+                $password = Str::random(32);
+
+                if (User::where('email', '=', $email)->count() == 0 && !array_key_exists($email, $creating)) {
+                    // User doesn't exist, create it.
+                    $creating[$email] = true;
+                    fwrite($commandsFile, "php artisan user:create " . escapeshellarg($hostname) . " " . escapeshellarg($email) . " " . escapeshellarg($password) . "\n");
+                    fwrite($commandsFile, "php artisan user:makehost " . escapeshellarg($email) . " " . escapeshellarg(utf8_encode($groupname)) . "\n");
+                }
             }
         }
     }

--- a/app/Console/Commands/ImportMRES.php
+++ b/app/Console/Commands/ImportMRES.php
@@ -15,7 +15,7 @@ class ImportMRES extends Command
      *
      * @var string
      */
-    protected $signature = 'import:mres {input} {output} {commands} {--networks=CSV list of ids}';
+    protected $signature = 'import:mres {input} {output} {commands} {user_network} {group_networks}';
 
 
     /**
@@ -45,7 +45,8 @@ class ImportMRES extends Command
         $input = $this->argument('input');
         $output = $this->argument('output');
         $commands = $this->argument('commands');
-        $networks = $this->option('networks');
+        $user_network = $this->argument('user_network');
+        $group_networks = $this->argument('group_networks');
 
         $inputFile = fopen($input, 'r');
         $outputFile = fopen($output, 'w');
@@ -157,7 +158,7 @@ class ImportMRES extends Command
                             $lng,
                             $website,
                             $phone,
-                            $networks,
+                            $group_networks,
                             $description,
                         ]);
 
@@ -179,7 +180,7 @@ class ImportMRES extends Command
                 if (User::where('email', '=', $email)->count() == 0 && !array_key_exists($email, $creating)) {
                     // User doesn't exist, create it.
                     $creating[$email] = true;
-                    fwrite($commandsFile, "php artisan user:create " . escapeshellarg($hostname) . " " . escapeshellarg($email) . " " . escapeshellarg($password) . "\n");
+                    fwrite($commandsFile, "php artisan user:create " . escapeshellarg(utf8_encode($hostname)) . " " . escapeshellarg($email) . " " . escapeshellarg($password) . " fr $user_network\n");
                     fwrite($commandsFile, "php artisan user:makehost " . escapeshellarg($email) . " " . escapeshellarg(utf8_encode($groupname)) . "\n");
                 }
             }

--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Role;
+use App\Services\DiscourseService;
 use App\User;
 use App\WikiSyncStatus;
 use Illuminate\Console\Command;
@@ -41,7 +42,7 @@ class UserCreate extends Command
      *
      * @return mixed
      */
-    public function handle()
+    public function handle(DiscourseService $discourseService)
     {
         $name = $this->argument('name');
         $email = $this->argument('email');
@@ -89,6 +90,10 @@ class UserCreate extends Command
             if ($user)
             {
                 $this->info("User created #" . $user->id);
+
+                if (config('restarters.features.discourse_integration')) {
+                    $discourseService->syncSso($user);
+                }
             } else
             {
                 $this->error("User creation failed");

--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -17,7 +17,7 @@ class UserCreate extends Command
      *
      * @var string
      */
-    protected $signature = 'user:create {name} {email} {password}';
+    protected $signature = 'user:create {name} {email} {password} {language} {repair_network_id}';
 
     /**
      * The console command description.
@@ -46,27 +46,32 @@ class UserCreate extends Command
         $name = $this->argument('name');
         $email = $this->argument('email');
         $password = $this->argument('password');
+        $language = $this->argument('language');
+        $repair_network_id = $this->argument('repair_network_id');
 
-        if (User::where('email', $email)->count() > 0) {
+        if (User::where('email', $email)->count() > 0)
+        {
             $this->info("User $email already exists - leaving unmodified");
             return;
         }
 
         $rules = [
-            'name'                => 'required|string|max:255',
-            'email'               => 'required|string|email|max:255|unique:users',
-            'password'            => 'required|string|min:6',
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users',
+            'password' => 'required|string|min:6',
         ];
 
         $validator = Validator::make([
-            'name'                => $name,
-            'email'               => $email,
-            'password'            => $password,
-         ], $rules);
+                                         'name' => $name,
+                                         'email' => $email,
+                                         'password' => $password,
+                                     ], $rules);
 
-        if ($validator->fails()) {
+        if ($validator->fails())
+        {
             $this->error("Invalid parameters " . $validator->messages()->toJson());
-        } else {
+        } else
+        {
             $user = User::create([
                                      'name' => $name,
                                      'email' => $email,
@@ -76,12 +81,16 @@ class UserCreate extends Command
                                      'recovery_expires' => strftime('%Y-%m-%d %X', time() + (24 * 60 * 60)),
                                      'calendar_hash' => Str::random(15),
                                      'username' => '',
-                                     'wiki_sync_status' => WikiSyncStatus::CreateAtLogin
+                                     'wiki_sync_status' => WikiSyncStatus::CreateAtLogin,
+                                     'language' => $language,
+                                     'repair_network' => $repair_network_id,
                                  ]);
 
-            if ($user) {
+            if ($user)
+            {
                 $this->info("User created #" . $user->id);
-            } else {
+            } else
+            {
                 $this->error("User creation failed");
             }
 

--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Role;
+use App\User;
+use App\WikiSyncStatus;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+class UserCreate extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'user:create {name} {email} {password}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a user.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->argument('name');
+        $email = $this->argument('email');
+        $password = $this->argument('password');
+
+        if (User::where('email', $email)->count() > 0) {
+            $this->info("User $email already exists - leaving unmodified");
+            return;
+        }
+
+        $rules = [
+            'name'                => 'required|string|max:255',
+            'email'               => 'required|string|email|max:255|unique:users',
+            'password'            => 'required|string|min:6',
+        ];
+
+        $validator = Validator::make([
+            'name'                => $name,
+            'email'               => $email,
+            'password'            => $password,
+         ], $rules);
+
+        if ($validator->fails()) {
+            $this->error("Invalid parameters " . $validator->messages()->toJson());
+        } else {
+            $user = User::create([
+                                     'name' => $name,
+                                     'email' => $email,
+                                     'password' => Hash::make($password),
+                                     'role' => Role::RESTARTER,
+                                     'recovery' => substr(bin2hex(openssl_random_pseudo_bytes(32)), 0, 24),
+                                     'recovery_expires' => strftime('%Y-%m-%d %X', time() + (24 * 60 * 60)),
+                                     'calendar_hash' => Str::random(15),
+                                     'username' => '',
+                                     'wiki_sync_status' => WikiSyncStatus::CreateAtLogin
+                                 ]);
+
+            if ($user) {
+                $this->info("User created #" . $user->id);
+            } else {
+                $this->error("User creation failed");
+            }
+
+            $user->generateAndSetUsername();
+        }
+    }
+}

--- a/app/Console/Commands/UserMakeHost.php
+++ b/app/Console/Commands/UserMakeHost.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Role;
+use App\User;
+use App\WikiSyncStatus;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+class UserMakeHost extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'user:makehost {email} {groupname}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Make a user a host of a group.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $email = $this->argument('email');
+        $groupname = $this->argument('groupname');
+
+        $user = User::where('email', $email)->first();
+        if (!$user) {
+            $this->error("User $email not found.");
+            return;
+        }
+
+        $group = \App\Group::where('name', $groupname)->first();
+        if (!$group) {
+            $this->error("Group $groupname not found.");
+            return;
+        }
+
+        if ($group->isVolunteer($user->id)) {
+            $this->info("User $email is already a volunteer for group $groupname.");
+        } else {
+            $group->addVolunteer($user);
+            $group->makeMemberAHost($user);
+            $this->info("User $email is now a host of group $groupname.");
+        }
+    }
+}

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -31,7 +31,7 @@ class ResetPassword extends BaseNotification
             ->subject(__('notifications.password_reset_subject', [], $locale))
             ->greeting(__('notifications.greeting', [], $locale))
             ->line(__('notifications.password_reset_line1', [], $locale))
-            ->action(__('notifications.password_reset_action', [], $locale), $this->arr['url'])
+            ->action(__('notifications.password_reset_action', [], $locale), $this->arr['url'] . "&locale=" . $locale)
             ->line(__('notifications.password_reset_noaction', [], $locale));
     }
 

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Network;
 use App\Role;
 use App\User;
 use App\Group;
@@ -548,34 +549,57 @@ class DiscourseService
             Log::debug('Sync '.$user->id.' to Discourse OK');
         }
 
-        foreach ($user->networks as $network) {
-            if ($network->name === 'MRES') {
+        if ($user->repair_network) {
+            $network = Network::find($user->repair_network);
+
+            if ($network->name === 'Repair café Haut-de-France') {
                 // Special case - ensure that emails are turned off.  This is primarily turning off email_digests.
                 // Nothing else should ever be happening on Discourse for these users.
-                $response = $this->discourseClient->request(
-                    'PUT',
-                    "/u/{$user->username}.json",
-                    [
-                        'form_params' => [
-                            'mailing_list_mode' => false,
-                            'mailing_list_mode_frequency' => 1,
-                            'email_digests' => false,
-                            'email_in_reply_to' => true,
-                            'email_messages_level' => 2,
-                            'email_level' => 2,
-                            'email_previous_replies' => 1,
-                            'digest_after_minutes' => 10080,
-                            'include_tl0_in_digests' => true
-                        ]
-                    ]
+                $worked = false;
+
+                $response = $client->request(
+                    'GET',
+                    "/users/by-external/{$user->id}.json"
                 );
 
-                if ($response->getStatusCode() !== 200) {
-                    Log::error('Could not turn off Discourse mails for user '.$user->id.': '.$response->getReasonPhrase());
-                } else {
-                    Log::debug('Turned off Discourse mails for'.$user->id);
+                if ($response->getStatusCode() == 200)
+                {
+                    $json = json_decode($response->getBody()->getContents(), true);
+
+                    if (!empty($json['user']))
+                    {
+                        $userName = $json['user']['username'];
+
+                        $client = app('discourse-client');
+                        $response = $client->request(
+                            'PUT',
+                            "/u/{$userName}.json",
+                            [
+                                'form_params' => [
+                                    'mailing_list_mode' => false,
+                                    'mailing_list_mode_frequency' => 1,
+                                    'email_digests' => false,
+                                    'email_in_reply_to' => true,
+                                    'email_messages_level' => 2,
+                                    'email_level' => 2,
+                                    'email_previous_replies' => 1,
+                                    'digest_after_minutes' => 10080,
+                                    'include_tl0_in_digests' => true
+                                ]
+                            ]
+                        );
+
+                        $worked = true;
+                    }
                 }
 
+                if ($worked) {
+                    Log::debug('Turned off Discourse mails for' . $user->id);
+                } else {
+                    Log::error(
+                        'Could not turn off Discourse mails for user ' . $user->id . ': ' . $response->getReasonPhrase()
+                    );
+                }
             }
         }
     }

--- a/app/User.php
+++ b/app/User.php
@@ -411,35 +411,6 @@ class User extends Authenticatable implements Auditable, HasLocalePreference
         }
     }
 
-    /**
-     * Getter to display the user's repair network with options to provide the network name/slug
-     *
-     * NOT IN USE, decided on a more straightforward approach could be useful in the future
-     * @author Dean Appleton-Claydon
-     * @date   2019-03-22
-     * @param  bool $string
-     * @param  bool $slug
-     * @return mixed either string or int
-     */
-    public function getRepairNetwork($string = false, $slug = false)
-    {
-        if ($string) {
-            if ($this->repair_network === 2) {
-                $network = 'Repair Share';
-            } else {
-                $network = 'Restarters';
-            }
-
-            if ($slug) {
-                return Str::slug($network);
-            }
-
-            return $network;
-        }
-
-        return $this->repair_network;
-    }
-
     public function groupTag()
     {
         return $this->hasOne(GroupTags::class, 'id', 'access_group_tag_id');

--- a/tests/Feature/Groups/GroupCreateTest.php
+++ b/tests/Feature/Groups/GroupCreateTest.php
@@ -162,7 +162,7 @@ class GroupCreateTest extends TestCase
         $this->get('/party')->assertSee(e($eventAttributes['venue']));
 
         // ...and on the page for this group's events.
-        $this->get('/party/group/' . $idgroups)->assertSee($eventAttributes['venue']);
+        $this->get('/party/group/' . $idgroups)->assertSee(e($eventAttributes['venue']));
 
         // And to a network coordinator
         $coordinator = factory(User::class)->state('NetworkCoordinator')->create();

--- a/tests/Feature/Networks/NetworkCommandsTest.php
+++ b/tests/Feature/Networks/NetworkCommandsTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertTrue;
 
-class NetworkCommands extends TestCase {
+class NetworkCommandsTest extends TestCase {
     public function testCreate() {
         $this->artisan('network:create testname testshortname "test description" --website="https://therestartproject.org" --language=fr --timezone="Asia/Samarkand" --wordpress --zapier --drip --auto-approve-events')->assertExitCode(0);
         $network = Network::orderBy('id', 'desc')->first();

--- a/tests/Feature/Users/UserCommandsTest.php
+++ b/tests/Feature/Users/UserCommandsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Commands;
 
 use App\Group;
 use App\Helpers\Fixometer;
+use App\Network;
 use App\User;
 use DB;
 use Tests\TestCase;
@@ -13,9 +14,14 @@ use function PHPUnit\Framework\assertTrue;
 
 class UserCommandsTest extends TestCase {
     public function testCreate() {
-        $this->artisan('user:create testname test@test.com 1234567890')->assertExitCode(0);
+        $network = Network::all()->first();
+        DB::connection()->enableQueryLog();
+        $this->artisan('user:create testname test@test.com 1234567890 fr ' . $network->id)->assertExitCode(0);
         $user = User::where('email', 'test@test.com')->first();
+        $queries = DB::getQueryLog();
         self::assertEquals('testname', $user->name);
+        self::assertEquals('fr', $user->language);
+        self::assertEquals($network->id, $user->repair_network);
     }
 
     public function testMakeHost() {

--- a/tests/Feature/Users/UserCommandsTest.php
+++ b/tests/Feature/Users/UserCommandsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Commands;
+
+use App\Group;
+use App\Helpers\Fixometer;
+use App\User;
+use DB;
+use Tests\TestCase;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+
+class UserCommandsTest extends TestCase {
+    public function testCreate() {
+        $this->artisan('user:create testname test@test.com 1234567890')->assertExitCode(0);
+        $user = User::where('email', 'test@test.com')->first();
+        self::assertEquals('testname', $user->name);
+    }
+
+    public function testMakeHost() {
+        $host = factory(User::class)->states('Host')->create();
+        $group = factory(Group::class)->create();
+        assertFalse(Fixometer::userIsHostOfGroup($group->idgroups, $host->id));
+        $this->artisan('user:makehost ' . escapeshellarg($host->email) . ' ' . escapeshellarg($group->name))->assertExitCode(0);
+        assertTrue(Fixometer::userIsHostOfGroup($group->idgroups, $host->id));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -68,13 +68,16 @@ abstract class TestCase extends BaseTestCase
         DB::delete('delete from devices_faults_vacuums_ora_opinions');
 
         // Set up random auto increment values.  This avoids tests working because everything is 1.
+        //
+        // Some tables (e.g. network) have a tinyint as the ID, so we must be careful not to create values that
+        // overflow this.
         $tables = DB::select('SHOW TABLES');
         foreach ($tables as $table)
         {
             foreach ($table as $field => $tablename) {
                 try {
                     // This will throw an exception if the table doesn't have auto increment.
-                    DB::update("ALTER TABLE $tablename AUTO_INCREMENT = " . rand(1, 1000) . ";");
+                    DB::update("ALTER TABLE $tablename AUTO_INCREMENT = " . rand(1, 100) . ";");
                 } catch (\Exception $e) {
                 }
             }

--- a/tests/Unit/NotificationsTest.php
+++ b/tests/Unit/NotificationsTest.php
@@ -744,8 +744,8 @@ class NotificationsTest extends TestCase
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['en']['outroLines'] = [];
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['en']['outroLines'][0] = 'If you did not request a password reset, no further action is required.';
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['en']['actionText'] = 'Reset password';
-        $this->outputs['App\\Notifications\\ResetPassword']['mail']['en']['actionUrl'] = 'https://someurl.com';
-        $this->outputs['App\\Notifications\\ResetPassword']['mail']['en']['displayableActionUrl'] = 'https://someurl.com';
+        $this->outputs['App\\Notifications\\ResetPassword']['mail']['en']['actionUrl'] = 'https://someurl.com&locale=en';
+        $this->outputs['App\\Notifications\\ResetPassword']['mail']['en']['displayableActionUrl'] = 'https://someurl.com&locale=en';
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr'] = [];
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['level'] = 'info';
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['subject'] = 'Réinitialiser le mot de passe';
@@ -756,8 +756,8 @@ class NotificationsTest extends TestCase
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['outroLines'] = [];
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['outroLines'][0] = 'Si vous n\'avez pas demandé de réinitialisation du mot de passe, aucune action supplémentaire n\'est requise.';
         $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['actionText'] = 'Réinitialiser le mot de passe';
-        $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['actionUrl'] = 'https://someurl.com';
-        $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['displayableActionUrl'] = 'https://someurl.com';
+        $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['actionUrl'] = 'https://someurl.com&locale=fr';
+        $this->outputs['App\\Notifications\\ResetPassword']['mail']['fr']['displayableActionUrl'] = 'https://someurl.com&locale=fr';
         $this->outputs['App\\Notifications\\ResetPassword']['array'] = [];
         $this->outputs['App\\Notifications\\ResetPassword']['array']['en'] = [];
         $this->outputs['App\\Notifications\\ResetPassword']['array']['fr'] = [];


### PR DESCRIPTION
1. Add a command to create a user.  When they next log in (possibly after a password reset) then they'll get prompted to go through filling out the remaining details we need.
2. Add a command to make a user a host.
3. In the MRES import job, spit out a command script containing these two commands.