### PR TITLE
RES-1783 Edit a newly created fixed item, spare parts field value changed

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -58,7 +58,8 @@ const config = {
   },
 
   // Flakiness
-  timeout: 45000
+  timeout: 5 * 60 * 1000,
+  navigationTimeout: 30 * 1000
 };
 
 module.exports = config;

--- a/resources/js/components/DeviceRepairStatus.vue
+++ b/resources/js/components/DeviceRepairStatus.vue
@@ -3,6 +3,7 @@
     <multiselect
         :disabled="disabled"
         v-model="statusValue"
+        class="repair-outcome"
         :placeholder="__('devices.repair_outcome')"
         :options="statusOptions"
         track-by="id"
@@ -31,6 +32,7 @@
         :disabled="disabled"
         v-if="showParts"
         v-model="partsValue"
+        class="spare-parts"
         :placeholder="__('devices.spare_parts')"
         :options="partsOptions"
         :multiple="false"

--- a/resources/js/components/EventDevice.vue
+++ b/resources/js/components/EventDevice.vue
@@ -305,7 +305,9 @@ export default {
     },
     partsProvider () {
       // Third part parts are indicated via the parts provider field.
-      if (this.currentDevice.spare_parts === SPARE_PARTS_NOT_NEEDED) {
+      if (!this.currentDevice.spare_parts) {
+        return null
+      } else if (this.currentDevice.spare_parts === SPARE_PARTS_NOT_NEEDED) {
         this.currentDevice.spare_parts = SPARE_PARTS_NOT_NEEDED
       } else if (this.currentDevice.parts_provider === PARTS_PROVIDER_THIRD_PARTY) {
         this.currentDevice.spare_parts = SPARE_PARTS_THIRD_PARTY

--- a/resources/js/components/EventDevice.vue
+++ b/resources/js/components/EventDevice.vue
@@ -68,7 +68,7 @@
         {{ __('devices.delete_device') }}
       </b-btn>
       <DeviceQuantity v-if="add" :quantity.sync="currentDevice.quantity" class="flex-md-shrink-1 ml-2 mr-2"/>
-      <b-btn variant="tertiary" class="ml-2" @click="cancel" v-if="cancelButton">
+      <b-btn variant="tertiary" class="ml-2 cancel" @click="cancel" v-if="cancelButton">
         {{ __('partials.cancel') }}
       </b-btn>
     </div>

--- a/resources/js/components/EventDeviceSummary.vue
+++ b/resources/js/components/EventDeviceSummary.vue
@@ -9,7 +9,7 @@
           <div :class="badgeClass + ' d-block d-md-none'">
             {{ status }}
           </div>
-          <b-img v-if="sparePartsNeeded" src="/images/tick.svg" class="icon" />
+          <b-img v-if="sparePartsNeeded" src="/images/tick.svg" class="icon spare-parts" />
         </div>
       </b-td>
       <b-td class="d-none d-md-table-cell" v-if="powered">
@@ -49,7 +49,7 @@
         </span>
       </b-td>
       <b-td class="text-center d-none d-md-table-cell">
-        <b-img v-if="sparePartsNeeded" src="/images/tick.svg" class="icon" />
+        <b-img v-if="sparePartsNeeded" src="/images/tick.svg" class="icon spare-parts-tick" />
       </b-td>
       <b-td v-if="canedit" class="text-right d-none d-md-table-cell">
         <div class="d-flex">

--- a/tests/Integration/device.test.js
+++ b/tests/Integration/device.test.js
@@ -2,6 +2,7 @@ const {test, expect} = require('@playwright/test')
 const { login, createGroup, createEvent, approveEvent, addDevice } = require('./utils')
 
 test('Spare parts set as expected', async ({page, baseURL}) => {
+  test.slow()
   await login(page, baseURL)
   const groupid = await createGroup(page, baseURL)
   const eventid = await createEvent(page, baseURL, groupid, true)
@@ -13,6 +14,7 @@ test('Spare parts set as expected', async ({page, baseURL}) => {
 })
 
 test('Spare parts not set unexpectedly', async ({page, baseURL}) => {
+  test.slow()
   await login(page, baseURL)
   const groupid = await createGroup(page, baseURL)
   const eventid = await createEvent(page, baseURL, groupid, true)

--- a/tests/Integration/device.test.js
+++ b/tests/Integration/device.test.js
@@ -1,6 +1,28 @@
 const {test, expect} = require('@playwright/test')
 const { login, createGroup, createEvent, approveEvent, addDevice } = require('./utils')
 
+test('Spare parts set as expected', async ({page, baseURL}) => {
+  await login(page, baseURL)
+  const groupid = await createGroup(page, baseURL)
+  const eventid = await createEvent(page, baseURL, groupid, true)
+  await approveEvent(page, baseURL, eventid)
+  await addDevice(page, baseURL, eventid, true, false, true, true)
+
+  // Should  see spare parts tick in summary.  Two copies because of mobile view.
+  await expect(await page.locator('.spare-parts-tick').count()).toEqual(2);
+})
+
+test('Spare parts not set unexpectedly', async ({page, baseURL}) => {
+  await login(page, baseURL)
+  const groupid = await createGroup(page, baseURL)
+  const eventid = await createEvent(page, baseURL, groupid, true)
+  await approveEvent(page, baseURL, eventid)
+  await addDevice(page, baseURL, eventid, true, false, true)
+
+  // Should not see spare parts tick in summary.
+  await expect(await page.locator('.spare-parts-tick:visible').count()).toEqual(0);
+})
+
 test('Can create misc powered device', async ({page, baseURL}) => {
   await login(page, baseURL)
   const groupid = await createGroup(page, baseURL)

--- a/tests/Integration/utils.js
+++ b/tests/Integration/utils.js
@@ -159,7 +159,7 @@ exports.approveEvent = async function(page, baseURL, idevents) {
   await page.locator('text=Event details updated.')
 }
 
-exports.addDevice = async function(page, baseURL, idevents, powered, photo) {
+exports.addDevice = async function(page, baseURL, idevents, powered, photo, fixed, spareparts) {
   // Go to event edit page.
   await page.goto('/party/view/' + idevents)
 
@@ -175,6 +175,20 @@ exports.addDevice = async function(page, baseURL, idevents, powered, photo) {
   // Tab to category and select first.
   await page.keyboard.press('Tab')
   await page.keyboard.press('Enter')
+
+  if (fixed) {
+    // Tab to repair outcome and select fixed (first).
+    await page.keyboard.press('Tab')
+    await page.keyboard.press('Tab')
+    await page.keyboard.press('Tab')
+    await page.keyboard.press('Tab')
+    await page.keyboard.press('Enter')
+  }
+
+  if (spareparts) {
+    await page.locator('.spare-parts').click()
+    await page.keyboard.press('Enter')
+  }
 
   if (photo) {
     const [fileChooser] = await Promise.all([
@@ -202,6 +216,9 @@ exports.addDevice = async function(page, baseURL, idevents, powered, photo) {
     // Just dropzone
     await expect(page.locator('.device-photos:visible img')).toHaveCount(1)
   }
+
+  // Close the device edit.
+  await page.locator('.cancel').click()
 }
 
 exports.unfollowGroup = async function(page, idgroups) {


### PR DESCRIPTION
I think the scenario here is that you create an item, mark it as Fixed, but leave the spare parts field untouched.  

Logic doesn't handle the 0/null case of the `spare_parts` field, resulting in it wrongly selecting the last option.