### PR TITLE
RES-1808 Add includeDetails parameter to network API

### DIFF
--- a/app/Http/Controllers/API/NetworkController.php
+++ b/app/Http/Controllers/API/NetworkController.php
@@ -122,18 +122,37 @@ class NetworkController extends Controller
      *              type="boolean"
      *          )
      *      ),
+     *      @OA\Parameter(
+     *          name="includeDetails",
+     *          description="Include the details for each group.  This makes the call significantly slower.  Default false.",
+     *          required=false,
+     *          in="query",
+     *          @OA\Schema(
+     *              type="boolean"
+     *          )
+     *      ),
      *      @OA\Response(
      *          response=200,
      *          description="Successful operation",
      *          @OA\JsonContent(
      *              @OA\Property(
-     *                property="data",
-     *                title="data",
-     *                description="An array of groups",
-     *                type="array",
-     *                @OA\Items(
-     *                    ref="#/components/schemas/GroupSummary"
-     *                 )
+     *                  property="data",
+     *                  title="data",
+     *                  description="An array of groups",
+     *                  oneOf={
+     *                      @OA\Schema(
+     *                          type="array",
+     *                          @OA\Items(
+     *                            ref="#/components/schemas/GroupSummary"
+     *                          )
+     *                      ),
+     *                      @OA\Schema(
+     *                          type="array",
+     *                          @OA\Items(
+     *                            ref="#/components/schemas/Group"
+     *                          )
+     *                      ),
+     *                  },
      *              )
      *          )
      *       ),
@@ -160,7 +179,12 @@ class NetworkController extends Controller
             ->where('groups.updated_at', '>=', $start)
             ->where('groups.updated_at', '<=', $end)->get();
 
-        return \App\Http\Resources\GroupSummaryCollection::make($groups);
+
+        if ($request->get('includeDetails', false)) {
+            return \App\Http\Resources\GroupCollection::make($groups);
+        } else {
+            return \App\Http\Resources\GroupSummaryCollection::make($groups);
+        }
     }
 
     /**
@@ -199,6 +223,15 @@ class NetworkController extends Controller
      *              example="2022-09-18T12:30:00+00:00"
      *          )
      *      ),
+     *      @OA\Parameter(
+     *          name="includeDetails",
+     *          description="Include the details for each group.  This makes the call significantly slower.  Default false.",
+     *          required=false,
+     *          in="query",
+     *          @OA\Schema(
+     *              type="boolean"
+     *          )
+     *      ),
      *      @OA\Response(
      *          response=200,
      *          description="Successful operation",
@@ -207,10 +240,20 @@ class NetworkController extends Controller
      *                property="data",
      *                title="data",
      *                description="An array of events",
-     *                type="array",
-     *                @OA\Items(
-     *                    ref="#/components/schemas/EventSummary"
-     *                 )
+     *                oneOf={
+     *                      @OA\Schema(
+     *                          type="array",
+     *                          @OA\Items(
+     *                             ref="#/components/schemas/EventSummary"
+     *                          )
+     *                      ),
+     *                      @OA\Schema(
+     *                          type="array",
+     *                          @OA\Items(
+     *                             ref="#/components/schemas/Event"
+     *                          )
+     *                      ),
+     *                  },
      *              )
      *          )
      *       ),
@@ -242,6 +285,10 @@ class NetworkController extends Controller
             ->select('events.*')
             ->get();
 
-        return \App\Http\Resources\PartySummaryCollection::make($events);
+        if ($request->get('includeDetails', false)) {
+            return \App\Http\Resources\PartyCollection::make($events);
+        } else {
+            return \App\Http\Resources\PartySummaryCollection::make($events);
+        }
     }
 }

--- a/app/Http/Controllers/API/NetworkController.php
+++ b/app/Http/Controllers/API/NetworkController.php
@@ -192,7 +192,7 @@ class NetworkController extends Controller
      *      path="/api/v2/networks/{id}/events",
      *      operationId="getNetworkEvents",
      *      tags={"Networks"},
-     *      summary="Get Network Groups",
+     *      summary="Get Network Events",
      *      description="Returns list of events for a network.",
      *      @OA\Parameter(
      *          name="id",
@@ -225,7 +225,7 @@ class NetworkController extends Controller
      *      ),
      *      @OA\Parameter(
      *          name="includeDetails",
-     *          description="Include the details for each group.  This makes the call significantly slower.  Default false.",
+     *          description="Include the details for each event.  This makes the call significantly slower.  Default false.",
      *          required=false,
      *          in="query",
      *          @OA\Schema(

--- a/app/Http/Resources/PartyCollection.php
+++ b/app/Http/Resources/PartyCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+/**
+ * @OA\Schema(
+ *     title="EventCollection",
+ *     schema="EventCollection",
+ *     description="A collection of events.",
+ *     @OA\Xml(
+ *         name="EventCollection"
+ *     ),
+ * )
+ */
+
+class PartyCollection extends ResourceCollection
+{
+}

