### PR TITLE
RES-1824 Reset password page is not showing the email correctly.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -499,6 +499,8 @@ class UserController extends Controller
                     \Sentry\CaptureMessage($response['danger']);
                 }
             }
+        } else {
+            $email = $user ? $user->email : null;
         }
 
         return view('auth.reset-password', [

--- a/tests/Feature/Users/PasswordResetTest.php
+++ b/tests/Feature/Users/PasswordResetTest.php
@@ -58,6 +58,10 @@ class PasswordResetTest extends TestCase
 
         $restarter->refresh();
 
+        // Get the reset page - should see corresponding email.
+        $response = $this->get ('/user/reset?recovery=' . $restarter->recovery);
+        $response->assertSee($restarter->email);
+
         // Invalid code
         $response = $this->post('/user/reset', [
             'recovery' => '',


### PR DESCRIPTION
The page still works, but the email ought to show.