### PR TITLE
RES-1880 Ordering of events on dashboard

### DIFF
--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -115,7 +115,7 @@ class PartyController extends Controller
             $group = Group::find($group_id);
         } else {
             // This is a logged-in user's events page.  We want all relevant events.
-            foreach (Party::forUser()->get() as $event) {
+            foreach (Party::forUser(null)->reorder()->orderBy('event_start_utc', 'DESC')->get() as $event) {
                 $e = \App\Http\Controllers\PartyController::expandEvent($event, NULL);
                 $events[] = $e;
             }

--- a/app/Party.php
+++ b/app/Party.php
@@ -267,7 +267,7 @@ class Party extends Model implements Auditable
     public function scopeFuture($query) {
         // A future event is an event where the start time is greater than now.
         $query = $query->undeleted();
-        $query = $query->where('event_start_utc', '>', date('Y-m-d H:i:s'));
+        $query = $query->where('event_start_utc', '>', date('Y-m-d H:i:s'))->orderBy('event_start_utc','ASC');
         return $query;
     }
 
@@ -336,10 +336,15 @@ class Party extends Model implements Auditable
         //
         // The queries here are not desperately efficient, but we're battling Eloquent a bit.  The data size is
         // low enough it's not really an issue.
+        //
+        // The parent may want to specify an ORDER BY.  The parent can't use the reorder() method because it
+        // doesn't seem to go deep enough to penetrate a UNION query.  So we have to use reorder() here to strip out
+        // any ORDER BY introduced by other scopes, and then rely on the parent to specify an ORDER BY if they
+        // want one.
         $this->defaultUserIds($userids);
-        $hostFor = Party::with('theGroup.networks')->hostFor($userids);
-        $attending = Party::with('theGroup.networks')->attendingOrAttended($userids);
-        $memberOf = Party::with('theGroup.networks')->memberOfGroup($userids);
+        $hostFor = Party::with('theGroup.networks')->hostFor($userids)->reorder();
+        $attending = Party::with('theGroup.networks')->attendingOrAttended($userids)->reorder();
+        $memberOf = Party::with('theGroup.networks')->memberOfGroup($userids)->reorder();
 
         // In theory $query could contain something other than all().
         return $query->whereIn('idevents', $hostFor->
@@ -350,13 +355,14 @@ class Party extends Model implements Auditable
 
     public function scopeFutureForUser($query, $userids = null) {
         $this->defaultUserIds($userids);
-        $query = $query->forUser()->future($userids);
+        $query = $query->forUser(null)->future($userids)->reorder()->orderBy('event_start_utc', 'ASC');
+        error_log($query->toSql());
         return $query;
     }
 
     public function scopePastForUser($query, $userids = null) {
         $this->defaultUserIds($userids);
-        $query = $query->forUser()->past($userids);
+        $query = $query->forUser(null)->past($userids)->reorder()->orderBy('event_start_utc', 'DESC');
         return $query;
     }
 

--- a/app/Party.php
+++ b/app/Party.php
@@ -356,7 +356,6 @@ class Party extends Model implements Auditable
     public function scopeFutureForUser($query, $userids = null) {
         $this->defaultUserIds($userids);
         $query = $query->forUser(null)->future($userids)->reorder()->orderBy('event_start_utc', 'ASC');
-        error_log($query->toSql());
         return $query;
     }
 


### PR DESCRIPTION
The upcoming events on the dashboard are appearing in an odd order.  This is because we have a default ORDER BY introduced by `scopeUndeleted`, but when that is then used indirectly via other scopes which do a `union`, the order doesn't get applied to the overall query.

Eloquent is in a bit of a guddle over this. There is a `reorder() ` method which you can use to strip out earlier ORDER BY clauses in order to replace it with your own.  But this method doesn't seem to play nice with union queries, so it doesn't fully work for the case we want.

So I've changed one of the scopes to use `reorder` earlier enough so that it works, and then impose the order again in a parent scope.

There are times when it feels like writing raw queries is a lot easier.