### PR TITLE
RES-1867 Allow restarters to create groups

### DIFF
--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -15,6 +15,7 @@ use App\Notifications\AdminModerationGroup;
 use App\Notifications\GroupConfirmed;
 use App\Notifications\NewGroupWithinRadius;
 use App\Party;
+use App\Role;
 use App\Rules\Timezone;
 use App\User;
 use App\UserGroups;
@@ -582,8 +583,8 @@ class GroupController extends Controller
      *  )
      */
     public function createGroupv2(Request $request) {
-        // TODO Should we restrict group creation to non-Restarters?  The code in GroupController does.
         $user = $this->getUser();
+        $user->convertToHost();
 
         list($name, $area, $postcode, $location, $phone, $website, $description, $timezone, $latitude, $longitude, $country) = $this->validateGroupParams(
             $request,

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -99,8 +99,8 @@ class GroupController extends Controller
     {
         $user = User::find(Auth::id());
 
-        // Only administrators can add groups
-        if (Fixometer::hasRole($user, 'Restarter')) {
+        // Anyone who is logged in can create a group.
+        if (!$user) {
             return redirect('/user/forbidden');
         }
 

--- a/resources/views/group/index.blade.php
+++ b/resources/views/group/index.blade.php
@@ -22,7 +22,10 @@
 
       <?php
         $all_groups = $groups;
-        $can_create = App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator') || App\Helpers\Fixometer::hasRole(Auth::user(), 'NetworkCoordinator') || App\Helpers\Fixometer::hasRole(Auth::user(), 'Host');
+
+        // Any logged-in user can create a group.
+        $can_create = Auth::user() ? true : false;
+
         $show_tags = App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator');
 
         $user = Auth::user();

--- a/tests/Feature/Groups/BasicTest.php
+++ b/tests/Feature/Groups/BasicTest.php
@@ -38,7 +38,7 @@ class BasicTest extends TestCase
             [
                 // Can't assert on all-group-tags dev systems might have varying info.
                 'your-area' => 'London',
-                ':can-create' => 'false',
+                ':can-create' => 'true',
                 ':user-id' => $user->id,
                 'tab' => $tab,
                 ':network' => 'null',

--- a/tests/Feature/Groups/GroupCreateTest.php
+++ b/tests/Feature/Groups/GroupCreateTest.php
@@ -44,6 +44,18 @@ class GroupCreateTest extends TestCase
         // of creation should convert them into a host.
         $user = $this->loginAsTestUser(Role::RESTARTER);
         $this->assertFalse($user->hasRole(Role::HOST));
+
+        // Should see create button.
+        $response = $this->get('/group');
+        $response->assertSuccessful();
+        $props = $this->assertVueProperties($response, [
+            [],
+            [
+                ':can-create' => 'true',
+            ],
+        ]);
+
+        // Should be able to create a group.
         $response = $this->get('/group/create');
         $response->assertSuccessful();
         $idgroups = $this->createGroup();

--- a/tests/Feature/Groups/GroupCreateTest.php
+++ b/tests/Feature/Groups/GroupCreateTest.php
@@ -40,9 +40,17 @@ class GroupCreateTest extends TestCase
     }
 
     public function testCreateGroupAsRestarter() {
-        $this->loginAsTestUser(Role::RESTARTER);
+        // Restarters can create groups.  This wasn't true in the past and for backwards compatibility the act
+        // of creation should convert them into a host.
+        $user = $this->loginAsTestUser(Role::RESTARTER);
+        $this->assertFalse($user->hasRole(Role::HOST));
         $response = $this->get('/group/create');
-        $response->assertRedirect('/user/forbidden');
+        $response->assertSuccessful();
+        $idgroups = $this->createGroup();
+        $this->assertNotNull($idgroups);
+        $user->refresh();
+        $this->assertEquals(Role::HOST, $user->role);
+        $this->assertTrue($user->hasRole('Host'));
     }
 
     public function testCreateBadLocation()


### PR DESCRIPTION
Restarters should be able to create groups.  Allow them to do so, and promote to a host if required.