### PR TITLE
RES-1835 Fix queueing configuration

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'sync'),
+    'default' => env('QUEUE_CONNECTION', 'database'),
 
     /*
     |--------------------------------------------------------------------------
@@ -31,7 +31,7 @@ return [
     'connections' => [
 
         'sync' => [
-            'driver' => 'database',
+            'driver' => 'sync',
         ],
 
         'database' => [

--- a/resources/views/partials/visualisations/consume.blade.php
+++ b/resources/views/partials/visualisations/consume.blade.php
@@ -3,7 +3,7 @@
     @if( $measure == 'km' )
       <p>{{{ $equal_to }}} {{{ $measure }}}</p>
     @else
-      <p>{{{ $equal_to }}} {{{ Str::plural($measure, $equal_to) }}}</p>
+      <p>{{{ $equal_to }}} {{{ Str::plural($measure, floatval($equal_to)) }}}</p>
     @endif
     <br>
     <div class="p-5">@include('partials.visualisations.'.$measure.'-svg')</div>

--- a/resources/views/partials/visualisations/manufacture.blade.php
+++ b/resources/views/partials/visualisations/manufacture.blade.php
@@ -1,6 +1,6 @@
 <aside class="widget widget__2">
     <h2>{{{ $title }}}</h2>
-    <p title="{{{ $co2 }}} kg of CO2">{{{ $equal_to }}} {{{ Str::plural($measure, $equal_to) }}}</p>
+    <p title="{{{ $co2 }}} kg of CO2">{{{ $equal_to }}} {{{ Str::plural($measure, floatval($equal_to)) }}}</p>
     <br>
     <div class="row row-compressed">
 


### PR DESCRIPTION
Fix the queue configuration to use database by default.  Also fix up a couple of cases where we call `Str::plural` with a string, which now causes PHP warnings.