### PR TITLE
RES-1790 Add group location to API call

### DIFF
--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -39,38 +39,21 @@ class Group extends JsonResource
 
     /**
      *     @OA\Property(
+     *          property="location",
+     *          title="location",
+     *          description="The group's location",
+     *          format="object",
+     *          ref="#/components/schemas/GroupLocation"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
      *          property="image",
      *          title="image",
      *          description="URL of an image for this group.  You should prefix this with /uploads before use.",
      *          format="string",
      *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
-     *     )
-     */
-
-    /**
-     *     @OA\Property(
-     *          property="area",
-     *          description="The free-form area that this group is in.",
-     *          format="string",
-     *          example="<p>This is a description.</p>"
-     *     )
-     */
-
-    /**
-     *     @OA\Property(
-     *          property="location",
-     *          description="The location that this group is in.  Must be geocodable.",
-     *          format="string",
-     *          example="College Road, London NW10 5EX, UK"
-     *     )
-     */
-
-    /**
-     *     @OA\Property(
-     *          property="country",
-     *          description="The free-form country.",
-     *          format="string",
-     *          example="<p>This is a description.</p>"
      *     )
      */
 
@@ -290,14 +273,12 @@ class Group extends JsonResource
             'id' => $this->idgroups,
             'name' => $this->name,
             'image' => $this->groupImage && is_object($this->groupImage) && is_object($this->groupImage->image) ? $this->groupImage->image->path : null,
-            'area' => $this->area,
-            'country' => $this->country,
             'website' => $this->website,
             'phone' => $this->phone,
             'description' => $this->free_text,
             'stats' => $stats,
             'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
-            'location' => $this->location,
+            'location' => new GroupLocation($this),
             'networks' => $this->resource->networks,
             'timezone' => $this->timezone,
         ];

--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -58,6 +58,15 @@ class Group extends JsonResource
 
     /**
      *     @OA\Property(
+     *          property="location",
+     *          description="The location that this group is in.  Must be geocodable.",
+     *          format="string",
+     *          example="College Road, London NW10 5EX, UK"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
      *          property="country",
      *          description="The free-form country.",
      *          format="string",
@@ -95,6 +104,42 @@ class Group extends JsonResource
      *     )
      */
 
+    /**
+     *     @OA\Property(
+     *          property="next_event",
+     *          title="next_event",
+     *          description="Next event for this group",
+     *          ref="#/components/schemas/Event"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
+     *          property="timezone",
+     *          title="timezone",
+     *          description="Timezone for this group.",
+     *          format="string",
+     *          example="Europe/London"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
+     *         property="hosts",
+     *         title="hosts",
+     *         description="The number of hosts of this group.",
+     *         type="number",
+     *     ),
+
+    /**
+     *     @OA\Property(
+     *         property="restarters",
+     *         title="hosts",
+     *         description="The number of restarters in this group.",
+     *         type="number",
+     *     ),
+
+     */
     /**
      *     @OA\Property(
      *          property="stats",
@@ -254,6 +299,7 @@ class Group extends JsonResource
             'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
             'location' => $this->location,
             'networks' => $this->resource->networks,
+            'timezone' => $this->timezone,
         ];
 
         $ret['hosts'] = $this->resource->all_confirmed_hosts_count;

--- a/app/Http/Resources/GroupLocation.php
+++ b/app/Http/Resources/GroupLocation.php
@@ -66,6 +66,16 @@ class GroupLocation extends JsonResource
      */
 
     /**
+     *     @OA\Property(
+     *          property="postcode",
+     *          title="postcode",
+     *          description="The group postcode",
+     *          format="string",
+     *          example="SW9 7QD"
+     *     )
+     */
+
+    /**
      * Transform the resource into an array.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/app/Http/Resources/GroupLocation.php
+++ b/app/Http/Resources/GroupLocation.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Carbon\Carbon;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @OA\Schema(
+ *     title="GroupLocation",
+ *     schema="GroupLocation",
+ *     description="The information about the location of a group.",
+ *     @OA\Xml(
+ *         name="GroupLocation"
+ *     ),
+ * )
+ */
+
+class GroupLocation extends JsonResource
+{
+    /**
+     *     @OA\Property(
+     *          property="area",
+     *          description="The free-form area that this group is in.",
+     *          format="string",
+     *          example="London"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
+     *          property="location",
+     *          description="The location that this group is in.  Must be geocodable.",
+     *          format="string",
+     *          example="College Road, London NW10 5EX, UK"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
+     *          property="country",
+     *          description="The free-form country.",
+     *          format="string",
+     *          example="United Kingdom"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
+     *          property="lat",
+     *          title="lat",
+     *          description="Latitude of the group.",
+     *          format="float",
+     *          example="50.8113243"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
+     *          property="lng",
+     *          title="lng",
+     *          description="Longitude of the group.",
+     *          format="float",
+     *          example="-1.0788839"
+     *     )
+     */
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        $ret = [
+            'location' => $this->location,
+            'area' => $this->area,
+            'postcode' => $this->postcode,
+            'country' => $this->country,
+            'lat' => $this->latitude,
+            'lng' => $this->longitude,
+        ];
+
+        return($ret);
+    }
+}

