### PR TITLE
RES-1823 Network logo broken

### DIFF
--- a/app/Http/Resources/Network.php
+++ b/app/Http/Resources/Network.php
@@ -241,7 +241,7 @@ class Network extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'logo' => $this->logo ? ($request->root() . '/uploads/mid_' . $this->logo) : null,
+            'logo' => $this->logo ? ($request->root() . '/uploads/network_logos/' . $this->logo) : null,
             'description' => $this->description,
             'website' => $this->website,
             'shortname' => $this->shortname,

--- a/app/Http/Resources/NetworkSummary.php
+++ b/app/Http/Resources/NetworkSummary.php
@@ -58,7 +58,7 @@ class NetworkSummary extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'logo' => $this->logo
+            'logo' => $this->logo ? ($request->root() . '/uploads/network_logos/' . $this->logo) : null,
         ];
     }
 }

--- a/app/Network.php
+++ b/app/Network.php
@@ -52,8 +52,9 @@ class Network extends Model
 
     public function sizedLogo($size)
     {
-        $logo = preg_replace('/\\.([^.\\s]{3,4})$/', "-$size.$1", $this->logo);
-        return $logo;
+        // Network logos are not currently sized.
+        #$logo = preg_replace('/\\.([^.\\s]{3,4})$/', "-$size.$1", $this->logo);
+        return $this->logo;
     }
 
     public function groupsNotIn()


### PR DESCRIPTION
We recently changed the Network page to remove Fixometer file.  This fix assumed that network logos were scaled, which they're not. 