### PR TITLE
RES 1811 Fix return value for network logo path

### DIFF
--- a/app/Http/Resources/Network.php
+++ b/app/Http/Resources/Network.php
@@ -41,7 +41,7 @@ class Network extends JsonResource
      *     @OA\Property(
      *          property="logo",
      *          title="image",
-     *          description="URL of a logo for this network.  You should prefix this with /uploads before use.",
+     *          description="URL of a logo for this network.",
      *          format="string",
      *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
      *     )
@@ -241,7 +241,7 @@ class Network extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'logo' => public_path() . DIRECTORY_SEPARATOR . $this->logo,
+            'logo' => $this->logo ? ($request->root() . '/uploads/mid_' . $this->logo) : null,
             'description' => $this->description,
             'website' => $this->website,
             'shortname' => $this->shortname,

--- a/app/Http/Resources/Network.php
+++ b/app/Http/Resources/Network.php
@@ -241,7 +241,7 @@ class Network extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'logo' => $this->logo,
+            'logo' => public_path() . DIRECTORY_SEPARATOR . $this->logo,
             'description' => $this->description,
             'website' => $this->website,
             'shortname' => $this->shortname,

--- a/app/Http/Resources/Network.php
+++ b/app/Http/Resources/Network.php
@@ -241,7 +241,7 @@ class Network extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'logo' => $this->logo && is_object($this->logo) && is_object($this->logo->image) ? $this->logo->image->path : null,
+            'logo' => $this->logo,
             'description' => $this->description,
             'website' => $this->website,
             'shortname' => $this->shortname,

--- a/app/Http/Resources/NetworkSummary.php
+++ b/app/Http/Resources/NetworkSummary.php
@@ -58,7 +58,7 @@ class NetworkSummary extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'logo' => $this->logo && is_object($this->logo) && is_object($this->logo->image) ? $this->logo->image->path : null
+            'logo' => $this->logo
         ];
     }
 }

--- a/resources/js/components/GroupDevicesBreakdown.vue
+++ b/resources/js/components/GroupDevicesBreakdown.vue
@@ -99,7 +99,7 @@ export default {
 @import '~bootstrap/scss/variables';
 @import '~bootstrap/scss/mixins/_breakpoints';
 
-/deep/ .impact-stat-subtitle {
+::v-deep .impact-stat-subtitle {
   font-size: 80%;
 }
 
@@ -110,10 +110,5 @@ export default {
 .mobtitle {
   text-transform: uppercase;
   font-size: 18px;
-}
-
-// Some cluster names are a bit long in English, so make more space.
-/deep/ .ourtabs .nav-link {
-  padding-left: calc(5% + 1px) !important;
 }
 </style>

--- a/resources/sass/_events.scss
+++ b/resources/sass/_events.scss
@@ -340,6 +340,7 @@
         border-right: 1px solid $black;
         border-bottom: 1px solid $black;
         text-transform: uppercase;
+        height: 100%;
 
         &.smallpad {
             padding-left: calc(5% + 1px) !important;
@@ -352,6 +353,7 @@
         padding-left: calc(10% + 1px) !important;
         border-left: none;
         border-right: 1px solid $black;
+        height: 100%;
 
         &.smallpad {
             padding-left: calc(5% + 1px) !important;

--- a/tests/Feature/Networks/APIv2NetworkTest.php
+++ b/tests/Feature/Networks/APIv2NetworkTest.php
@@ -8,6 +8,7 @@ use App\Party;
 use App\User;
 use Carbon\Carbon;
 use DB;
+use http\Client\Request;
 use Tests\TestCase;
 
 class APIv2NetworkTest extends TestCase
@@ -58,7 +59,7 @@ class APIv2NetworkTest extends TestCase
         $this->assertEquals($network->name, $json['name']);
         $this->assertEquals($network->description, $json['description']);
         $this->assertEquals($network->website, $json['website']);
-        $this->assertEquals(public_path() . DIRECTORY_SEPARATOR . $network->logo, $json['logo']);
+        $this->assertStringEndsWith('/mid_' . $network->logo, $json['logo']);
         $this->assertTrue(array_key_exists('stats', $json));
         $this->assertTrue(array_key_exists('default_language', $json));
     }

--- a/tests/Feature/Networks/APIv2NetworkTest.php
+++ b/tests/Feature/Networks/APIv2NetworkTest.php
@@ -47,6 +47,10 @@ class APIv2NetworkTest extends TestCase
         $network = Network::first();
         self::assertNotNull($network);
 
+        // Ensure we have a logo to test retrieval.
+        $network->logo = '1590591632bedc48025b738e87fe674cf030e8c953ccdd91e914597.png';
+        $network->save();
+
         $response = $this->get('/api/v2/networks/' . $network->id);
         $response->assertSuccessful();
         $json = json_decode($response->getContent(), true)['data'];
@@ -54,6 +58,7 @@ class APIv2NetworkTest extends TestCase
         $this->assertEquals($network->name, $json['name']);
         $this->assertEquals($network->description, $json['description']);
         $this->assertEquals($network->website, $json['website']);
+        $this->assertEquals(public_path() . DIRECTORY_SEPARATOR . $network->logo, $json['logo']);
         $this->assertTrue(array_key_exists('stats', $json));
         $this->assertTrue(array_key_exists('default_language', $json));
     }


### PR DESCRIPTION
Since we changed the way in which the image uploads work, we just need to return the string value of the path now.