--- a/app/Http/Resources/GroupSummary.php
+++ b/app/Http/Resources/GroupSummary.php
@@ -40,6 +40,33 @@ class GroupSummary extends JsonResource
 
     /**
      *     @OA\Property(
+     *          property="area",
+     *          description="The free-form area that this group is in.",
+     *          format="string",
+     *          example="<p>This is a description.</p>"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
+     *          property="location",
+     *          description="The location that this group is in.  Must be geocodable.",
+     *          format="string",
+     *          example="College Road, London NW10 5EX, UK"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
+     *          property="country",
+     *          description="The free-form country.",
+     *          format="string",
+     *          example="<p>This is a description.</p>"
+     *     )
+     */
+
+    /**
+     *     @OA\Property(
      *          property="image",
      *          title="image",
      *          description="URL of an image for this group.  You should prefix this with /uploads before use.",
@@ -81,6 +108,9 @@ class GroupSummary extends JsonResource
             'image' => $this->groupImage && is_object($this->groupImage) && is_object($this->groupImage->image) ? $this->groupImage->image->path : null,
             'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
             'networks' => $this->resource->networks,
+            'area' => $this->area,
+            'country' => $this->country,
+            'location' => $this->location,
         ];
 
         if ($request->get('includeNextEvent', false)) {

--- a/app/Http/Resources/GroupSummary.php
+++ b/app/Http/Resources/GroupSummary.php
@@ -30,7 +30,7 @@ class GroupSummary extends JsonResource
 
     /**
      *     @OA\Property(
-     *          property="name",
+     *          property="area",
      *          title="name",
      *          description="Unique name of this group",
      *          format="string",
@@ -40,28 +40,11 @@ class GroupSummary extends JsonResource
 
     /**
      *     @OA\Property(
-     *          property="area",
-     *          description="The free-form area that this group is in.",
-     *          format="string",
-     *          example="<p>This is a description.</p>"
-     *     )
-     */
-
-    /**
-     *     @OA\Property(
      *          property="location",
-     *          description="The location that this group is in.  Must be geocodable.",
-     *          format="string",
-     *          example="College Road, London NW10 5EX, UK"
-     *     )
-     */
-
-    /**
-     *     @OA\Property(
-     *          property="country",
-     *          description="The free-form country.",
-     *          format="string",
-     *          example="<p>This is a description.</p>"
+     *          title="location",
+     *          description="The group's location",
+     *          format="object",
+     *          ref="#/components/schemas/GroupLocation"
      *     )
      */
 
@@ -108,9 +91,7 @@ class GroupSummary extends JsonResource
             'image' => $this->groupImage && is_object($this->groupImage) && is_object($this->groupImage->image) ? $this->groupImage->image->path : null,
             'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
             'networks' => $this->resource->networks,
-            'area' => $this->area,
-            'country' => $this->country,
-            'location' => $this->location,
+            'location' => new GroupLocation($this),
         ];
 
         if ($request->get('includeNextEvent', false)) {

--- a/tests/Feature/Groups/APIv2GroupTest.php
+++ b/tests/Feature/Groups/APIv2GroupTest.php
@@ -40,6 +40,10 @@ class APIv2GroupTest extends TestCase
         $this->assertTrue(array_key_exists('description', $json['data']));
         $this->assertTrue(array_key_exists('stats', $json['data']));
         $this->assertTrue(array_key_exists('updated_at', $json['data']));
+        $this->assertTrue(array_key_exists('location', $json['data']));
+        $location = $json['data']['location'];
+        $this->assertEquals('London', $location['location']);
+        $this->assertEquals('United Kingdom', $location['country']);
 
         // Test group moderation.
         $response = $this->get("/api/v2/moderate/groups?api_token=1234");

--- a/tests/Feature/Networks/APIv2NetworkTest.php
+++ b/tests/Feature/Networks/APIv2NetworkTest.php
@@ -67,7 +67,11 @@ class APIv2NetworkTest extends TestCase
                                                        'name' => 'Restart',
                                                        'events_push_to_wordpress' => true,
                                                    ]);
-        $group = factory(Group::class)->create();
+        $group = factory(Group::class)->create([
+                                                   'location' => 'London',
+                                                   'area' => 'London',
+                                                   'country' => 'GB',
+                                               ]);
         $network->addGroup($group);
 
         // Create event for group
@@ -85,6 +89,10 @@ class APIv2NetworkTest extends TestCase
             $json = json_decode($response->getContent(), true)['data'];
             $this->assertEquals(1, count($json));
             $this->assertEquals($group->idgroups, $json[0]['id']);
+            $this->assertEquals($group->name, $json[0]['name']);
+            $this->assertEquals($group->location, $json[0]['location']);
+            $this->assertEquals($group->area, $json[0]['area']);
+            $this->assertEquals($group->country, $json[0]['country']);
 
             if ($getNextEvent) {
                 $this->assertEquals($event->idevents, $json[0]['next_event']['id']);

--- a/tests/Feature/Networks/APIv2NetworkTest.php
+++ b/tests/Feature/Networks/APIv2NetworkTest.php
@@ -90,9 +90,13 @@ class APIv2NetworkTest extends TestCase
             $this->assertEquals(1, count($json));
             $this->assertEquals($group->idgroups, $json[0]['id']);
             $this->assertEquals($group->name, $json[0]['name']);
-            $this->assertEquals($group->location, $json[0]['location']);
-            $this->assertEquals($group->area, $json[0]['area']);
-            $this->assertEquals($group->country, $json[0]['country']);
+            $this->assertTrue(array_key_exists('location', $json[0]));
+            $location = $json[0]['location'];
+            $this->assertEquals($group->location, $location['location']);
+            $this->assertEquals($group->country, $location['country']);
+            $this->assertEquals($group->area, $location['area']);
+            $this->assertEquals($group->latitude, $location['lat']);
+            $this->assertEquals($group->longitude, $location['lng']);
 
             if ($getNextEvent) {
                 $this->assertEquals($event->idevents, $json[0]['next_event']['id']);


### PR DESCRIPTION
Add the `area`, `location` and `country` fields to the group summary.