### PR TITLE
RES-1843 Add OpenAPI coverage testing

### DIFF
--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -346,6 +346,8 @@ class EventController extends Controller
             return strtotime($a->resource->event_start_utc) - strtotime($b->resource->event_start_utc);
         });
 
-        return response()->json($ret);
+        return response()->json([
+            'data' => $ret
+        ]);
     }
 }

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -313,7 +313,7 @@ class EventController extends Controller
      *             type="array",
      *             description="An array of groups",
      *             @OA\Items(
-     *                 ref="#/components/schemas/EventSummary"
+     *                 ref="#/components/schemas/Event"
      *             )
      *          )
      *       ),

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -289,6 +289,40 @@ class EventController extends Controller
         return $user;
     }
 
+    /**
+     * @OA\Get(
+     *      path="/api/v2/moderate/events",
+     *      operationId="getEventsModeratev2",
+     *      tags={"Events"},
+     *      summary="Get Events for Moderation",
+     *      description="Only available for Administrators and Network Coordinators.",
+     *      @OA\Parameter(
+     *          name="api_token",
+     *          description="A valid user API token",
+     *          required=true,
+     *          in="query",
+     *          @OA\Schema(
+     *              type="string",
+     *              example="1234"
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              @OA\Property(
+     *                property="data",
+     *                title="data",
+     *                description="An array of events",
+     *                type="array",
+     *                @OA\Items(
+     *                    ref="#/components/schemas/EventSummary"
+     *                )
+     *              )
+     *          )
+     *       ),
+     *     )
+     */
     public function moderateEventsv2(Request $request) {
         // Get the user that the API has been authenticated as.
         $user = $this->getUser();

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -310,15 +310,11 @@ class EventController extends Controller
      *          response=200,
      *          description="Successful operation",
      *          @OA\JsonContent(
-     *              @OA\Property(
-     *                property="data",
-     *                title="data",
-     *                description="An array of events",
-     *                type="array",
-     *                @OA\Items(
-     *                    ref="#/components/schemas/EventSummary"
-     *                )
-     *              )
+     *             type="array",
+     *             description="An array of groups",
+     *             @OA\Items(
+     *                 ref="#/components/schemas/EventSummary"
+     *             )
      *          )
      *       ),
      *     )
@@ -346,8 +342,6 @@ class EventController extends Controller
             return strtotime($a->resource->event_start_utc) - strtotime($b->resource->event_start_utc);
         });
 
-        return response()->json([
-            'data' => $ret
-        ]);
+        return response()->json($ret);
     }
 }

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -430,7 +430,6 @@ class GroupController extends Controller
         return PartySummaryCollection::make($parties);
     }
 
-    // TODO Add to OpenAPI.
     public function listVolunteers(Request $request, $idgroups) {
         $group = Group::findOrFail($idgroups);
 
@@ -644,7 +643,73 @@ class GroupController extends Controller
         ]);
     }
 
-    // TODO Add to OpenAPI
+    /**
+     * @OA\Patch(
+     *      path="/api/v2/groups/{id}",
+     *      operationId="editGroup",
+     *      tags={"Groups"},
+     *      summary="Edit Group",
+     *      description="Edit a group.",
+     *      @OA\Parameter(
+     *          name="api_token",
+     *          description="A valid user API token",
+     *          required=true,
+     *          in="query",
+     *          @OA\Schema(
+     *              type="string",
+     *              example="1234"
+     *          )
+     *      ),
+     *     @OA\RequestBody(
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                required={"name","location","description"},
+     *                @OA\Property(
+     *                   property="name",
+     *                   ref="#/components/schemas/Group/properties/name",
+     *                ),
+     *                @OA\Property(
+     *                   property="location",
+     *                   ref="#/components/schemas/Group/properties/location",
+     *                ),
+     *                @OA\Property(
+     *                   property="phone",
+     *                   ref="#/components/schemas/Group/properties/phone"
+     *                ),
+     *                @OA\Property(
+     *                   property="website",
+     *                   ref="#/components/schemas/Group/properties/website"
+     *                ),
+     *                @OA\Property(
+     *                   property="description",
+     *                   ref="#/components/schemas/Group/properties/description",
+     *                ),
+     *                @OA\Property(
+     *                   property="timezone",
+     *                   ref="#/components/schemas/Group/properties/timezone"
+     *                ),
+     *                @OA\Property(
+     *                   description="Image for the group",
+     *                   property="image",
+     *                   type="string", format="binary"
+     *                 )
+     *             )
+     *         )
+     *    ),
+     *    @OA\Response(
+     *        response=200,
+     *        description="Successful operation",
+     *        @OA\JsonContent(
+     *            @OA\Property(
+     *              property="data",
+     *              title="data",
+     *              ref="#/components/schemas/Group"
+     *            )
+     *        ),
+     *     )
+     *  )
+     */
     public function updateGroupv2(Request $request, $idGroup) {
         $user = $this->getUser();
 

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -243,7 +243,39 @@ class GroupController extends Controller
         ]);
     }
 
