### PR TITLE
RES-1760 remove xref

### DIFF
--- a/app/Http/Controllers/NetworkController.php
+++ b/app/Http/Controllers/NetworkController.php
@@ -98,7 +98,6 @@ class NetworkController extends Controller
 
             // Store it in the network object.
             if ($path) {
-                error_log("Save logo $path");
                 $network->logo = $path;
                 $network->save();
             } else {

--- a/app/Http/Controllers/NetworkController.php
+++ b/app/Http/Controllers/NetworkController.php
@@ -11,13 +11,6 @@ use Lang;
 
 class NetworkController extends Controller
 {
-    protected $crossReferenceTableId;
-
-    public function __construct()
-    {
-        $this->crossReferenceTableId = config('restarters.xref_types.networks');
-    }
-
     /**
      * Display a listing of the resource.
      *
@@ -98,8 +91,19 @@ class NetworkController extends Controller
         $this->authorize('update', $network);
 
         if ($request->hasFile('network_logo')) {
-            $fileHelper = new FixometerFile;
-            $networkLogoFilename = $fileHelper->upload('network_logo', 'image', $network->id, $this->crossReferenceTableId, false, false, false, false);
+            // Save the file.
+            $path = $request->file('network_logo')->store('network_logos', [
+                'disk' => 'public_uploads',
+            ]);
+
+            // Store it in the network object.
+            if ($path) {
+                error_log("Save logo $path");
+                $network->logo = $path;
+                $network->save();
+            } else {
+                abort(500, 'Failed to save logo');
+            }
         }
 
         return redirect()->route('networks.edit', [$network]);

--- a/app/Network.php
+++ b/app/Network.php
@@ -50,9 +50,10 @@ class Network extends Model
         return $events->flatten(1);
     }
 
-    public function logo()
+    public function logo($size)
     {
-        return url('/uploads/' . $this->logo);
+        $logo = preg_replace('/\\.([^.\\s]{3,4})$/', "-$size.$1", $this->logo);
+        return $logo;
     }
 
     public function groupsNotIn()

--- a/app/Network.php
+++ b/app/Network.php
@@ -52,9 +52,7 @@ class Network extends Model
 
     public function logo()
     {
-        return $this->hasOne(\App\Xref::class, 'reference', 'id')
-            ->where('reference_type', config('restarters.xref_types.networks'))
-            ->where('object_type', 5);
+        return url('/uploads/' . $this->logo);
     }
 
     public function groupsNotIn()

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "addwiki/mediawiki-api": "~0.7.0",
         "addwiki/mediawiki-api-base": "~2.0",
         "barryvdh/laravel-translation-manager": "^0.6.2",
+        "bkwld/croppa": "^4.11",
         "caseyamcl/guzzle_retry_middleware": "^2.6",
         "cweagans/composer-patches": "^1.7",
         "darkaonline/l5-swagger": "6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfe55024b27dbf16d764b7a6317138a7",
+    "content-hash": "cbe298a0bdba527d8a4912594cbd49d9",
     "packages": [
         {
             "name": "addwiki/mediawiki-api",
@@ -270,6 +270,69 @@
                 "translator"
             ],
             "time": "2022-03-17T20:07:34+00:00"
+        },
+        {
+            "name": "bkwld/croppa",
+            "version": "4.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BKWLD/croppa.git",
+                "reference": "ccec1bff1da60d37801b66e9defb21ef7cfa5ca6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BKWLD/croppa/zipball/ccec1bff1da60d37801b66e9defb21ef7cfa5ca6",
+                "reference": "ccec1bff1da60d37801b66e9defb21ef7cfa5ca6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "illuminate/console": "4 - 8",
+                "illuminate/routing": "4 - 8",
+                "illuminate/support": "4 - 8",
+                "league/flysystem": "~1.0",
+                "php": "^7.2.5|^8.0",
+                "symfony/http-foundation": "2 - 5",
+                "symfony/http-kernel": "2 - 5",
+                "weotch/phpthumb": "^1.0.5"
+            },
+            "conflict": {
+                "league/flysystem-cached-adapter": "<1.0.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9",
+                "phpunit/phpunit": "4 - 5"
+            },
+            "suggest": {
+                "ext-exif": "Required if you want to have Croppa auto-rotate images from devices like mobile phones based on exif meta data."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Bkwld\\Croppa\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "Croppa": "Bkwld\\Croppa\\Facade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Bkwld\\Croppa": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Reinhard"
+                }
+            ],
+            "description": "Image thumbnail creation through specially formatted URLs for Laravel",
+            "time": "2021-03-19T17:25:26+00:00"
         },
         {
             "name": "caseyamcl/guzzle_retry_middleware",
@@ -590,12 +653,6 @@
                 "api",
                 "laravel",
                 "swagger"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/DarkaOnLine",
-                    "type": "github"
-                }
             ],
             "time": "2021-01-11T12:34:15+00:00"
         },
@@ -6910,6 +6967,41 @@
             "time": "2021-12-12T23:02:06+00:00"
         },
         {
+            "name": "weotch/phpthumb",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/weotch/PHPThumb.git",
+                "reference": "f5c1d2ef2e9de3bded7483778618bf8cac2511c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/weotch/PHPThumb/zipball/f5c1d2ef2e9de3bded7483778618bf8cac2511c3",
+                "reference": "f5c1d2ef2e9de3bded7483778618bf8cac2511c3",
+                "shasum": ""
+            },
+            "replace": {
+                "dannytrue/phpthumb": "dev-master#2d8898f62e75a743e248dd5906a038d574e0dfe0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Reinhard"
+                }
+            ],
+            "description": "Fork of PHPThumb that adds auto-image rotation based on EXIF data and composer support",
+            "time": "2015-05-12T22:56:19+00:00"
+        },
+        {
             "name": "wouternl/laravel-drip",
             "version": "1.2.4",
             "source": {
@@ -9890,6 +9982,5 @@
     "platform": {
         "php": "^7.2|^8.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }

--- a/config/croppa.php
+++ b/config/croppa.php
@@ -1,0 +1,145 @@
+<?php return array(
+
+    /*
+    |-----------------------------------------------------------------------------
+    | Image source and crop destination
+    |-----------------------------------------------------------------------------
+    */
+
+    /**
+     * The directory where source images are found. This is generally where your
+     * admin stores uploaded files. Can be either an absolute path to your local
+     * disk (the default) or the name of an IoC binding of a Flysystem instance.
+     *
+     * @var string  Absolute path in local fileystem
+     *      string  IoC binding name of League\Flysystem\Filesystem
+     *      string  IoC binding name of League\Flysystem\Cached\CachedAdapter
+     */
+    'src_dir' => public_path().'/uploads',
+
+    /**
+     * The directory where cropped images should be saved. The route to the
+     * cropped versions is what should be rendered in your markup; it must be a
+     * web accessible directory.
+     *
+     * @var string  Absolute path in local fileystem
+     *      string  IoC binding name of League\Flysystem\Filesystem
+     *      string  IoC binding name of League\Flysystem\Cached\CachedAdapter
+     */
+    'crops_dir' => public_path().'/uploads',
+
+    /**
+     * Maximum number of sizes to allow for a particular source file. This is to
+     * limit scripts from filling up your hard drive with images. Set to false or
+     * comment out to have no limit. This is disabled by default because the
+     * `signing_key` is a better prevention of malicious usage.
+     *
+     * @var integer | boolean
+     */
+    'max_crops' => 3,
+
+
+    /*
+    |-----------------------------------------------------------------------------
+    | URL parsing and generation
+    |-----------------------------------------------------------------------------
+    */
+
+    /**
+     * A regex pattern that is applied to both the src url passed to
+     * `Croppa::url()` as well as the crop path received when handling a crop
+     * request to find the path to the src image relative to both the src_dir
+     * and crops_dirs. This path will be used to find the source image in the
+     * src_dir. The path component of the regex must exist in the first captured
+     * subpattern. In other words, in the `preg_match` $matches[1].
+     *
+     * @var string
+     */
+    'path' => 'uploads/(.*)$',
+
+    /**
+     * A regex pattern that works like `path` except it is only used by the
+     * `Croppa::url($url)` generator function. If the $path url matches, it is
+     * passed through with no Croppa URL suffixes added. Thus, it will not be
+     * cropped. This is designed, in particular, for animated gifs which lose
+     * animation when cropped.
+     *
+     * @var string
+     */
+    'ignore' => '\.(gif|GIF)$',
+
+    /**
+     * A string that is prepended to the path captured by the `path` pattern
+     * (above) that is used to from the URL to crops.
+     */
+    // 'url_prefix' => '//'.Request::getHttpHost().'/uploads/',         // Local
+    // 'url_prefix' => 'https://your-bucket.s3.amazonaws.com/uploads/', // S3
+
+    /**
+     * Reject attempts to maliciously create images by signing the generated
+     * request with a hash based on the request parameters and this signing key.
+     * Set to 'app.key' to use Laravel's `app.key` config, any other string to use
+     * THAT as the key, or false to disable.
+     *
+     * If you are generating URLs outside of `Croppa::url()`, like the croppa.js
+     * module, you can disable this feature by setting the `signing_key` config
+     * to false.
+     *
+     * @var string | boolean
+     */
+    'signing_key' => false,
+
+    /**
+     * The PHP memory limit used by the script to generate thumbnails. Some
+     * images require a lot of memory to perform the resize, so you may increase
+     * this memory limit.
+     */
+    'memory_limit' => '128M',
+
+    /*
+    |-----------------------------------------------------------------------------
+    | Image settings
+    |-----------------------------------------------------------------------------
+    */
+
+    /**
+     * The jpeg quality of generated images. The difference between 100 and 95
+     * usually cuts the file size in half. Going down to 70 looks ok on photos
+     * and will reduce filesize by more than another half but on vector files
+     * there is noticeable aliasing.
+     *
+     * @var integer
+     */
+    'jpeg_quality' => 95,
+
+    /**
+     * Turn on interlacing to make progessive jpegs.
+     *
+     * @var boolean
+     */
+    'interlace' => true,
+
+    /**
+     * If the source image is smaller than the requested size, allow Croppa to
+     * scale up the image. This will reduce in quality loss.
+     *
+     * @var boolean
+     */
+    'upscale' => false,
+
+    /**
+     * Filters for adding additional GD effects to an image and using them as parameter
+     * in the croppa image slug.
+     *
+     * @var array
+     */
+    'filters' => [
+        'gray'      => Bkwld\Croppa\Filters\BlackWhite::class,
+        'darkgray'  => Bkwld\Croppa\Filters\Darkgray::class,
+        'blur'      => Bkwld\Croppa\Filters\Blur::class,
+        'negative'  => Bkwld\Croppa\Filters\Negative::class,
+        'orange'    => Bkwld\Croppa\Filters\OrangeWarhol::class,
+        'turquoise' => Bkwld\Croppa\Filters\TurquoiseWarhol::class,
+    ],
+
+);

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -55,6 +55,11 @@ return [
             'visibility' => 'public',
         ],
 
+        'public_uploads' => [
+            'driver' => 'local',
+            'root'   => public_path() . '/uploads',
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/database/migrations/2022_10_06_162442_network_logo.php
+++ b/database/migrations/2022_10_06_162442_network_logo.php
@@ -20,14 +20,15 @@ class NetworkLogo extends Migration
         $networks = \App\Network::all();
 
         foreach ($networks as $network) {
+            // Find the logo.
             $logo = \App\Xref::where('reference', $network->id)
                 ->where('reference_type', config('restarters.xref_types.networks'))
                 ->where('object_type', 5)
             ->first();
 
             if (is_object($logo) && is_object($logo->image)) {
+                // Save in the network column.
                 $network->logo = $logo->image->path;
-                error_log("{$network->id} logo {$network->logo}");
                 $network->save();
             }
         }

--- a/database/migrations/2022_10_06_162442_network_logo.php
+++ b/database/migrations/2022_10_06_162442_network_logo.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class NetworkLogo extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('networks', function (Blueprint $table) {
+            $table->string('logo', 255)->nullable();
+        });
+
+        $networks = \App\Network::all();
+
+        foreach ($networks as $network) {
+            $logo = \App\Xref::where('reference', $network->id)
+                ->where('reference_type', config('restarters.xref_types.networks'))
+                ->where('object_type', 5)
+            ->first();
+
+            if (is_object($logo) && is_object($logo->image)) {
+                $network->logo = $logo->image->path;
+                error_log("{$network->id} logo {$network->logo}");
+                $network->save();
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('networks', function (Blueprint $table) {
+            $table->dropColumn('logo');
+        });
+    }
+}

--- a/resources/views/networks/index.blade.php
+++ b/resources/views/networks/index.blade.php
@@ -33,13 +33,12 @@
                     @foreach($yourNetworks as $network)
                         <tr>
                             <td>
-                                @php( $logo = $network->logo )
-                                @if( is_object($logo) && is_object($logo->image) )
-                                    <img style="width: auto; height:50px" src="{{ asset('/uploads/mid_'. $logo->image->path) }}" alt="{{{ $network->name }}} logo">
+                                @php( $logo = $network->logo('_x100') )
+                                @if( $logo )
+                                    <img style="width: auto; height:50px" src="{{ asset("/uploads/$logo") }}" alt="{{{ $network->name }}} logo">
                                 @else
                                     <img src="{{ url('/uploads/mid_1474993329ef38d3a4b9478841cc2346f8e131842fdcfd073b307.jpg') }}" alt="generic network logo">
                                 @endif
-    </div>
                             </td>
                             <td>
                                 <a href="/networks/{{$network->id}}">{{ $network->name }}</a>
@@ -80,13 +79,12 @@
                     @foreach($allNetworks as $network)
                         <tr>
                             <td>
-                                @php( $logo = $network->logo )
-                                @if( is_object($logo) && is_object($logo->image) )
-                                    <img style="width: auto; max-width: 100%; max-height:50px" src="{{ asset('/uploads/mid_'. $logo->image->path) }}" alt="{{{ $network->name }}} logo">
-                                @else
-                                    <img src="{{ url('/uploads/mid_1474993329ef38d3a4b9478841cc2346f8e131842fdcfd073b307.jpg') }}" alt="generic network logo">
-                                @endif
-    </div>
+                              @php( $logo = $network->logo('_x100') )
+                              @if( $logo )
+                                <img style="width: auto; height:50px" src="{{ asset("/uploads/$logo") }}" alt="{{{ $network->name }}} logo">
+                              @else
+                                <img src="{{ url('/uploads/mid_1474993329ef38d3a4b9478841cc2346f8e131842fdcfd073b307.jpg') }}" alt="generic network logo">
+                              @endif
                             </td>
                             <td>
                                 <a href="/networks/{{$network->id}}">{{ $network->name }}</a>

--- a/resources/views/networks/show.blade.php
+++ b/resources/views/networks/show.blade.php
@@ -25,9 +25,9 @@
                     <div class="row">
                         <div class="col-lg-3 align-self-center" style="text-align:center">
                             <div class="network-icon">
-                                @php( $logo = $network->logo )
-                                @if( is_object($logo) && is_object($logo->image) )
-                                <img style="max-width: 100%; max-height:50px" src="{{ asset('/uploads/mid_'. $logo->image->path) }}" alt="{{{ $network->name }}} logo">
+                                @php( $logo = $network->logo('_x100') )
+                                @if( $logo )
+                                <img style="max-width: 100%; max-height:50px" src="{{ asset("/uploads/$logo") }}" alt="{{{ $network->name }}} logo">
                                 @else
                                 <img src="{{ url('/uploads/mid_1474993329ef38d3a4b9478841cc2346f8e131842fdcfd073b307.jpg') }}" alt="generic network logo">
                                 @endif

--- a/tests/Feature/Groups/BasicTest.php
+++ b/tests/Feature/Groups/BasicTest.php
@@ -39,7 +39,7 @@ class BasicTest extends TestCase
                 ':user-id' => $user->id,
                 'tab' => 'mine',
                 ':network' => 'null',
-                ':networks' => '[{"id":' . Network::first()->id . ',"name":"Restarters","description":null,"website":null,"default_language":"en","timezone":"Europe\\/London","created_at":"2021-05-24 12:19:37","updated_at":"2021-05-24 12:19:37","events_push_to_wordpress":0,"include_in_zapier":0,"users_push_to_drip":0,"shortname":"restarters","discourse_group":null,"auto_approve_events":0}]',
+                ':networks' => '[{"id":' . Network::first()->id . ',"name":"Restarters","description":null,"website":null,"default_language":"en","timezone":"Europe\\/London","created_at":"2021-05-24 12:19:37","updated_at":"2021-05-24 12:19:37","events_push_to_wordpress":0,"include_in_zapier":0,"users_push_to_drip":0,"shortname":"restarters","discourse_group":null,"auto_approve_events":0,"logo":null}]',
                 ':show-tags' => 'false',
             ],
         ]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -257,9 +257,9 @@ abstract class TestCase extends BaseTestCase
     {
         // Sinple code to filter out timestamps or other random values.
         if ($val && is_string($val)) {
-            $val = preg_replace('/"created_at":".*"/', '"created_at":"TIMESTAMP"', $val);
-            $val = preg_replace('/"updated_at":".*"/', '"updated_at":"TIMESTAMP"', $val);
-            $val = preg_replace('/"shareable_code":".*"/', '"shareable_code":"SHARECODE"', $val);
+            $val = preg_replace('/"created_at":".*?"/', '"created_at":"TIMESTAMP"', $val);
+            $val = preg_replace('/"updated_at":".*?"/', '"updated_at":"TIMESTAMP"', $val);
+            $val = preg_replace('/"shareable_code":".*?"/', '"shareable_code":"SHARECODE"', $val);
         }
 
         return $val;


### PR DESCRIPTION
1. Add a `logo` column to the `networks` table to store the file path, and migrate the data over.
2. Upload files in NetworkController using `store()`, which is more idiomatic.
3. Put them in `public_uploads/network_logos`, by creating a disk for that in `filesystems.php` and passing a path to `store()`.
4. Change the `logo()` method to generate the appropriate path for Croppa, which will handle generating and caching different sizes as required.
5. Increase logos from 50px to 100px - retina screens means that probably too low res nowadays.
6. Fix a bug in the test, where the regex was greedy and shouldn't be.