--- a/app/Network.php
+++ b/app/Network.php
@@ -50,7 +50,7 @@ class Network extends Model
         return $events->flatten(1);
     }
 
-    public function logo($size)
+    public function sizedLogo($size)
     {
         $logo = preg_replace('/\\.([^.\\s]{3,4})$/', "-$size.$1", $this->logo);
         return $logo;

--- a/resources/views/networks/index.blade.php
+++ b/resources/views/networks/index.blade.php
@@ -33,7 +33,7 @@
                     @foreach($yourNetworks as $network)
                         <tr>
                             <td>
-                                @php( $logo = $network->logo('_x100') )
+                                @php( $logo = $network->sizedLogo('_x100') )
                                 @if( $logo )
                                     <img style="width: auto; height:50px" src="{{ asset("/uploads/$logo") }}" alt="{{{ $network->name }}} logo">
                                 @else
@@ -79,7 +79,7 @@
                     @foreach($allNetworks as $network)
                         <tr>
                             <td>
-                              @php( $logo = $network->logo('_x100') )
+                              @php( $logo = $network->sizedLogo('_x100') )
                               @if( $logo )
                                 <img style="width: auto; height:50px" src="{{ asset("/uploads/$logo") }}" alt="{{{ $network->name }}} logo">
                               @else

--- a/resources/views/networks/show.blade.php
+++ b/resources/views/networks/show.blade.php
@@ -25,7 +25,7 @@
                     <div class="row">
                         <div class="col-lg-3 align-self-center" style="text-align:center">
                             <div class="network-icon">
-                                @php( $logo = $network->logo('_x100') )
+                                @php( $logo = $network->sizedLogo('_x100') )
                                 @if( $logo )
                                 <img style="max-width: 100%; max-height:50px" src="{{ asset("/uploads/$logo") }}" alt="{{{ $network->name }}} logo">
                                 @else

--- a/tests/Feature/Networks/APIv2NetworkTest.php
+++ b/tests/Feature/Networks/APIv2NetworkTest.php
@@ -59,10 +59,10 @@ class APIv2NetworkTest extends TestCase
     }
 
     /**
-     * @dataProvider providerTrueFalse
+     * @dataProvider providerGroupsParameters
      * @param $value
      */
