### PR TITLE
RES-1820 Ensure age is not older than 500 years

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -70,7 +70,7 @@ class DeviceController extends Controller
     public function ajaxCreate(Request $request)
     {
         $rules = [
-            'category' => 'required|filled',
+            'category' => 'required|filled'
         ];
 
         $validator = Validator::make($request->all(), $rules);
@@ -78,6 +78,10 @@ class DeviceController extends Controller
         if ($validator->fails()) {
             return response()->json($validator->messages(), 200);
         }
+
+        $request->validate([
+                               'age' => 'nullable|numeric|max:500'
+                           ]);
 
         $category = $request->input('category');
         $weight = $request->filled('estimate') ? $request->input('estimate', 0) : 0;
@@ -236,6 +240,10 @@ class DeviceController extends Controller
         $event_id = $request->input('event_id');
         $wiki = $request->input('wiki');
         $estimate = $request->filled('estimate') ? $request->input('estimate', 0) : 0;
+
+        $request->validate([
+            'age' => 'nullable|numeric|max:500'
+        ]);
 
         if (empty($repair_status)) { //Override
             $repair_status = 0;

--- a/resources/js/store/devices.js
+++ b/resources/js/store/devices.js
@@ -131,6 +131,12 @@ export default {
         headers: {
           'X-CSRF-TOKEN': rootGetters['auth/CSRF']
         }
+      }).catch(function(error) {
+        if (error && error.response && error.response.data) {
+          throw new Error(error.response.data.message)
+        } else {
+          throw new Error('Unknown error')
+        }
       })
 
       if (ret && ret.data && ret.data.success && ret.data.devices) {
@@ -159,6 +165,12 @@ export default {
       let ret = await axios.post('/device/edit/' + params.iddevices, params, {
         headers: {
           'X-CSRF-TOKEN': rootGetters['auth/CSRF']
+        }
+      }).catch(function(error) {
+        if (error && error.response && error.response.data) {
+          throw new Error(error.response.data.message)
+        } else {
+          throw new Error('Unknown error')
         }
       })
 


### PR DESCRIPTION
This adds a validation on the server side so that an exception is thrown if the age is > 500 years on device add/edit.  This should trigger an exception which we will see in Sentry.

Added something to ensure that these errors get displayed on the client side.

There is a different kind of validation code on the server which returns a success with some information.  I think that code is now dead, but it will get removed when we convert this to an API call, so I'm ignoring it for now.