### PR TITLE
RES-1866 Discourse usernames not syncing

### DIFF
--- a/app/Console/Commands/SyncDiscourseUsernames.php
+++ b/app/Console/Commands/SyncDiscourseUsernames.php
@@ -69,8 +69,8 @@ class SyncDiscourseUsernames extends Command
         foreach ($usersFromDiscourse as $discourseUser) {
             if (property_exists($discourseUser, 'single_sign_on_record') &&
                 $discourseUser->single_sign_on_record &&
-                property_exists($discourseUser->single_sign_on_record, 'external_email')) {
-                $user = User::where('email', $discourseUser->single_sign_on_record->external_email)->first();
+                property_exists($discourseUser->single_sign_on_record, 'external_id')) {
+                $user = User::find($discourseUser->single_sign_on_record->external_id);
 
                 if (! is_null($user)) {
                     $usersFoundInRestarters++;


### PR DESCRIPTION
I'm not sure if this is due to a change in Discourse behaviour, but the API is no longer returning the email address.  However it does return the external (i.e. Restarters) id, so we can use that instead.