-    public function testListGroups($getNextEvent) {
+    public function testListGroups($getNextEvent, $getDetails) {
         $network = factory(Network::class)->create([
                                                        'name' => 'Restart',
                                                        'events_push_to_wordpress' => true,
@@ -82,29 +82,35 @@ class APIv2NetworkTest extends TestCase
                                                                      ]);
 
         // List networks.
-        $response = $this->get("/api/v2/networks/{$network->id}/groups?" . ($getNextEvent ? 'includeNextEvent=true' : ''));
+        $url = "/api/v2/networks/{$network->id}/groups?" .
+                ($getNextEvent ? '&includeNextEvent=true' : '') .
+                ($getDetails ? '&includeDetails=true' : '');
+        $response = $this->get($url);
 
-        try {
-            $response->assertSuccessful();
-            $json = json_decode($response->getContent(), true)['data'];
-            $this->assertEquals(1, count($json));
-            $this->assertEquals($group->idgroups, $json[0]['id']);
-            $this->assertEquals($group->name, $json[0]['name']);
-            $this->assertTrue(array_key_exists('location', $json[0]));
-            $location = $json[0]['location'];
-            $this->assertEquals($group->location, $location['location']);
-            $this->assertEquals($group->country, $location['country']);
-            $this->assertEquals($group->area, $location['area']);
-            $this->assertEquals($group->latitude, $location['lat']);
-            $this->assertEquals($group->longitude, $location['lng']);
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true)['data'];
+        $this->assertEquals(1, count($json));
+        $this->assertEquals($group->idgroups, $json[0]['id']);
+        $this->assertEquals($group->name, $json[0]['name']);
+        $this->assertTrue(array_key_exists('location', $json[0]));
+        $location = $json[0]['location'];
+        $this->assertEquals($group->location, $location['location']);
+        $this->assertEquals($group->country, $location['country']);
+        $this->assertEquals($group->area, $location['area']);
+        $this->assertEquals($group->latitude, $location['lat']);
+        $this->assertEquals($group->longitude, $location['lng']);
+
+        if ($getDetails) {
+            $this->assertNotNull($json[0]['description']);
+            $this->assertEquals($event->idevents, $json[0]['next_event']['id']);
+        } else {
+            $this->assertFalse(array_key_exists('description', $json[0]));
 
             if ($getNextEvent) {
                 $this->assertEquals($event->idevents, $json[0]['next_event']['id']);
             } else {
                 $this->assertFalse(array_key_exists('next_event', $json[0]));
             }
-        } catch (\Exception $e) {
-            error_log($e->getMessage());
         }
 
         // Test updated_at filters.
@@ -123,14 +129,20 @@ class APIv2NetworkTest extends TestCase
         $this->assertEquals(0, count($json));
     }
 
-    public function providerTrueFalse() {
+    public function providerGroupsParameters() {
         return [
-            [false],
-            [true],
+            [false, false],
+            [false, true],
+            [true, false],
+            [true, true],
         ];
     }
 
-    public function testListEvents() {
+    /**
+     * @dataProvider providerEventsParameters
+     * @param $value
+     */
+    public function testListEvents($getDetails) {
         $network = factory(Network::class)->create([
                                                        'name' => 'Restart',
                                                        'events_push_to_wordpress' => true,
@@ -151,13 +163,21 @@ class APIv2NetworkTest extends TestCase
         DB::statement(DB::raw("UPDATE events SET updated_at = '2011-01-01 12:34'"));
         DB::statement(DB::raw("UPDATE `groups` SET updated_at = '2011-01-02 12:34'"));
 
-        $response = $this->get("/api/v2/networks/{$network->id}/events");
+        $url = "/api/v2/networks/{$network->id}/events" .
+            ($getDetails ? '?includeDetails=true' : '');
+        $response = $this->get($url);
         $response->assertSuccessful();
         $json = json_decode($response->getContent(), true)['data'];
         $this->assertEquals(1, count($json));
         $this->assertEquals($event->idevents, $json[0]['id']);
         $this->assertEquals('2011-01-01T12:34:00+00:00', $json[0]['updated_at']);
         $this->assertEquals('2011-01-02T12:34:00+00:00', $json[0]['group']['updated_at']);
+
+        if ($getDetails) {
+            $this->assertNotNull($json[0]['description']);
+        } else {
+            $this->assertFalse(array_key_exists('description', $json[0]));
+        }
 
         # Test updated filters.
         $start = '2011-01-01T10:34:00+00:00';
@@ -173,5 +193,12 @@ class APIv2NetworkTest extends TestCase
         $response->assertSuccessful();
         $json = json_decode($response->getContent(), true)['data'];
         $this->assertEquals(0, count($json));
+    }
+
+    public function providerEventsParameters() {
+        return [
+            [false],
+            [true],
+        ];
     }
 }


### PR DESCRIPTION
Generally the API should return quickly and without too much data, suitable for a web client.  But for networks, the API may be used for background bulk operations where it's more convenient to fetch the details in a single call.  

This PR adds an `includeDetails` parameter to allow this.