-    // TODO Add to OpenAPI.
+    /**
+     * @OA\Get(
+     *      path="/api/v2//groups/names",
+     *      operationId="getGroupListv2",
+     *      tags={"Groups"},
+     *      summary="Get list of group names",
+     *      @OA\Response(
+     *          response=200,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *             description="An array of groups",
+     *             type="array",
+     *             @OA\Items(
+     *                @OA\Property(
+     *                    property="id",
+     *                    title="id",
+     *                    description="Unique identifier of this group",
+     *                    format="int64",
+     *                    example=1
+     *                ),
+     *                @OA\Property(
+     *                    property="name",
+     *                    title="name",
+     *                    description="Unique name of this group",
+     *                    format="string",
+     *                    example="Restarters HQ"
+     *                )
+     *             )
+     *          )
+     *       ),
+     *     )
+     */
+
     public static function listNamesv2(Request $request) {
         // We only return the group id and name, for speed.
         $groups = Group::select('idgroups', 'name')->get();
@@ -453,14 +485,10 @@ class GroupController extends Controller
      *          response=200,
      *          description="Successful operation",
      *          @OA\JsonContent(
-     *              @OA\Property(
-     *                description="An array of groups",
-     *                type="array",
-     *                property="data",
-     *                title="data",
-     *                @OA\Items(
-     *                    ref="#/components/schemas/GroupSummary"
-     *                )
+     *             description="An array of groups",
+     *             type="array",
+     *             @OA\Items(
+     *                 ref="#/components/schemas/GroupSummary"
      *             )
      *          )
      *       ),
@@ -469,9 +497,7 @@ class GroupController extends Controller
     public function moderateGroupsv2(Request $request) {
         $user = $this->getUser();
         $ret = \App\Http\Resources\GroupCollection::make(Group::unapprovedVisibleTo($user->id));
-        return response()->json([
-            'data' => $ret
-        ]);
+        return response()->json($ret);
     }
 
     /**

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -259,7 +259,9 @@ class GroupController extends Controller
      *                description="An array of group names",
      *                type="array",
      *                @OA\Items(
-     *                   ref="#/components/schemas/GroupSummary"
+     *                   type="object",
+     *                   @OA\Property(property="id", type="integer", example=1),
+     *                   @OA\Property(property="name", type="string", example="Group Name"),
      *                )
      *             )
      *          )
@@ -500,7 +502,7 @@ class GroupController extends Controller
      *             description="An array of groups",
      *             type="array",
      *             @OA\Items(
-     *                 ref="#/components/schemas/GroupSummary"
+     *                 ref="#/components/schemas/Group"
      *             )
      *          )
      *       ),

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -469,7 +469,9 @@ class GroupController extends Controller
     public function moderateGroupsv2(Request $request) {
         $user = $this->getUser();
         $ret = \App\Http\Resources\GroupCollection::make(Group::unapprovedVisibleTo($user->id));
-        return response()->json($ret);
+        return response()->json([
+            'data' => $ret
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -253,22 +253,26 @@ class GroupController extends Controller
      *          response=200,
      *          description="Successful operation",
      *          @OA\JsonContent(
-     *             description="An array of groups",
-     *             type="array",
-     *             @OA\Items(
-     *                @OA\Property(
-     *                    property="id",
-     *                    title="id",
-     *                    description="Unique identifier of this group",
-     *                    format="int64",
-     *                    example=1
-     *                ),
-     *                @OA\Property(
-     *                    property="name",
-     *                    title="name",
-     *                    description="Unique name of this group",
-     *                    format="string",
-     *                    example="Restarters HQ"
+     *              @OA\Property(
+     *                property="data",
+     *                title="data",
+     *                description="An array of group tags",
+     *                type="array",
+     *                @OA\Items(
+     *                   @OA\Property(
+     *                       property="id",
+     *                       title="id",
+     *                       description="Unique identifier of this group",
+     *                       format="int64",
+     *                       example=1
+     *                   ),
+     *                   @OA\Property(
+     *                       property="name",
+     *                       title="name",
+     *                       description="Unique name of this group",
+     *                       format="string",
+     *                       example="Restarters HQ"
+     *                   )
      *                )
      *             )
      *          )
@@ -293,7 +297,25 @@ class GroupController extends Controller
         ];
     }
 
-    // TODO Add to OpenAPI.
+    /**
+     * @OA\Get(
+     *      path="/api/v2/groups/tags",
+     *      operationId="getGroupTagsv2",
+     *      tags={"Groups"},
+     *      summary="Get list of group tags",
+     *      @OA\Response(
+     *          response=200,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              @OA\Property(
+     *                property="data",
+     *                title="data",
+     *                ref="#/components/schemas/Tag"
+     *              )
+     *          )
+     *       ),
+     *     )
+     */
     public static function listTagsv2(Request $request) {
         return [
             'data' => TagCollection::make(GroupTags::all())

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -349,7 +349,7 @@ class GroupController extends Controller
      *              @OA\Property(
      *                property="data",
      *                title="data",
-     *                description="An array of groups",
+     *                description="An array of events",
      *                type="array",
      *                @OA\Items(
      *                    ref="#/components/schemas/EventSummary"
@@ -432,7 +432,40 @@ class GroupController extends Controller
         return $user;
     }
 
-    // TODO Add to OpenAPI.
+    /**
+     * @OA\Get(
+     *      path="/api/v2/moderate/groups",
+     *      operationId="getGroupsModeratev2",
+     *      tags={"Groups"},
+     *      summary="Get Groups for Moderation",
+     *      description="Only available for Administrators and Network Coordinators. ",
+     *      @OA\Parameter(
+     *          name="api_token",
+     *          description="A valid user API token",
+     *          required=true,
+     *          in="query",
+     *          @OA\Schema(
+     *              type="string",
+     *              example="1234"
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              @OA\Property(
+     *                description="An array of groups",
+     *                type="array",
+     *                property="data",
+     *                title="data",
+     *                @OA\Items(
+     *                    ref="#/components/schemas/GroupSummary"
+     *                )
+     *             )
+     *          )
+     *       ),
+     *     )
+     */
     public function moderateGroupsv2(Request $request) {
         $user = $this->getUser();
         $ret = \App\Http\Resources\GroupCollection::make(Group::unapprovedVisibleTo($user->id));

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -245,7 +245,7 @@ class GroupController extends Controller
 
     /**
      * @OA\Get(
-     *      path="/api/v2//groups/names",
+     *      path="/api/v2/groups/names",
      *      operationId="getGroupListv2",
      *      tags={"Groups"},
      *      summary="Get list of group names",
@@ -256,23 +256,10 @@ class GroupController extends Controller
      *              @OA\Property(
      *                property="data",
      *                title="data",
-     *                description="An array of group tags",
+     *                description="An array of group names",
      *                type="array",
      *                @OA\Items(
-     *                   @OA\Property(
-     *                       property="id",
-     *                       title="id",
-     *                       description="Unique identifier of this group",
-     *                       format="int64",
-     *                       example=1
-     *                   ),
-     *                   @OA\Property(
-     *                       property="name",
-     *                       title="name",
-     *                       description="Unique name of this group",
-     *                       format="string",
-     *                       example="Restarters HQ"
-     *                   )
+     *                   ref="#/components/schemas/GroupSummary"
      *                )
      *             )
      *          )
@@ -310,8 +297,12 @@ class GroupController extends Controller
      *              @OA\Property(
      *                property="data",
      *                title="data",
-     *                ref="#/components/schemas/Tag"
-     *              )
+     *                description="An array of group tags",
+     *                type="array",
+     *                @OA\Items(
+     *                   ref="#/components/schemas/Tag"
+     *                )
+     *             )
      *          )
      *       ),
      *     )

--- a/app/Http/Controllers/API/NetworkController.php
+++ b/app/Http/Controllers/API/NetworkController.php
@@ -136,23 +136,20 @@ class NetworkController extends Controller
      *          description="Successful operation",
      *          @OA\JsonContent(
      *              @OA\Property(
-     *                  property="data",
-     *                  title="data",
-     *                  description="An array of groups",
-     *                  oneOf={
-     *                      @OA\Schema(
-     *                          type="array",
-     *                          @OA\Items(
-     *                            ref="#/components/schemas/GroupSummary"
-     *                          )
-     *                      ),
-     *                      @OA\Schema(
-     *                          type="array",
-     *                          @OA\Items(
-     *                            ref="#/components/schemas/Group"
-     *                          )
-     *                      ),
-     *                  },
+     *                 property="data",
+     *                 title="data",
+     *                 description="An array of groups",
+     *                 type="array",
+     *                 @OA\Items(
+     *                    oneOf={
+     *                        @OA\Schema(
+     *                          ref="#/components/schemas/GroupSummary"
+     *                        ),
+     *                        @OA\Schema(
+     *                          ref="#/components/schemas/Group"
+     *                        ),
+     *                    },
+     *                 )
      *              )
      *          )
      *       ),
@@ -260,20 +257,17 @@ class NetworkController extends Controller
      *                property="data",
      *                title="data",
      *                description="An array of events",
-     *                oneOf={
-     *                      @OA\Schema(
-     *                          type="array",
-     *                          @OA\Items(
-     *                             ref="#/components/schemas/EventSummary"
-     *                          )
-     *                      ),
-     *                      @OA\Schema(
-     *                          type="array",
-     *                          @OA\Items(
-     *                             ref="#/components/schemas/Event"
-     *                          )
-     *                      ),
-     *                  },
+     *                type="array",
+     *                @OA\Items(
+     *                    oneOf={
+     *                        @OA\Schema(
+     *                          ref="#/components/schemas/EventSummary"
+     *                        ),
+     *                        @OA\Schema(
+     *                          ref="#/components/schemas/Event"
+     *                        ),
+     *                    },
+     *                 )
      *              )
      *          )
      *       ),

--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -271,7 +271,7 @@ class Group extends JsonResource
             'networks' => new NetworkSummaryCollection($this->networks),
             'tags' => new TagCollection($this->group_tags),
             'timezone' => $this->timezone,
-            'approved' => $this->approved,
+            'approved' => $this->approved ? true : false,
         ];
 
         $ret['hosts'] = $this->resource->all_confirmed_hosts_count;

--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -64,7 +64,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *          property="next_event",
  *          title="next_event",
  *          description="Next event for this group",
- *          ref="#/components/schemas/Event"
+ *          ref="#/components/schemas/EventSummary"
  *     ),
  *     @OA\Property(
  *          property="timezone",
@@ -291,7 +291,8 @@ class Group extends JsonResource
                 'start' => $nextevent->event_start_utc,
                 'end' => $nextevent->event_end_utc,
                 'timezone' => $nextevent->timezone,
-                'title' => $nextevent->venue ?? $nextevent->location
+                'title' => $nextevent->venue ?? $nextevent->location,
+                'summary' => true
             ];
         }
 

--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -10,240 +10,242 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *     title="Group",
  *     schema="Group",
  *     description="A Group of Restarters, who organise events.",
- *     @OA\Xml(
- *         name="Group"
+ *     required={"id", "full"},
+ *     @OA\Property(
+ *          property="id",
+ *          title="id",
+ *          description="Unique identifier of this group",
+ *          format="int64",
+ *          example=1
  *     ),
+ *     @OA\Property(
+ *          property="name",
+ *          title="name",
+ *          description="Unique name of this group",
+ *          format="string",
+ *          example="Restarters HQ"
+ *     ),
+ *     @OA\Property(
+ *          property="location",
+ *          title="location",
+ *          description="The group's location",
+ *          format="object",
+ *          ref="#/components/schemas/GroupLocation"
+ *     ),
+ *     @OA\Property(
+ *          property="image",
+ *          title="image",
+ *          description="URL of an image for this group.  You should prefix this with /uploads before use.",
+ *          format="string",
+ *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
+ *     ),
+ *     @OA\Property(
+ *          property="phone",
+ *          title="phone",
+ *          description="An optional phone number to contact the group.",
+ *          format="string",
+ *          example="07544 314678"
+ *     ),
+ *     @OA\Property(
+ *          property="website",
+ *          title="website",
+ *          description="An URL for the group's own separate website.",
+ *          format="string",
+ *          example="https://therestartproject.org"
+ *     ),
+ *     @OA\Property(
+ *          property="description",
+ *          title="description",
+ *          description="HTML description of the group.",
+ *          format="string",
+ *          example="<p>This is a description.</p>"
+ *     ),
+ *     @OA\Property(
+ *          property="next_event",
+ *          title="next_event",
+ *          description="Next event for this group",
+ *          ref="#/components/schemas/Event"
+ *     ),
+ *     @OA\Property(
+ *          property="timezone",
+ *          title="timezone",
+ *          description="Timezone for this group.  If empty will inherit the timezone from the network.",
+ *          format="string",
+ *          example="Europe/London"
+ *     ),
+ *     @OA\Property(
+ *         property="hosts",
+ *         title="hosts",
+ *         description="The number of hosts of this group.",
+ *         type="number",
+ *     ),
+ *     @OA\Property(
+ *         property="restarters",
+ *         title="hosts",
+ *         description="The number of restarters in this group.",
+ *         type="number",
+ *     ),
+ *     @OA\Property(
+ *         property="approved",
+ *         title="hosts",
+ *         description="Whether the group has been approved",
+ *         type="boolean",
+ *     ),
+ *     @OA\Property(
+ *         property="networks",
+ *         title="networks",
+ *         description="An array of networks of which the group is a member.",
+ *         type="array",
+ *         @OA\Items(
+ *            ref="#/components/schemas/NetworkSummary"
+ *         )
+ *     ),
+ *     @OA\Property(
+ *         property="tags",
+ *         title="tags",
+ *         description="An array of tags which apply to the group.",
+ *         type="array",
+ *         @OA\Items(
+ *            ref="#/components/schemas/Tag"
+ *         )
+ *     ),
+ *     @OA\Property(
+ *          property="full",
+ *          title="full",
+ *          description="Indicates that this is a full result, not summary group information.",
+ *          format="boolean",
+ *          example="true"
+ *     ),
+ *     @OA\Property(
+ *          property="stats",
+ *          title="stats",
+ *          description="An array of statistics about the activity of a group.",
+ *          format="object",
+ *          @OA\Property(
+ *              property="co2_powered",
+ *              title="co2_powered",
+ *              description="The amount of CO2 saved by repairing powered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="co2_unpowered",
+ *              title="co2_unpowered",
+ *              description="The amount of CO2 saved by repairing unpowered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="co2_total",
+ *              title="co2_total",
+ *              description="co2_powered + co2_unpowered",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="waste_powered",
+ *              title="waste_powered",
+ *              description="The weight in kg of waste saved by repairing powered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="waste_unpowered",
+ *              title="waste_unpowered",
+ *              description="The weight in kg of waste saved by repairing unpowered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_powered",
+ *              title="fixed_powered",
+ *              description="The number of powered items which have been repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_unpowered",
+ *              title="fixed_unpowered",
+ *              description="The number of unpowered items which have been repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_devices",
+ *              title="fixed_devices",
+ *              description="fixed_powered + fixed_unpowered",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="repairable_devices",
+ *              title="repairable_devices",
+ *              description="The number of devices which were capable of being repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="dead_devices",
+ *              title="dead_devices",
+ *              description="The number of devices which were not capable of being repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="unknown_repair_status",
+ *              title="unknown_repair_status",
+ *              description="The number of devices where the repair status was not known.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="devices_powered",
+ *              title="devices_powered",
+ *              description="The number of powered devices seen.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="devices_unpowered",
+ *              title="devices_unpowered",
+ *              description="The number of unpowered devices seen.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="no_weight_powered",
+ *              title="no_weight_powered",
+ *              description="The number of powered devices where no weight was provided.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="no_weight_unpowered",
+ *              title="no_weight_unpowered",
+ *              description="The number of unpowered devices where no weight was provided.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="participants",
+ *              title="participants",
+ *              description="The number of people who attended.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="volunteers",
+ *              title="volunteers",
+ *              description="The number of volunteers.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="hours_volunteered",
+ *              title="hours_volunteered",
+ *              description="The estimated number of hours volunteered for this group.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="events",
+ *              title="events",
+ *              description="The number of events created by this group.",
+ *              type="number",
+ *          ),
+ *     ),
+ *     @OA\Property(
+ *          property="updated_at",
+ *          title="updated_at",
+ *          description="The last change to this group.  This includes changes which affect the stats.",
+ *          format="date-time",
+ *     )
  * )
 */
 class Group extends JsonResource
 {
-    /**
-     *     @OA\Property(
-     *          property="id",
-     *          title="id",
-     *          description="Unique identifier of this group",
-     *          format="int64",
-     *          example=1
-     *     )
-     *     @OA\Property(
-     *          property="name",
-     *          title="name",
-     *          description="Unique name of this group",
-     *          format="string",
-     *          example="Restarters HQ"
-     *     )
-     *     @OA\Property(
-     *          property="location",
-     *          title="location",
-     *          description="The group's location",
-     *          format="object",
-     *          ref="#/components/schemas/GroupLocation"
-     *     )
-     *     @OA\Property(
-     *          property="image",
-     *          title="image",
-     *          description="URL of an image for this group.  You should prefix this with /uploads before use.",
-     *          format="string",
-     *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
-     *     )
-     *     @OA\Property(
-     *          property="phone",
-     *          title="phone",
-     *          description="An optional phone number to contact the group.",
-     *          format="string",
-     *          example="07544 314678"
-     *     )
-     *     @OA\Property(
-     *          property="website",
-     *          title="website",
-     *          description="An URL for the group's own separate website.",
-     *          format="string",
-     *          example="https://therestartproject.org"
-     *     )
-     *     @OA\Property(
-     *          property="description",
-     *          title="description",
-     *          description="HTML description of the group.",
-     *          format="string",
-     *          example="<p>This is a description.</p>"
-     *     )
-     *     @OA\Property(
-     *          property="next_event",
-     *          title="next_event",
-     *          description="Next event for this group",
-     *          ref="#/components/schemas/Event"
-     *     )
-     *     @OA\Property(
-     *          property="timezone",
-     *          title="timezone",
-     *          description="Timezone for this group.  If empty will inherit the timezone from the network.",
-     *          format="string",
-     *          example="Europe/London"
-     *     )
-     *     @OA\Property(
-     *         property="hosts",
-     *         title="hosts",
-     *         description="The number of hosts of this group.",
-     *         type="number",
-     *     ),
-     *     @OA\Property(
-     *         property="restarters",
-     *         title="hosts",
-     *         description="The number of restarters in this group.",
-     *         type="number",
-     *     ),
-     *     @OA\Property(
-     *         property="approved",
-     *         title="hosts",
-     *         description="Whether the group has been approved",
-     *         type="boolean",
-     *     ),
-     *     @OA\Property(
-     *         property="networks",
-     *         title="networks",
-     *         description="An array of networks of which the group is a member.",
-     *         type="array",
-     *         @OA\Items(
-     *            ref="#/components/schemas/NetworkSummary"
-     *         )
-     *     )
-     *     @OA\Property(
-     *         property="tags",
-     *         title="tags",
-     *         description="An array of tags which apply to the group.",
-     *         type="array",
-     *         @OA\Items(
-     *            ref="#/components/schemas/Tag"
-     *         )
-     *     )
-     *     @OA\Property(
-     *          property="stats",
-     *          title="stats",
-     *          description="An array of statistics about the activity of a group.",
-     *          format="object",
-     *          @OA\Property(
-     *              property="co2_powered",
-     *              title="co2_powered",
-     *              description="The amount of CO2 saved by repairing powered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="co2_unpowered",
-     *              title="co2_unpowered",
-     *              description="The amount of CO2 saved by repairing unpowered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="co2_total",
-     *              title="co2_total",
-     *              description="co2_powered + co2_unpowered",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="waste_powered",
-     *              title="waste_powered",
-     *              description="The weight in kg of waste saved by repairing powered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="waste_unpowered",
-     *              title="waste_unpowered",
-     *              description="The weight in kg of waste saved by repairing unpowered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_powered",
-     *              title="fixed_powered",
-     *              description="The number of powered items which have been repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_unpowered",
-     *              title="fixed_unpowered",
-     *              description="The number of unpowered items which have been repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_devices",
-     *              title="fixed_devices",
-     *              description="fixed_powered + fixed_unpowered",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="repairable_devices",
-     *              title="repairable_devices",
-     *              description="The number of devices which were capable of being repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="dead_devices",
-     *              title="dead_devices",
-     *              description="The number of devices which were not capable of being repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="unknown_repair_status",
-     *              title="unknown_repair_status",
-     *              description="The number of devices where the repair status was not known.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="devices_powered",
-     *              title="devices_powered",
-     *              description="The number of powered devices seen.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="devices_unpowered",
-     *              title="devices_unpowered",
-     *              description="The number of unpowered devices seen.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="no_weight_powered",
-     *              title="no_weight_powered",
-     *              description="The number of powered devices where no weight was provided.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="no_weight_unpowered",
-     *              title="no_weight_unpowered",
-     *              description="The number of unpowered devices where no weight was provided.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="participants",
-     *              title="participants",
-     *              description="The number of people who attended.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="volunteers",
-     *              title="volunteers",
-     *              description="The number of volunteers.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="hours_volunteered",
-     *              title="hours_volunteered",
-     *              description="The estimated number of hours volunteered for this group.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="events",
-     *              title="events",
-     *              description="The number of events created by this group.",
-     *              type="number",
-     *          ),
-     *     )
-     *     @OA\Property(
-     *          property="updated_at",
-     *          title="updated_at",
-     *          description="The last change to this group.  This includes changes which affect the stats.",
-     *          format="date-time",
-     *     )
-     */
-
     private $data;
 
     /**
@@ -272,6 +274,7 @@ class Group extends JsonResource
             'tags' => new TagCollection($this->group_tags),
             'timezone' => $this->timezone,
             'approved' => $this->approved ? true : false,
+            'full' => true
         ];
 
         $ret['hosts'] = $this->resource->all_confirmed_hosts_count;

--- a/app/Http/Resources/GroupCollection.php
+++ b/app/Http/Resources/GroupCollection.php
@@ -4,6 +4,18 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
+/**
+ * @OA\Schema(
+ *     title="GroupCollection",
+ *     schema="GroupCollection",
+ *     description="A collection of groups.",
+ *     type="array",
+ *     @OA\Items(
+ *         ref="#/components/schemas/Group"
+ *     )
+ * )
+*/
+
 class GroupCollection extends ResourceCollection
 {
     /**

--- a/app/Http/Resources/GroupLocation.php
+++ b/app/Http/Resources/GroupLocation.php
@@ -10,56 +10,49 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *     title="GroupLocation",
  *     schema="GroupLocation",
  *     description="The information about the location of a group.",
- *     @OA\Xml(
- *         name="GroupLocation"
+ *     @OA\Property(
+ *          property="area",
+ *          description="The free-form area that this group is in.",
+ *          format="string",
+ *          example="London"
  *     ),
+ *     @OA\Property(
+ *          property="location",
+ *          description="The location that this group is in.  Must be geocodable.",
+ *          format="string",
+ *          example="College Road, London NW10 5EX, UK"
+ *     ),
+ *     @OA\Property(
+ *          property="country",
+ *          description="The free-form country.",
+ *          format="string",
+ *          example="United Kingdom"
+ *     ),
+ *     @OA\Property(
+ *          property="lat",
+ *          title="lat",
+ *          description="Latitude of the group.",
+ *          format="float",
+ *          example="50.8113243"
+ *     ),
+ *     @OA\Property(
+ *          property="lng",
+ *          title="lng",
+ *          description="Longitude of the group.",
+ *          format="float",
+ *          example="-1.0788839"
+ *     ),
+ *     @OA\Property(
+ *          property="postcode",
+ *          title="postcode",
+ *          description="The group postcode",
+ *          format="string",
+ *          example="SW9 7QD"
+ *     )
  * )
- */
-
+*/
 class GroupLocation extends JsonResource
 {
-    /**
-     *     @OA\Property(
-     *          property="area",
-     *          description="The free-form area that this group is in.",
-     *          format="string",
-     *          example="London"
-     *     )
-     *     @OA\Property(
-     *          property="location",
-     *          description="The location that this group is in.  Must be geocodable.",
-     *          format="string",
-     *          example="College Road, London NW10 5EX, UK"
-     *     )
-     *     @OA\Property(
-     *          property="country",
-     *          description="The free-form country.",
-     *          format="string",
-     *          example="United Kingdom"
-     *     )
-     *     @OA\Property(
-     *          property="lat",
-     *          title="lat",
-     *          description="Latitude of the group.",
-     *          format="float",
-     *          example="50.8113243"
-     *     )
-     *     @OA\Property(
-     *          property="lng",
-     *          title="lng",
-     *          description="Longitude of the group.",
-     *          format="float",
-     *          example="-1.0788839"
-     *     )
-     *     @OA\Property(
-     *          property="postcode",
-     *          title="postcode",
-     *          description="The group postcode",
-     *          format="string",
-     *          example="SW9 7QD"
-     *     )
-     */
-
     /**
      * Transform the resource into an array.
      *

--- a/app/Http/Resources/GroupSummary.php
+++ b/app/Http/Resources/GroupSummary.php
@@ -27,7 +27,7 @@ class GroupSummary extends JsonResource
      *          example=1
      *     )
      *     @OA\Property(
-     *          property="area",
+     *          property="name",
      *          title="name",
      *          description="Unique name of this group",
      *          format="string",

--- a/app/Http/Resources/GroupSummary.php
+++ b/app/Http/Resources/GroupSummary.php
@@ -108,7 +108,8 @@ class GroupSummary extends JsonResource
                     'online' => $nextevent->online,
                     'lat' => $nextevent->latitude,
                     'lng' => $nextevent->longitude,
-                    'updated_at' => $nextevent->updated_at->toIso8601String()
+                    'updated_at' => $nextevent->updated_at->toIso8601String(),
+                    'summary' => true
                 ];
             }
         }

--- a/app/Http/Resources/GroupSummary.php
+++ b/app/Http/Resources/GroupSummary.php
@@ -10,58 +10,69 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *     title="GroupSummary",
  *     schema="GroupSummary",
  *     description="The very basic information about a group.  For full information, fetch the group.",
- *     @OA\Xml(
- *         name="GroupSummary"
+ *     required={"id", "summary"},
+ *     @OA\Property(
+ *          property="id",
+ *          title="id",
+ *          description="Unique identifier of this group",
+ *          format="int64",
+ *          example=1
  *     ),
+ *     @OA\Property(
+ *          property="name",
+ *          title="name",
+ *          description="Unique name of this group",
+ *          format="string",
+ *          example="Restarters HQ"
+ *     ),
+ *     @OA\Property(
+ *          property="image",
+ *          title="image",
+ *          description="URL of an image for this group.  You should prefix this with /uploads before use.",
+ *          format="string",
+ *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
+ *     ),
+ *     @OA\Property(
+ *          property="location",
+ *          title="location",
+ *          description="The group's location",
+ *          format="object",
+ *          ref="#/components/schemas/GroupLocation"
+ *     ),
+ *     @OA\Property(
+ *         property="networks",
+ *         title="networks",
+ *         description="An array of networks of which the group is a member.",
+ *         type="array",
+ *         @OA\Items(
+ *            ref="#/components/schemas/NetworkSummary"
+ *         )
+ *     ),
+ *     @OA\Property(
+ *          property="updated_at",
+ *          title="updated_at",
+ *          description="The last change to this group.  This includes changes which affect the stats.",
+ *          format="date-time",
+ *     ),
+ *     @OA\Property(
+ *          property="next_event",
+ *          title="next_event",
+ *          description="The next event, if any, for this group.  Only present if includeNextEvent=true.",
+ *          format="object",
+ *          ref="#/components/schemas/EventSummary"
+ *     ),
+ *     @OA\Property(
+ *          property="summary",
+ *          title="summary",
+ *          description="Indicates that this is a summary result, not full group information.",
+ *          format="boolean",
+ *          example="true"
+ *     )
  * )
  */
 
 class GroupSummary extends JsonResource
 {
-    /**
-     *     @OA\Property(
-     *          property="id",
-     *          title="id",
-     *          description="Unique identifier of this group",
-     *          format="int64",
-     *          example=1
-     *     )
-     *     @OA\Property(
-     *          property="name",
-     *          title="name",
-     *          description="Unique name of this group",
-     *          format="string",
-     *          example="Restarters HQ"
-     *     )
-     *     @OA\Property(
-     *          property="location",
-     *          title="location",
-     *          description="The group's location",
-     *          format="object",
-     *          ref="#/components/schemas/GroupLocation"
-     *     )
-     *     @OA\Property(
-     *          property="image",
-     *          title="image",
-     *          description="URL of an image for this group.  You should prefix this with /uploads before use.",
-     *          format="string",
-     *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
-     *     )
-     *     @OA\Property(
-     *          property="updated_at",
-     *          title="updated_at",
-     *          description="The last change to this group.  This includes changes which affect the stats.",
-     *          format="date-time",
-     *     )
-     *     @OA\Property(
-     *          property="next_event",
-     *          title="next_event",
-     *          description="The next event, if any, for this group.  Only present if includeNextEvent=true.",
-     *          format="object",
-     *          ref="#/components/schemas/EventSummary"
-     *     )
-     */
-
     /**
      * Transform the resource into an array.
      *
@@ -74,9 +85,10 @@ class GroupSummary extends JsonResource
             'id' => $this->idgroups,
             'name' => $this->name,
             'image' => $this->groupImage && is_object($this->groupImage) && is_object($this->groupImage->image) ? $this->groupImage->image->path : null,
-            'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
-            'networks' => $this->resource->networks,
             'location' => new GroupLocation($this),
+            'networks' => new NetworkSummaryCollection($this->resource->networks),
+            'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
+            'summary' => true
         ];
 
         if ($request->get('includeNextEvent', false)) {
@@ -96,7 +108,7 @@ class GroupSummary extends JsonResource
                     'online' => $nextevent->online,
                     'lat' => $nextevent->latitude,
                     'lng' => $nextevent->longitude,
-                    'updated_at' => $nextevent->updated_at->toIso8601String(),
+                    'updated_at' => $nextevent->updated_at->toIso8601String()
                 ];
             }
         }

--- a/app/Http/Resources/GroupSummaryCollection.php
+++ b/app/Http/Resources/GroupSummaryCollection.php
@@ -4,6 +4,18 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
+/**
+ * @OA\Schema(
+ *     title="GroupSummaryCollection",
+ *     schema="GroupSummaryCollection",
+ *     description="A collection of group summaries.",
+ *     type="array",
+ *     @OA\Items(
+ *         ref="#/components/schemas/GroupSummary"
+ *     )
+ * )
+*/
+
 class GroupSummaryCollection extends ResourceCollection
 {
 }

--- a/app/Http/Resources/Network.php
+++ b/app/Http/Resources/Network.php
@@ -9,200 +9,201 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *     title="Network",
  *     schema="Network",
  *     description="A network of Groups using the Restarters platform.",
- *     @OA\Xml(
- *         name="Network"
+ *     required={"id", "full"},
+ *     @OA\Property(
+ *          property="id",
+ *          title="id",
+ *          description="Unique identifier of this network",
+ *          format="int64",
+ *          example=1
  *     ),
+ *     @OA\Property(
+ *          property="name",
+ *          title="name",
+ *          description="Unique name of this network",
+ *          format="string",
+ *          example="Default Network"
+ *     ),
+ *     @OA\Property(
+ *          property="logo",
+ *          title="image",
+ *          description="URL of a logo for this network.",
+ *          format="string",
+ *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
+ *     ),
+ *     @OA\Property(
+ *          property="description",
+ *          title="description",
+ *          description="HTML description of the network.",
+ *          format="string",
+ *          example="<p>This is a description.</p>"
+ *     ),
+ *     @OA\Property(
+ *          property="website",
+ *          title="website",
+ *          description="An URL for the networks's own separate website.",
+ *          format="string",
+ *          example="https://therestartproject.org"
+ *     ),
+ *     @OA\Property(
+ *          property="shortname",
+ *          title="shortname",
+ *          description="A short name for the network..",
+ *          format="string",
+ *          example="resarters"
+ *     ),
+ *     @OA\Property(
+ *          property="default_language",
+ *          title="default_language",
+ *          description="The default language for users in this network.",
+ *          format="string",
+ *          example="fr-BE"
+ *     ),
+ *     @OA\Property(
+ *          property="timezone",
+ *          title="timezone",
+ *          description="Default timezone for this network.",
+ *          format="string",
+ *          example="Europe/London"
+ *     ),
+ *     @OA\Property(
+ *          property="stats",
+ *          title="stats",
+ *          description="An array of statistics about the activity of a network.",
+ *          format="object",
+ *          @OA\Property(
+ *              property="co2_powered",
+ *              title="co2_powered",
+ *              description="The amount of CO2 saved by repairing powered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="co2_unpowered",
+ *              title="co2_unpowered",
+ *              description="The amount of CO2 saved by repairing unpowered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="co2_total",
+ *              title="co2_total",
+ *              description="co2_powered + co2_unpowered",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="waste_powered",
+ *              title="waste_powered",
+ *              description="The weight in kg of waste saved by repairing powered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="waste_unpowered",
+ *              title="waste_unpowered",
+ *              description="The weight in kg of waste saved by repairing unpowered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_powered",
+ *              title="fixed_powered",
+ *              description="The number of powered items which have been repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_unpowered",
+ *              title="fixed_unpowered",
+ *              description="The number of unpowered items which have been repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_devices",
+ *              title="fixed_devices",
+ *              description="fixed_powered + fixed_unpowered",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="repairable_devices",
+ *              title="repairable_devices",
+ *              description="The number of devices which were capable of being repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="dead_devices",
+ *              title="dead_devices",
+ *              description="The number of devices which were not capable of being repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="unknown_repair_status",
+ *              title="unknown_repair_status",
+ *              description="The number of devices where the repair status was not known.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="devices_powered",
+ *              title="devices_powered",
+ *              description="The number of powered devices seen.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="devices_unpowered",
+ *              title="devices_unpowered",
+ *              description="The number of unpowered devices seen.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="no_weight_powered",
+ *              title="no_weight_powered",
+ *              description="The number of powered devices where no weight was provided.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="no_weight_unpowered",
+ *              title="no_weight_unpowered",
+ *              description="The number of unpowered devices where no weight was provided.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="participants",
+ *              title="participants",
+ *              description="The number of people who attended.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="volunteers",
+ *              title="volunteers",
+ *              description="The number of volunteers.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="hours_volunteered",
+ *              title="hours_volunteered",
+ *              description="The estimated number of hours volunteered for this network.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="events",
+ *              title="events",
+ *              description="The number of events created by this network.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *               property="full",
+ *               title="full",
+ *               description="Indicates that this is a full result, not summary network information.",
+ *               format="boolean",
+ *               example="true"
+ *          )
+ *     ),
+ *     @OA\Property(
+ *          property="updated_at",
+ *          title="updated_at",
+ *          description="The last change to this network.  This includes changes which affect the stats.",
+ *          format="date-time",
+ *     )
  * )
  */
 
 class Network extends JsonResource
 {
-    /**
-     *     @OA\Property(
-     *          property="id",
-     *          title="id",
-     *          description="Unique identifier of this network",
-     *          format="int64",
-     *          example=1
-     *     )
-     *     @OA\Property(
-     *          property="name",
-     *          title="name",
-     *          description="Unique name of this network",
-     *          format="string",
-     *          example="Default Network"
-     *     )
-     *     @OA\Property(
-     *          property="logo",
-     *          title="image",
-     *          description="URL of a logo for this network.",
-     *          format="string",
-     *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
-     *     )
-     *     @OA\Property(
-     *          property="description",
-     *          title="description",
-     *          description="HTML description of the network.",
-     *          format="string",
-     *          example="<p>This is a description.</p>"
-     *     )
-     *     @OA\Property(
-     *          property="website",
-     *          title="website",
-     *          description="An URL for the networks's own separate website.",
-     *          format="string",
-     *          example="https://therestartproject.org"
-     *     )
-     *     @OA\Property(
-     *          property="shortname",
-     *          title="shortname",
-     *          description="A short name for the network..",
-     *          format="string",
-     *          example="resarters"
-     *     )
-     *     @OA\Property(
-     *          property="default_language",
-     *          title="default_language",
-     *          description="The default language for users in this network.",
-     *          format="string",
-     *          example="fr-BE"
-     *     )
-     *     @OA\Property(
-     *          property="timezone",
-     *          title="timezone",
-     *          description="Default timezone for this network.",
-     *          format="string",
-     *          example="Europe/London"
-     *     )
-     *     @OA\Property(
-     *          property="stats",
-     *          title="stats",
-     *          description="An array of statistics about the activity of a network.",
-     *          format="object",
-     *          @OA\Property(
-     *              property="co2_powered",
-     *              title="co2_powered",
-     *              description="The amount of CO2 saved by repairing powered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="co2_unpowered",
-     *              title="co2_unpowered",
-     *              description="The amount of CO2 saved by repairing unpowered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="co2_total",
-     *              title="co2_total",
-     *              description="co2_powered + co2_unpowered",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="waste_powered",
-     *              title="waste_powered",
-     *              description="The weight in kg of waste saved by repairing powered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="waste_unpowered",
-     *              title="waste_unpowered",
-     *              description="The weight in kg of waste saved by repairing unpowered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_powered",
-     *              title="fixed_powered",
-     *              description="The number of powered items which have been repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_unpowered",
-     *              title="fixed_unpowered",
-     *              description="The number of unpowered items which have been repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_devices",
-     *              title="fixed_devices",
-     *              description="fixed_powered + fixed_unpowered",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="repairable_devices",
-     *              title="repairable_devices",
-     *              description="The number of devices which were capable of being repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="dead_devices",
-     *              title="dead_devices",
-     *              description="The number of devices which were not capable of being repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="unknown_repair_status",
-     *              title="unknown_repair_status",
-     *              description="The number of devices where the repair status was not known.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="devices_powered",
-     *              title="devices_powered",
-     *              description="The number of powered devices seen.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="devices_unpowered",
-     *              title="devices_unpowered",
-     *              description="The number of unpowered devices seen.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="no_weight_powered",
-     *              title="no_weight_powered",
-     *              description="The number of powered devices where no weight was provided.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="no_weight_unpowered",
-     *              title="no_weight_unpowered",
-     *              description="The number of unpowered devices where no weight was provided.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="participants",
-     *              title="participants",
-     *              description="The number of people who attended.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="volunteers",
-     *              title="volunteers",
-     *              description="The number of volunteers.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="hours_volunteered",
-     *              title="hours_volunteered",
-     *              description="The estimated number of hours volunteered for this network.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="events",
-     *              title="events",
-     *              description="The number of events created by this network.",
-     *              type="number",
-     *          ),
-     *     )
-     *     @OA\Property(
-     *          property="updated_at",
-     *          title="updated_at",
-     *          description="The last change to this network.  This includes changes which affect the stats.",
-     *          format="date-time",
-     *     )
-     */
-
-
     /**
      * Transform the resource into an array.
      *
@@ -220,7 +221,8 @@ class Network extends JsonResource
             'shortname' => $this->shortname,
             'default_language' => $this->default_language,
             'stats' => $this->resource->stats(),
-            'timezone' => $this->resource->timezone
+            'timezone' => $this->resource->timezone,
+            'full' => true
         ];
     }
 }

--- a/app/Http/Resources/NetworkSummary.php
+++ b/app/Http/Resources/NetworkSummary.php
@@ -9,38 +9,40 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *     title="NetworkSummary",
  *     schema="NetworkSummary",
  *     description="The summary information about a network.  For the full information, fetch the network.",
- *     @OA\Xml(
- *         name="Network"
+ *     required={"id", "summary"},
+ *     @OA\Property(
+ *          property="id",
+ *          title="id",
+ *          description="Unique identifier of this network",
+ *          format="int64",
+ *          example=1
  *     ),
+ *     @OA\Property(
+ *          property="name",
+ *          title="name",
+ *          description="Unique name of this network",
+ *          format="string",
+ *          example="Default Network"
+ *     ),
+ *     @OA\Property(
+ *          property="logo",
+ *          title="image",
+ *          description="URL of a logo for this network.  You should prefix this with /uploads before use.",
+ *          format="string",
+ *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
+ *     ),
+ *     @OA\Property(
+ *          property="summary",
+ *          title="summary",
+ *          description="Indicates that this is a summary result, not full network information.",
+ *          format="boolean",
+ *          example="true"
+ *     )
  * )
  */
 
 class NetworkSummary extends JsonResource
 {
-    /**
-     *     @OA\Property(
-     *          property="id",
-     *          title="id",
-     *          description="Unique identifier of this network",
-     *          format="int64",
-     *          example=1
-     *     )
-     *     @OA\Property(
-     *          property="name",
-     *          title="name",
-     *          description="Unique name of this network",
-     *          format="string",
-     *          example="Default Network"
-     *     )
-     *     @OA\Property(
-     *          property="logo",
-     *          title="image",
-     *          description="URL of a logo for this network.  You should prefix this with /uploads before use.",
-     *          format="string",
-     *          example="/mid_1597853610178a4b76e4d666b2a7b32ee75d8a24c706f1cbf213970.png"
-     *     )
-     */
-
     /**
      * Transform the resource into an array.
      *
@@ -53,6 +55,7 @@ class NetworkSummary extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'logo' => $this->logo ? ($request->root() . '/uploads/' . $this->logo) : null,
+            'summary' => true
         ];
     }
 }

--- a/app/Http/Resources/NetworkSummaryCollection.php
+++ b/app/Http/Resources/NetworkSummaryCollection.php
@@ -4,6 +4,18 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
+/**
+ * @OA\Schema(
+ *     title="NetworkSummaryCollection",
+ *     schema="NetworkSummaryCollection",
+ *     description="A collection of network summaries.",
+ *     type="array",
+ *     @OA\Items(
+ *         ref="#/components/schemas/NetworkSummary"
+ *     )
+ * )
+*/
+
 class NetworkSummaryCollection extends ResourceCollection
 {
     /**

--- a/app/Http/Resources/Party.php
+++ b/app/Http/Resources/Party.php
@@ -10,219 +10,221 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *     title="Event",
  *     schema="Event",
  *     description="The full information about an event.",
- *     @OA\Xml(
- *         name="Event"
+ *     required={"id", "full"},
+ *     @OA\Property(
+ *          property="id",
+ *          title="id",
+ *          description="Unique identifier of this event",
+ *          format="int64",
+ *          example=1
  *     ),
+ *     @OA\Property(
+ *          property="start",
+ *          title="start",
+ *          description="Start time of the event in ISO8601 format.",
+ *          format="date-time",
+ *          example="2022-09-18T11:30:00+00:00"
+ *     ),
+ *     @OA\Property(
+ *          property="end",
+ *          title="end",
+ *          description="End time of the event in ISO8601 format",
+ *          format="date-time",
+ *          example="2022-09-18T12:30:00+00:00"
+ *     ),
+ *     @OA\Property(
+ *          property="timezone",
+ *          title="timezone",
+ *          description="Timezone in which the event is taking place.",
+ *          format="string",
+ *          example="Europe/London"
+ *     ),
+ *     @OA\Property(
+ *          property="title",
+ *          title="title",
+ *          description="Title of the event",
+ *          format="string",
+ *          example="Europe/London"
+ *     ),
+ *     @OA\Property(
+ *          property="description",
+ *          title="description",
+ *          description="A description of the event.  May contain HTML",
+ *          format="string",
+ *          example="Come along and we'll fix your broken electrical items."
+ *     ),
+ *     @OA\Property(
+ *          property="location",
+ *          title="location",
+ *          description="Human-readable address of the event",
+ *          format="string",
+ *          example="Europe/London"
+ *     ),
+ *     @OA\Property(
+ *          property="lat",
+ *          title="lat",
+ *          description="Latitude at which the event is taking place.  Only valid if online=false.",
+ *          format="float",
+ *          example="50.8113243"
+ *     ),
+ *     @OA\Property(
+ *          property="online",
+ *          title="online",
+ *          description="Whether this event is online (virtual).",
+ *          format="boolean",
+ *          example="false"
+ *     ),
+ *     @OA\Property(
+ *          property="lng",
+ *          title="lng",
+ *          description="Longitude at which the event is taking place.  Only valid if online=false.",
+ *          format="float",
+ *          example="-1.0788839"
+ *     ),
+ *     @OA\Property(
+ *          property="group",
+ *          title="group",
+ *          description="The group which is hosting this event.",
+ *          ref="#/components/schemas/GroupSummary"
+ *     ),
+ *     @OA\Property(
+ *         property="approved",
+ *         title="hosts",
+ *         description="Whether the event has been approved",
+ *         type="boolean",
+ *     ),
+ *     @OA\Property(
+ *          property="stats",
+ *          title="stats",
+ *          description="An array of statistics about the activity of an event.",
+ *          format="object",
+ *          @OA\Property(
+ *              property="co2_powered",
+ *              title="co2_powered",
+ *              description="The amount of CO2 saved by repairing powered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="co2_unpowered",
+ *              title="co2_unpowered",
+ *              description="The amount of CO2 saved by repairing unpowered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="co2_total",
+ *              title="co2_total",
+ *              description="co2_powered + co2_unpowered",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="waste_powered",
+ *              title="waste_powered",
+ *              description="The weight in kg of waste saved by repairing powered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="waste_unpowered",
+ *              title="waste_unpowered",
+ *              description="The weight in kg of waste saved by repairing unpowered items.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_powered",
+ *              title="fixed_powered",
+ *              description="The number of powered items which have been repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_unpowered",
+ *              title="fixed_unpowered",
+ *              description="The number of unpowered items which have been repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="fixed_devices",
+ *              title="fixed_devices",
+ *              description="fixed_powered + fixed_unpowered",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="repairable_devices",
+ *              title="repairable_devices",
+ *              description="The number of devices which were capable of being repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="dead_devices",
+ *              title="dead_devices",
+ *              description="The number of devices which were not capable of being repaired.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="unknown_repair_status",
+ *              title="unknown_repair_status",
+ *              description="The number of devices where the repair status was not known.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="devices_powered",
+ *              title="devices_powered",
+ *              description="The number of powered devices seen.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="devices_unpowered",
+ *              title="devices_unpowered",
+ *              description="The number of unpowered devices seen.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="no_weight_powered",
+ *              title="no_weight_powered",
+ *              description="The number of powered devices where no weight was provided.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="no_weight_unpowered",
+ *              title="no_weight_unpowered",
+ *              description="The number of unpowered devices where no weight was provided.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="participants",
+ *              title="participants",
+ *              description="The number of people who attended.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="volunteers",
+ *              title="volunteers",
+ *              description="The number of volunteers.",
+ *              type="number",
+ *          ),
+ *          @OA\Property(
+ *              property="hours_volunteered",
+ *              title="hours_volunteered",
+ *              description="The estimated number of hours volunteered for this event.",
+ *              type="number",
+ *          ),
+ *     ),
+ *     @OA\Property(
+ *          property="updated_at",
+ *          title="updated_at",
+ *          description="The last change to this group.  This includes changes which affect the stats.",
+ *          format="date-time",
+ *     ),
+ *     @OA\Property(
+ *          property="full",
+ *          title="full",
+ *          description="Indicates that this is a full result, not summary group information.",
+ *          format="boolean",
+ *          example="true"
+ *     )
  * )
  */
 
 class Party extends JsonResource
 {
-    /**
-     *     @OA\Property(
-     *          property="id",
-     *          title="id",
-     *          description="Unique identifier of this event",
-     *          format="int64",
-     *          example=1
-     *     )
-     *     @OA\Property(
-     *          property="start",
-     *          title="start",
-     *          description="Start time of the event in ISO8601 format.",
-     *          format="date-time",
-     *          example="2022-09-18T11:30:00+00:00"
-     *     )
-     *     @OA\Property(
-     *          property="end",
-     *          title="end",
-     *          description="End time of the event in ISO8601 format",
-     *          format="date-time",
-     *          example="2022-09-18T12:30:00+00:00"
-     *     )
-     *     @OA\Property(
-     *          property="timezone",
-     *          title="timezone",
-     *          description="Timezone in which the event is taking place.",
-     *          format="string",
-     *          example="Europe/London"
-     *     )
-     *     @OA\Property(
-     *          property="title",
-     *          title="title",
-     *          description="Title of the event",
-     *          format="string",
-     *          example="Europe/London"
-     *     )
-     *     @OA\Property(
-     *          property="description",
-     *          title="description",
-     *          description="A description of the event.  May contain HTML",
-     *          format="string",
-     *          example="Come along and we'll fix your broken electrical items."
-     *     )
-     *     @OA\Property(
-     *          property="location",
-     *          title="location",
-     *          description="Human-readable address of the event",
-     *          format="string",
-     *          example="Europe/London"
-     *     )
-     *     @OA\Property(
-     *          property="lat",
-     *          title="lat",
-     *          description="Latitude at which the event is taking place.  Only valid if online=false.",
-     *          format="float",
-     *          example="50.8113243"
-     *     )
-     *     @OA\Property(
-     *          property="online",
-     *          title="online",
-     *          description="Whether this event is online (virtual).",
-     *          format="boolean",
-     *          example="false"
-     *     )
-     *     @OA\Property(
-     *          property="lng",
-     *          title="lng",
-     *          description="Longitude at which the event is taking place.  Only valid if online=false.",
-     *          format="float",
-     *          example="-1.0788839"
-     *     )
-     *     @OA\Property(
-     *          property="group",
-     *          title="group",
-     *          description="The group which is hosting this event.",
-     *          ref="#/components/schemas/GroupSummary"
-     *     )
-     *     @OA\Property(
-     *         property="approved",
-     *         title="hosts",
-     *         description="Whether the event has been approved",
-     *         type="boolean",
-     *     ),
-     *     @OA\Property(
-     *          property="stats",
-     *          title="stats",
-     *          description="An array of statistics about the activity of an event.",
-     *          format="object",
-     *          @OA\Property(
-     *              property="co2_powered",
-     *              title="co2_powered",
-     *              description="The amount of CO2 saved by repairing powered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="co2_unpowered",
-     *              title="co2_unpowered",
-     *              description="The amount of CO2 saved by repairing unpowered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="co2_total",
-     *              title="co2_total",
-     *              description="co2_powered + co2_unpowered",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="waste_powered",
-     *              title="waste_powered",
-     *              description="The weight in kg of waste saved by repairing powered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="waste_unpowered",
-     *              title="waste_unpowered",
-     *              description="The weight in kg of waste saved by repairing unpowered items.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_powered",
-     *              title="fixed_powered",
-     *              description="The number of powered items which have been repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_unpowered",
-     *              title="fixed_unpowered",
-     *              description="The number of unpowered items which have been repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="fixed_devices",
-     *              title="fixed_devices",
-     *              description="fixed_powered + fixed_unpowered",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="repairable_devices",
-     *              title="repairable_devices",
-     *              description="The number of devices which were capable of being repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="dead_devices",
-     *              title="dead_devices",
-     *              description="The number of devices which were not capable of being repaired.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="unknown_repair_status",
-     *              title="unknown_repair_status",
-     *              description="The number of devices where the repair status was not known.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="devices_powered",
-     *              title="devices_powered",
-     *              description="The number of powered devices seen.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="devices_unpowered",
-     *              title="devices_unpowered",
-     *              description="The number of unpowered devices seen.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="no_weight_powered",
-     *              title="no_weight_powered",
-     *              description="The number of powered devices where no weight was provided.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="no_weight_unpowered",
-     *              title="no_weight_unpowered",
-     *              description="The number of unpowered devices where no weight was provided.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="participants",
-     *              title="participants",
-     *              description="The number of people who attended.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="volunteers",
-     *              title="volunteers",
-     *              description="The number of volunteers.",
-     *              type="number",
-     *          ),
-     *          @OA\Property(
-     *              property="hours_volunteered",
-     *              title="hours_volunteered",
-     *              description="The estimated number of hours volunteered for this event.",
-     *              type="number",
-     *          ),
-     *     )
-     *     @OA\Property(
-     *          property="updated_at",
-     *          title="updated_at",
-     *          description="The last change to this group.  This includes changes which affect the stats.",
-     *          format="date-time",
-     *     )
-     */
-
     /**
      * Transform the resource into an array.
      *

--- a/app/Http/Resources/Party.php
+++ b/app/Http/Resources/Party.php
@@ -249,6 +249,7 @@ class Party extends JsonResource
             'stats' => $this->resource->getEventStats(),
             'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
             'approved' => $this->approved ? true : false,
+            'full' => true,
         ];
     }
 }

--- a/app/Http/Resources/Party.php
+++ b/app/Http/Resources/Party.php
@@ -96,6 +96,12 @@ class Party extends JsonResource
      *          ref="#/components/schemas/GroupSummary"
      *     )
      *     @OA\Property(
+     *         property="approved",
+     *         title="hosts",
+     *         description="Whether the event has been approved",
+     *         type="boolean",
+     *     ),
+     *     @OA\Property(
      *          property="stats",
      *          title="stats",
      *          description="An array of statistics about the activity of an event.",
@@ -240,6 +246,7 @@ class Party extends JsonResource
             'description' => $this->free_text,
             'stats' => $this->resource->getEventStats(),
             'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
+            'approved' => $this->approved ? true : false,
         ];
     }
 }

--- a/app/Http/Resources/PartyCollection.php
+++ b/app/Http/Resources/PartyCollection.php
@@ -9,10 +9,11 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
  *     title="EventCollection",
  *     schema="EventCollection",
  *     description="A collection of events.",
- *     @OA\Xml(
- *         name="EventCollection"
- *     ),
- * )
+ *     type="array",
+ *     @OA\Items(
+ *         ref="#/components/schemas/Event"
+ *     )
+ * * )
  */
 
 class PartyCollection extends ResourceCollection

--- a/app/Http/Resources/PartySummary.php
+++ b/app/Http/Resources/PartySummary.php
@@ -17,7 +17,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *          description="Unique identifier of this event",
  *          format="int64",
  *          example=1
-     *     )
+ *     ),
  *     @OA\Property(
  *          property="start",
  *          title="start",
@@ -86,7 +86,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *          description="Whether this event has been approved.",
  *          format="boolean",
  *          example="false"
- *     )
+ *     ),
  *     @OA\Property(
  *          property="updated_at",
  *          title="updated_at",
@@ -99,7 +99,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *          description="Indicates that this is a summary result, not full group information.",
  *          format="boolean",
  *          example="true"
- *     ),
+ *     )
  * )
  */
 

--- a/app/Http/Resources/PartySummary.php
+++ b/app/Http/Resources/PartySummary.php
@@ -44,14 +44,14 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *          title="title",
  *          description="Title of the event",
  *          format="string",
- *          example="Europe/London"
+ *          example="Repair Cafe"
  *     ),
  *     @OA\Property(
  *          property="location",
  *          title="location",
  *          description="Human-readable address of the event",
  *          format="string",
- *          example="Europe/London"
+ *          example="Village Hall, Main Street, Anytown, UK"
  *     ),
  *     @OA\Property(
  *          property="online",

--- a/app/Http/Resources/PartySummary.php
+++ b/app/Http/Resources/PartySummary.php
@@ -81,6 +81,13 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *          ref="#/components/schemas/GroupSummary"
  *     ),
  *     @OA\Property(
+ *          property="approved",
+ *          title="approved",
+ *          description="Whether this event has been approved.",
+ *          format="boolean",
+ *          example="false"
+ *     )
+ *     @OA\Property(
  *          property="updated_at",
  *          title="updated_at",
  *          description="The last change to this group.  This includes changes which affect the stats.",
@@ -93,13 +100,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *          format="boolean",
  *          example="true"
  *     ),
- *     @OA\Property(
- *          property="approved",
- *          title="approved",
- *          description="Whether this event has been approved.",
- *          format="boolean",
- *          example="false"
- *     )
  * )
  */
 

--- a/app/Http/Resources/PartySummary.php
+++ b/app/Http/Resources/PartySummary.php
@@ -10,92 +10,94 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *     title="EventSummary",
  *     schema="EventSummary",
  *     description="The basic information about an event.  For full information, fetch the event.",
- *     @OA\Xml(
- *         name="EventSummary"
+ *     required={"id", "summary"},
+ *     @OA\Property(
+ *          property="id",
+ *          title="id",
+ *          description="Unique identifier of this event",
+ *          format="int64",
+ *          example=1
+ *     ),
+ *     @OA\Property(
+ *          property="start",
+ *          title="start",
+ *          description="Start time of the event in ISO8601 format.",
+ *          format="date-time",
+ *          example="2022-09-18T11:30:00+00:00"
+ *     ),
+ *     @OA\Property(
+ *          property="end",
+ *          title="end",
+ *          description="End time of the event in ISO8601 format",
+ *          format="date-time",
+ *          example="2022-09-18T12:30:00+00:00"
+ *     ),
+ *     @OA\Property(
+ *          property="timezone",
+ *          title="timezone",
+ *          description="Timezone in which the event is taking place.",
+ *          format="string",
+ *          example="Europe/London"
+ *     ),
+ *     @OA\Property(
+ *          property="title",
+ *          title="title",
+ *          description="Title of the event",
+ *          format="string",
+ *          example="Europe/London"
+ *     ),
+ *     @OA\Property(
+ *          property="location",
+ *          title="location",
+ *          description="Human-readable address of the event",
+ *          format="string",
+ *          example="Europe/London"
+ *     ),
+ *     @OA\Property(
+ *          property="online",
+ *          title="online",
+ *          description="Whether this event is online (virtual).",
+ *          format="boolean",
+ *          example="false"
+ *     ),
+ *     @OA\Property(
+ *          property="lat",
+ *          title="lat",
+ *          description="Latitude at which the event is taking place.  Only valid if online=false.",
+ *          format="float",
+ *          example="50.8113243"
+ *     ),
+ *     @OA\Property(
+ *          property="lng",
+ *          title="lng",
+ *          description="Longitude at which the event is taking place.  Only valid if online=false.",
+ *          format="float",
+ *          example="-1.0788839"
+ *     ),
+ *     @OA\Property(
+ *          property="group",
+ *          title="group",
+ *          description="The group which is hosting this event.",
+ *          ref="#/components/schemas/GroupSummary"
+ *     ),
+ *     @OA\Property(
+ *          property="updated_at",
+ *          title="updated_at",
+ *          description="The last change to this group.  This includes changes which affect the stats.",
+ *          format="date-time",
+ *     ),
+ *     @OA\Property(
+ *          property="summary",
+ *          title="summary",
+ *          description="Indicates that this is a summary result, not full group information.",
+ *          format="boolean",
+ *          example="true"
  *     ),
  * )
  */
 
 class PartySummary extends JsonResource
 {
-    /**
-     *     @OA\Property(
-     *          property="id",
-     *          title="id",
-     *          description="Unique identifier of this event",
-     *          format="int64",
-     *          example=1
-     *     )
-     *     @OA\Property(
-     *          property="start",
-     *          title="start",
-     *          description="Start time of the event in ISO8601 format.",
-     *          format="date-time",
-     *          example="2022-09-18T11:30:00+00:00"
-     *     )
-     *     @OA\Property(
-     *          property="end",
-     *          title="end",
-     *          description="End time of the event in ISO8601 format",
-     *          format="date-time",
-     *          example="2022-09-18T12:30:00+00:00"
-     *     )
-     *     @OA\Property(
-     *          property="timezone",
-     *          title="timezone",
-     *          description="Timezone in which the event is taking place.",
-     *          format="string",
-     *          example="Europe/London"
-     *     )
-     *     @OA\Property(
-     *          property="title",
-     *          title="title",
-     *          description="Title of the event",
-     *          format="string",
-     *          example="Europe/London"
-     *     )
-     *     @OA\Property(
-     *          property="location",
-     *          title="location",
-     *          description="Human-readable address of the event",
-     *          format="string",
-     *          example="Europe/London"
-     *     )
-     *     @OA\Property(
-     *          property="online",
-     *          title="online",
-     *          description="Whether this event is online (virtual).",
-     *          format="boolean",
-     *          example="false"
-     *     )
-     *     @OA\Property(
-     *          property="lat",
-     *          title="lat",
-     *          description="Latitude at which the event is taking place.  Only valid if online=false.",
-     *          format="float",
-     *          example="50.8113243"
-     *     )
-     *     @OA\Property(
-     *          property="lng",
-     *          title="lng",
-     *          description="Longitude at which the event is taking place.  Only valid if online=false.",
-     *          format="float",
-     *          example="-1.0788839"
-     *     )
-     *     @OA\Property(
-     *          property="group",
-     *          title="group",
-     *          description="The group which is hosting this event.",
-     *          ref="#/components/schemas/GroupSummary"
-     *     )
-     *     @OA\Property(
-     *          property="updated_at",
-     *          title="updated_at",
-     *          description="The last change to this group.  This includes changes which affect the stats.",
-     *          format="date-time",
-     *     )
-     */
-
     /**
      * Transform the resource into an array.
      *
@@ -119,7 +121,8 @@ class PartySummary extends JsonResource
             'lat' => $this->latitude,
             'lng' => $this->longitude,
             'group' => \App\Http\Resources\GroupSummary::make($this->theGroup),
-            'updated_at' => $this->updated_at->toIso8601String()
+            'updated_at' => $this->updated_at->toIso8601String(),
+            'summary' => true
         ];
     }
 }

--- a/app/Http/Resources/PartySummaryCollection.php
+++ b/app/Http/Resources/PartySummaryCollection.php
@@ -9,11 +9,12 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
  *     title="EventSummaryCollection",
  *     schema="EventSummaryCollection",
  *     description="A collection of event summaries.",
- *     @OA\Xml(
- *         name="EventSummaryCollection"
- *     ),
+ *     type="array",
+ *     @OA\Items(
+ *         ref="#/components/schemas/EventSummary"
+ *     )
  * )
- */
+*/
 
 class PartySummaryCollection extends ResourceCollection
 {

--- a/app/Http/Resources/Tag.php
+++ b/app/Http/Resources/Tag.php
@@ -9,38 +9,32 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *     title="Tag",
  *     schema="Tag",
  *     description="A tag to record something about a group.",
- *     @OA\Xml(
- *         name="Network"
+ *     @OA\Property(
+ *          property="id",
+ *          title="id",
+ *          description="Unique identifier of this tag",
+ *          format="int64",
+ *          example=1
  *     ),
+ *     @OA\Property(
+ *          property="name",
+ *          title="name",
+ *          description="Unique name of this tag",
+ *          format="string",
+ *          example="Scotland"
+ *     ),
+ *     @OA\Property(
+ *          property="description",
+ *          title="description",
+ *          description="What this tag is for",
+ *          format="string",
+ *          example="Groups in Scotland"
+ *     )
  * )
  */
 
 class Tag extends JsonResource
 {
-    /**
-     *     @OA\Property(
-     *          property="id",
-     *          title="id",
-     *          description="Unique identifier of this tag",
-     *          format="int64",
-     *          example=1
-     *     )
-     *     @OA\Property(
-     *          property="name",
-     *          title="name",
-     *          description="Unique name of this tag",
-     *          format="string",
-     *          example="Scotland"
-     *     )
-     *     @OA\Property(
-     *          property="description",
-     *          title="description",
-     *          description="What this tag is for",
-     *          format="string",
-     *          example="Groups in Scotland"
-     *     )
-     */
-
     /**
      * Transform the resource into an array.
      *

--- a/app/Http/Resources/TagCollection.php
+++ b/app/Http/Resources/TagCollection.php
@@ -4,6 +4,18 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
+/**
+ * @OA\Schema(
+ *     title="TagCollection",
+ *     schema="TagCollection",
+ *     description="A collection of group tags.",
+ *     type="array",
+ *     @OA\Items(
+ *         ref="#/components/schemas/Tag"
+ *     )
+ * )
+ */
+
 class TagCollection extends ResourceCollection
 {
     /**

--- a/composer.json
+++ b/composer.json
@@ -46,15 +46,16 @@
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.6",
+        "fakerphp/faker": "^1.20.0",
         "laravel/dusk": "^6.21",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^6.3",
+        "osteel/openapi-httpfoundation-testing": "^0.8.0",
         "php-coveralls/php-coveralls": "^2.4",
         "phpunit/phpunit": "^9.5.10",
+        "spatie/laravel-ignition": "^1.4",
         "squizlabs/php_codesniffer": "^3.6",
-        "symfony/dom-crawler": "^6.0",
-        "fakerphp/faker": "^1.20.0",
-        "spatie/laravel-ignition": "^1.4"
+        "symfony/dom-crawler": "^6.0"
     },
     "autoload": {
         "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86c42496c9ca09c1222f401c5485c713",
+    "content-hash": "4f8a9f097d45d20082d16e928ca792cb",
     "packages": [
         {
             "name": "addwiki/mediawiki-api",
@@ -9473,6 +9473,75 @@
             "time": "2022-07-11T09:26:42+00:00"
         },
         {
+            "name": "cebe/php-openapi",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cebe/php-openapi.git",
+                "reference": "020d72b8e3a9a60bc229953e93eda25c49f46f45"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cebe/php-openapi/zipball/020d72b8e3a9a60bc229953e93eda25c49f46f45",
+                "reference": "020d72b8e3a9a60bc229953e93eda25c49f46f45",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^5.2",
+                "php": ">=7.1.0",
+                "symfony/yaml": "^3.4 || ^4 || ^5 || ^6"
+            },
+            "conflict": {
+                "symfony/yaml": "3.4.0 - 3.4.4 || 4.0.0 - 4.4.17 || 5.0.0 - 5.1.9 || 5.2.0"
+            },
+            "require-dev": {
+                "apis-guru/openapi-directory": "1.0.0",
+                "cebe/indent": "*",
+                "mermade/openapi3-examples": "1.0.0",
+                "nexmo/api-specification": "1.0.0",
+                "oai/openapi-specification": "3.0.3",
+                "phpstan/phpstan": "^0.12.0",
+                "phpunit/phpunit": "^6.5 || ^7.5 || ^8.5 || ^9.4"
+            },
+            "bin": [
+                "bin/php-openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "cebe\\openapi\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Carsten Brandt",
+                    "email": "mail@cebe.cc",
+                    "homepage": "https://cebe.cc/",
+                    "role": "Creator"
+                }
+            ],
+            "description": "Read and write OpenAPI yaml/json files and make the content accessable in PHP objects.",
+            "homepage": "https://github.com/cebe/php-openapi#readme",
+            "keywords": [
+                "openapi"
+            ],
+            "support": {
+                "issues": "https://github.com/cebe/php-openapi/issues",
+                "source": "https://github.com/cebe/php-openapi"
+            },
+            "time": "2022-04-20T14:46:44+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "2.0.0",
             "source": {
@@ -9662,6 +9731,76 @@
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
+                "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/justinrainbow/json-schema/issues",
+                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.12"
+            },
+            "time": "2022-04-13T08:02:27+00:00"
+        },
+        {
             "name": "laravel/dusk",
             "version": "v6.25.2",
             "source": {
@@ -9733,6 +9872,238 @@
                 "source": "https://github.com/laravel/dusk/tree/v6.25.2"
             },
             "time": "2022-09-29T09:37:07+00:00"
+        },
+        {
+            "name": "league/openapi-psr7-validator",
+            "version": "0.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/openapi-psr7-validator.git",
+                "reference": "c3daf7cc679a8c40c591a0272392ab726b92844f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/openapi-psr7-validator/zipball/c3daf7cc679a8c40c591a0272392ab726b92844f",
+                "reference": "c3daf7cc679a8c40c591a0272392ab726b92844f",
+                "shasum": ""
+            },
+            "require": {
+                "cebe/php-openapi": "^1.6",
+                "ext-json": "*",
+                "league/uri": "^6.3",
+                "php": ">=7.2",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/http-message": "^1.0",
+                "psr/http-server-middleware": "^1.0",
+                "respect/validation": "^1.1.3 || ^2.0",
+                "riverline/multipart-parser": "^2.0.3",
+                "webmozart/assert": "^1.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.0",
+                "guzzlehttp/psr7": "^1.5",
+                "hansott/psr7-cookies": "^3.0.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpstan/phpstan-webmozart-assert": "^1",
+                "phpunit/phpunit": "^7 || ^8 || ^9",
+                "symfony/cache": "^5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OpenAPIValidation\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Validate PSR-7 messages against OpenAPI (3.0.2) specifications expressed in YAML or JSON",
+            "homepage": "https://github.com/thephpleague/openapi-psr7-validator",
+            "keywords": [
+                "http",
+                "openapi",
+                "psr7",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/openapi-psr7-validator/issues",
+                "source": "https://github.com/thephpleague/openapi-psr7-validator/tree/0.17"
+            },
+            "time": "2022-02-10T13:54:23+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "6.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/a700b4656e4c54371b799ac61e300ab25a2d1d39",
+                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "league/uri-interfaces": "^2.3",
+                "php": "^8.1",
+                "psr/http-message": "^1.0.1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.9.5",
+                "nyholm/psr7": "^1.5.1",
+                "php-http/psr7-integration-tests": "^1.1.1",
+                "phpbench/phpbench": "^1.2.6",
+                "phpstan/phpstan": "^1.8.5",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.1.1",
+                "phpstan/phpstan-strict-rules": "^1.4.3",
+                "phpunit/phpunit": "^9.5.24",
+                "psr/http-factory": "^1.0.1"
+            },
+            "suggest": {
+                "ext-fileinfo": "Needed to create Data URI from a filepath",
+                "ext-intl": "Needed to improve host validation",
+                "league/uri-components": "Needed to easily manipulate URI objects",
+                "psr/http-factory": "Needed to use the URI factory"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri/issues",
+                "source": "https://github.com/thephpleague/uri/tree/6.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-13T19:58:47+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "00e7e2943f76d8cb50c7dfdc2f6dee356e15e383"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/00e7e2943f76d8cb50c7dfdc2f6dee356e15e383",
+                "reference": "00e7e2943f76d8cb50c7dfdc2f6dee356e15e383",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.19",
+                "phpstan/phpstan": "^0.12.90",
+                "phpstan/phpstan-phpunit": "^0.12.19",
+                "phpstan/phpstan-strict-rules": "^0.12.9",
+                "phpunit/phpunit": "^8.5.15 || ^9.5"
+            },
+            "suggest": {
+                "ext-intl": "to use the IDNA feature",
+                "symfony/intl": "to use the IDNA feature via Symfony Polyfill"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common interface for URI representation",
+            "homepage": "http://github.com/thephpleague/uri-interfaces",
+            "keywords": [
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/uri-interfaces/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-28T04:27:21+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -10087,6 +10458,74 @@
                 }
             ],
             "time": "2023-01-03T12:54:54+00:00"
+        },
+        {
+            "name": "osteel/openapi-httpfoundation-testing",
+            "version": "v0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/osteel/openapi-httpfoundation-testing.git",
+                "reference": "718cd0c2b3dd9fceaab51faa9b08009477b6c025"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/osteel/openapi-httpfoundation-testing/zipball/718cd0c2b3dd9fceaab51faa9b08009477b6c025",
+                "reference": "718cd0c2b3dd9fceaab51faa9b08009477b6c025",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "league/openapi-psr7-validator": "^0.17",
+                "nyholm/psr7": "^1.0",
+                "php": "^7.2|^8.0",
+                "psr/http-message": "^1.0",
+                "symfony/http-foundation": "^4.0 || ^5.0 || ^6.0",
+                "symfony/psr-http-message-bridge": "^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=8.5.23",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Osteel\\OpenApi\\Testing\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Yannick Chenot",
+                    "email": "yannick@yellowraincoat.co.uk",
+                    "homepage": "https://github.com/osteel",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Validate HttpFoundation requests and responses against OpenAPI (3.0.x) definitions",
+            "homepage": "https://github.com/osteel/openapi-httpfoundation-testing",
+            "keywords": [
+                "api",
+                "http",
+                "httpfoundation",
+                "laravel",
+                "openapi",
+                "symfony",
+                "testing",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/osteel/openapi-httpfoundation-testing/issues",
+                "source": "https://github.com/osteel/openapi-httpfoundation-testing/tree/v0.8"
+            },
+            "time": "2023-02-01T19:24:59+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10766,6 +11205,297 @@
                 }
             ],
             "time": "2023-01-14T12:32:24+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "aff2f80e33b7f026ec96bb42f63242dc50ffcae7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/aff2f80e33b7f026ec96bb42f63242dc50ffcae7",
+                "reference": "aff2f80e33b7f026ec96bb42f63242dc50ffcae7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-handler/issues",
+                "source": "https://github.com/php-fig/http-server-handler/tree/master"
+            },
+            "time": "2018-10-30T16:46:14+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "2296f45510945530b9dceb8bcedb5cb84d40c5f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/2296f45510945530b9dceb8bcedb5cb84d40c5f5",
+                "reference": "2296f45510945530b9dceb8bcedb5cb84d40c5f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/master"
+            },
+            "time": "2018-10-30T17:12:04+00:00"
+        },
+        {
+            "name": "respect/stringifier",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Respect/Stringifier.git",
+                "reference": "e55af3c8aeaeaa2abb5fa47a58a8e9688cc23b59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Respect/Stringifier/zipball/e55af3c8aeaeaa2abb5fa47a58a8e9688cc23b59",
+                "reference": "e55af3c8aeaeaa2abb5fa47a58a8e9688cc23b59",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.8",
+                "malukenho/docheader": "^0.1.7",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/stringify.php"
+                ],
+                "psr-4": {
+                    "Respect\\Stringifier\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Respect/Stringifier Contributors",
+                    "homepage": "https://github.com/Respect/Stringifier/graphs/contributors"
+                }
+            ],
+            "description": "Converts any value to a string",
+            "homepage": "http://respect.github.io/Stringifier/",
+            "keywords": [
+                "respect",
+                "stringifier",
+                "stringify"
+            ],
+            "support": {
+                "issues": "https://github.com/Respect/Stringifier/issues",
+                "source": "https://github.com/Respect/Stringifier/tree/0.2.0"
+            },
+            "time": "2017-12-29T19:39:25+00:00"
+        },
+        {
+            "name": "respect/validation",
+            "version": "2.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Respect/Validation.git",
+                "reference": "d304ace5325efd7180daffb1f8627bb0affd4e3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Respect/Validation/zipball/d304ace5325efd7180daffb1f8627bb0affd4e3a",
+                "reference": "d304ace5325efd7180daffb1f8627bb0affd4e3a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0 || ^8.1 || ^8.2",
+                "respect/stringifier": "^0.2.0",
+                "symfony/polyfill-mbstring": "^1.2"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^3.0",
+                "malukenho/docheader": "^0.1",
+                "mikey179/vfsstream": "^1.6",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.6",
+                "psr/http-message": "^1.0",
+                "respect/coding-standard": "^3.0",
+                "squizlabs/php_codesniffer": "^3.7",
+                "symfony/validator": "^3.0||^4.0"
+            },
+            "suggest": {
+                "egulias/email-validator": "Strict (RFC compliant) email validation",
+                "ext-bcmath": "Arbitrary Precision Mathematics",
+                "ext-fileinfo": "File Information",
+                "ext-mbstring": "Multibyte String Functions"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Respect\\Validation\\": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Respect/Validation Contributors",
+                    "homepage": "https://github.com/Respect/Validation/graphs/contributors"
+                }
+            ],
+            "description": "The most awesome validation engine ever created for PHP",
+            "homepage": "http://respect.github.io/Validation/",
+            "keywords": [
+                "respect",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Respect/Validation/issues",
+                "source": "https://github.com/Respect/Validation/tree/2.2.4"
+            },
+            "time": "2023-02-15T01:05:24+00:00"
+        },
+        {
+            "name": "riverline/multipart-parser",
+            "version": "2.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Riverline/multipart-parser.git",
+                "reference": "ebba10245b5a6e03a673ff52c547d05029caedab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Riverline/multipart-parser/zipball/ebba10245b5a6e03a673ff52c547d05029caedab",
+                "reference": "ebba10245b5a6e03a673ff52c547d05029caedab",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "laminas/laminas-diactoros": "^1.8.7",
+                "phpunit/phpunit": "^5.2 || ^6.0 || ^7.0",
+                "psr/http-message": "^1.0",
+                "symfony/psr-http-message-bridge": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Riverline\\MultiPartParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Romain Cambien",
+                    "email": "romain@cambien.net"
+                },
+                {
+                    "name": "Riverline",
+                    "homepage": "http://www.riverline.fr"
+                }
+            ],
+            "description": "One class library to parse multipart content with encoding and charset support.",
+            "keywords": [
+                "http",
+                "multipart",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/Riverline/multipart-parser/issues",
+                "source": "https://github.com/Riverline/multipart-parser/tree/2.0.9"
+            },
+            "time": "2021-10-18T09:56:35+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/resources/js/store/events.js
+++ b/resources/js/store/events.js
@@ -115,8 +115,8 @@ export default {
 
       let ret = await axios.get('/api/v2/moderate/events?api_token=' + apiToken)
 
-      if (ret && ret.data && ret.data.data) {
-        commit('setModerate', ret.data.data)
+      if (ret && ret.data) {
+        commit('setModerate', ret.data)
       }
     }
   },

--- a/resources/js/store/events.js
+++ b/resources/js/store/events.js
@@ -115,8 +115,8 @@ export default {
 
       let ret = await axios.get('/api/v2/moderate/events?api_token=' + apiToken)
 
-      if (ret && ret.data) {
-        commit('setModerate', ret.data)
+      if (ret && ret.data && ret.data.data) {
+        commit('setModerate', ret.data.data)
       }
     }
   },

--- a/resources/js/store/groups.js
+++ b/resources/js/store/groups.js
@@ -121,8 +121,8 @@ export default {
 
       let ret = await axios.get('/api/v2/moderate/groups?api_token=' + apiToken)
 
-      if (ret && ret.data) {
-        commit('setModerate', ret.data)
+      if (ret && ret.data && ret.data.data) {
+        commit('setModerate', ret.data.data)
       }
     },
     async list({commit}) {

--- a/resources/js/store/groups.js
+++ b/resources/js/store/groups.js
@@ -121,8 +121,8 @@ export default {
 
       let ret = await axios.get('/api/v2/moderate/groups?api_token=' + apiToken)
 
-      if (ret && ret.data && ret.data.data) {
-        commit('setModerate', ret.data.data)
+      if (ret && ret.data) {
+        commit('setModerate', ret.data)
       }
     },
     async list({commit}) {

--- a/tests/Feature/Events/APIv2EventTest.php
+++ b/tests/Feature/Events/APIv2EventTest.php
@@ -69,8 +69,8 @@ class APIv2EventTest extends TestCase
         $response = $this->get("/api/v2/moderate/events?api_token=1234");
         $response->assertSuccessful();
         $json = json_decode($response->getContent(), true);
-        self::assertEquals(1, count($json));
-        self::assertEquals($id1, $json[0]['id']);
+        self::assertEquals(1, count($json['data']));
+        self::assertEquals($id1, $json['data'][0]['id']);
     }
 
 

--- a/tests/Feature/Events/APIv2EventTest.php
+++ b/tests/Feature/Events/APIv2EventTest.php
@@ -69,8 +69,8 @@ class APIv2EventTest extends TestCase
         $response = $this->get("/api/v2/moderate/events?api_token=1234");
         $response->assertSuccessful();
         $json = json_decode($response->getContent(), true);
-        self::assertEquals(1, count($json['data']));
-        self::assertEquals($id1, $json['data'][0]['id']);
+        self::assertEquals(1, count($json));
+        self::assertEquals($id1, $json[0]['id']);
     }
 
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -89,10 +89,12 @@ abstract class TestCase extends BaseTestCase
             }
         }
 
-        $network = new Network();
-        $network->name = 'Restarters';
-        $network->shortname = 'restarters';
-        $network->save();
+        if (!Network::where('name', 'Restarters')->first()) {
+            $network = new Network();
+            $network->name = 'Restarters';
+            $network->shortname = 'restarters';
+            $network->save();
+        }
 
         $this->withoutExceptionHandling();
         app('honeypot')->disable();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -350,16 +350,34 @@ abstract class TestCase extends BaseTestCase
 
         if (strpos($uri, '/api/v2') === 0) {
             // Validate response against OpenAPI schema.
-            try {
-                $result = $this->OpenAPIValidator->validate($response->baseResponse, $uri, 'get');
-                $this->assertTrue($result);
-            } catch (ValidationException $e) {
-                if (strpos($e->getMessage(), 'Data must match exactly one schema') !== false) {
-                    // Ignore this - see https://github.com/thephpleague/openapi-psr7-validator/issues/170
-                } else {
-                    throw $e;
-                }
-            }
+            $result = $this->OpenAPIValidator->validate($response->baseResponse, $uri, 'get');
+            $this->assertTrue($result);
+        }
+
+        return $response;
+    }
+
+    public function patch($uri, array $params = [], $headers = [])
+    {
+        $response = parent::patch($uri, $params, $headers);
+
+        if (strpos($uri, '/api/v2') === 0) {
+            // Validate response against OpenAPI schema.
+            $result = $this->OpenAPIValidator->validate($response->baseResponse, $uri, 'patch');
+            $this->assertTrue($result);
+        }
+
+        return $response;
+    }
+
+    public function post($uri, array $params = [], $headers = [])
+    {
+        $response = parent::post($uri, $params, $headers);
+
+        if (strpos($uri, '/api/v2') === 0) {
+            // Validate response against OpenAPI schema.
+            $result = $this->OpenAPIValidator->validate($response->baseResponse, $uri, 'post');
+            $this->assertTrue($result);
         }
 
         return $response;


### PR DESCRIPTION
This builds in automatic testing of the OpenAPI specification to our tests.  

We have some cases where we use `anyOf` to return a group/group summary or similar.  For the code to work out which one it is and validate it, we need to add in fields which force the models to be different (not just a subset) and make it required.

Fixes quite a fix issues with the way the API was documented which I hadn't noticed.