### PR TITLE
RES-1856 Allow "outdated" timezones

### DIFF
--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -720,7 +720,7 @@ class GroupController extends Controller
         $longitude = null;
         $country = null;
 
-        if ($timezone && !in_array($timezone, \DateTimeZone::listIdentifiers())) {
+        if ($timezone && !in_array($timezone, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC))) {
             throw ValidationException::withMessages(['location ' => __('partials.validate_timezone')]);
         }
 

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -270,6 +270,15 @@ class ApiController extends Controller
     }
 
     public function timezones() {
-        return response()->json(\DB::select("SELECT name FROM mysql.time_zone_name WHERE name NOT LIKE 'posix%' AND name NOT LIKE 'right%';"));
+        $zones = \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC);
+        $ret = [];
+
+        foreach ($zones as $zone) {
+            $ret[] = [
+                'name' => $zone
+            ];
+        }
+
+        return response()->json($ret);
     }
 }

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -184,7 +184,7 @@ class PartyController extends Controller
             // We might be passed a timezone; if not then use the timezone of the group.
             $timezone = $request->input('timezone', $groupobj->timezone);
 
-            if ($timezone && !in_array($timezone, \DateTimeZone::listIdentifiers())) {
+            if ($timezone && !in_array($timezone, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC))) {
                 $error['timezone'] = 'Please select a valid timezone.';
                 $response['warning'] = $error['timezone'];
             }
@@ -199,7 +199,7 @@ class PartyController extends Controller
                                    ],
                                    'timezone' => [
                                        function ($attribute, $value, $fail) use ($request) {
-                                           if ($request->filled('timezone') && !in_array($request->timezone, \DateTimeZone::listIdentifiers())) {
+                                           if ($request->filled('timezone') && !in_array($request->timezone, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC))) {
                                                $fail(__('partials.validate_timezone'));
                                            }
                                        },
@@ -399,7 +399,6 @@ class PartyController extends Controller
                       'allGroups' => $allGroups,
                       'formdata' => PartyController::expandEvent($party, NULL),
                       'remotePost' => null,
-                      'grouplist' => $Groups->findList(),
                       'user' => Auth::user(),
                       'user_groups' => $groupsUserIsInChargeOf,
                       'userInChargeOfMultipleGroups' => $userInChargeOfMultipleGroups,

--- a/app/Rules/Timezone.php
+++ b/app/Rules/Timezone.php
@@ -25,7 +25,7 @@ class Timezone implements Rule
      */
     public function passes($attribute, $value)
     {
-        return in_array($value, \DateTimeZone::listIdentifiers());
+        return in_array($value, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC));
     }
 
     /**

--- a/tests/Feature/Groups/APIv2GroupTest.php
+++ b/tests/Feature/Groups/APIv2GroupTest.php
@@ -258,4 +258,33 @@ class APIv2GroupTest extends TestCase
         $json = json_decode($response->getContent(), true);
         self::assertEquals($tag->id, $json['data']['tags'][0]['id']);
     }
+
+    public function testOutdated() {
+        // Check we can create a group with an outdated timezone.
+        $user = User::factory()->administrator()->create([
+                                                             'api_token' => '1234',
+                                                         ]);
+        // Set a network on the user.
+        $network = Network::factory()->create([
+                                                  'shortname' => 'network',
+                                              ]);
+        $user->repair_network = $network->id;
+        $user->save();
+
+        $response = $this->post(
+            '/api/v2/groups?api_token=1234',
+            [
+                'name' => 'Test Group',
+                'location' => 'London',
+                'description' => 'Some text.',
+                'timezone' => 'Australia/Canberra'
+            ]
+        );
+
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true);
+        $this->assertTrue(array_key_exists('id', $json));
+        $idgroups = $json['id'];
+        $this->assertGreaterThan(0, $idgroups);
+    }
 }

--- a/tests/Feature/Groups/GroupEditTest.php
+++ b/tests/Feature/Groups/GroupEditTest.php
@@ -123,5 +123,15 @@ class GroupEditTest extends TestCase
         $timezones = json_decode($response->getContent(), TRUE);
         self::assertGreaterThan(0, count($timezones));
         self::assertTrue(array_key_exists('name', $timezones[0]));
+
+        // Australia/Canberra is an outdated timezone; check it appears.
+        $found = false;
+        foreach ($timezones as $timezone) {
+            if ($timezone['name'] == 'Australia/Canberra') {
+                $found = true;
+            }
+        }
+
+        self::assertTrue($found);
     }
 }


### PR DESCRIPTION
Some timezones, e.g. Australia/Canberra, are "outdated", and not returned by PHP by default.  We had an inconsistency - we grabbed a list of timezones from MySQL, but then validated it using the PHP list.

It's arguable which we should use, but we should definitely be consistent.  I think we should use the PHP list, because if it doesn't work in MySQL then it should - it's a MySQL config issue.