### PR TITLE
RES-1785 Show past events most recent first

### DIFF
--- a/resources/js/components/GroupEventScrollTable.vue
+++ b/resources/js/components/GroupEventScrollTable.vue
@@ -321,7 +321,12 @@ export default {
         switch (key) {
           case 'date_short':
           case 'date_long':
-            ret = new moment(b.event_start_utc).unix() - new moment(a.event_start_utc).unix()
+            if (this.past) {
+              // Show past events most recent first.
+              ret = new moment(a.event_start_utc).unix() - new moment(b.event_start_utc).unix()
+            } else {
+              ret = new moment(b.event_start_utc).unix() - new moment(a.event_start_utc).unix()
+            }
             break
           case 'title':
             const atitle = a.venue ? a.venue : a.location


### PR DESCRIPTION
We use a custom sort function for the events table; make it aware of the past.

There's a very slight confusion which could arise because of the arrows on the sort table.  You might think that the arrows should start with a different one selected on the two different tabs.  They don't.  But I think anyone who uses these arrows to change the sort direction will basically treat them as a toggle without much thought as to what they mean.