### PR TITLE
RES-1849 Make number of events/groups shown on dashboard have a consistent max

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -33,7 +33,7 @@ class DashboardController extends Controller
 
         $expanded_events = [];
 
-        $upcoming_events = Party::futureForUser()->get();
+        $upcoming_events = Party::futureForUser()->get()->take(5);
 
         foreach ($upcoming_events as $event) {
             $expanded_event = \App\Http\Controllers\PartyController::expandEvent($event, null);
@@ -52,7 +52,7 @@ class DashboardController extends Controller
             ->orderBy('groups.name', 'ASC')
             ->groupBy('groups.idgroups', 'groups.name')
             ->select(['groups.idgroups', 'groups.name'])
-            ->take(3)
+            ->take(5)
             ->get();
 
         if ($your_groups) {


### PR DESCRIPTION
Use a max of 5 for groups and upcoming events.