### PR TITLE
RES-1906 Demote network coordinator

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -380,9 +380,9 @@ class UserController extends Controller
             'role' => $request->input('user_role'),
         ]);
 
-        // If we are demoting from NetworkCoordinator to host, remove them from the list of coordinators for
+        // If we are demoting from NetworkCoordinator, remove them from the list of coordinators for
         // any networks they are currently coordinating.
-        if ($oldRole == Role::NETWORK_COORDINATOR && $user->role == Role::HOST) {
+        if ($oldRole == Role::NETWORK_COORDINATOR && ($user->role == Role::HOST) || $user->role == Role::RESTARTER) {
             $user->networks()->detach();
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -373,10 +373,18 @@ class UserController extends Controller
 
         $user = User::find($user_id);
 
+        $oldRole = $user->role;
+
         // Set role for User
         $user->update([
-        'role' => $request->input('user_role'),
+            'role' => $request->input('user_role'),
         ]);
+
+        // If we are demoting from NetworkCoordinator to host, remove them from the list of coordinators for
+        // any networks they are currently coordinating.
+        if ($oldRole == Role::NETWORK_COORDINATOR && $user->role == Role::HOST) {
+            $user->networks()->detach();
+        }
 
         // The user may have previously been removed from the group, which will mean they have an entry in
         // users_groups with deleted_at set.  Zap that if present so that sync() then works.  sync() doesn't

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -382,7 +382,7 @@ class UserController extends Controller
 
         // If we are demoting from NetworkCoordinator, remove them from the list of coordinators for
         // any networks they are currently coordinating.
-        if ($oldRole == Role::NETWORK_COORDINATOR && ($user->role == Role::HOST) || $user->role == Role::RESTARTER) {
+        if ($oldRole == Role::NETWORK_COORDINATOR && ($user->role == Role::HOST || $user->role == Role::RESTARTER)) {
             $user->networks()->detach();
         }
 

--- a/tests/Feature/Events/AddRemoveVolunteerTest.php
+++ b/tests/Feature/Events/AddRemoveVolunteerTest.php
@@ -198,7 +198,7 @@ class AddRemoveVolunteerTest extends TestCase
         $response = $this->post('/profile/edit-admin-settings', [
             '_token' => $tokenValue,
             'id' => $host->id,
-            'user_role' => 2,
+            'user_role' => Role::ADMINISTRATOR,
             'assigned_groups' => [
                 $idgroups
             ],

--- a/tests/Feature/Events/AddRemoveVolunteerTest.php
+++ b/tests/Feature/Events/AddRemoveVolunteerTest.php
@@ -9,6 +9,7 @@ use App\Network;
 use App\Notifications\AdminModerationEvent;
 use App\Notifications\NotifyRestartersOfNewEvent;
 use App\Party;
+use App\Role;
 use App\User;
 use DB;
 use Faker\Generator as Faker;

--- a/tests/Feature/Events/InviteEventTest.php
+++ b/tests/Feature/Events/InviteEventTest.php
@@ -146,8 +146,8 @@ class InviteEventTest extends TestCase
         // ...should show up in the list of events with an invitation as we have not yet accepted.
         $response3 = $this->get('/party');
         $events = $this->getVueProperties($response3)[1][':initial-events'];
-        $this->assertNotFalse(strpos($events, '"attending":false'));
-        $this->assertNotFalse(strpos($events, '"invitation"'));
+        $this->assertStringContainsString('"attending":false', $events);
+        $this->assertStringContainsString('"invitation"', $events);
 
         // Now accept the invitation.
         $response4 = $this->get($invitation);

--- a/tests/Feature/Networks/NetworkTest.php
+++ b/tests/Feature/Networks/NetworkTest.php
@@ -19,11 +19,6 @@ class NetworkTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        DB::statement('SET foreign_key_checks=0');
-        Network::truncate();
-        DB::delete('delete from user_network');
-        DB::statement('SET foreign_key_checks=1');
-
         $this->networkService = new RepairNetworkService();
     }
 
@@ -329,5 +324,40 @@ class NetworkTest extends TestCase
         $response->assertRedirect();
         $this->assertTrue($network->containsGroup($group));
         $this->assertTrue($group->isMemberOf($network));
+    }
+
+    public function testRemoveNetworkCoordinatorByRole() {
+        $this->withoutExceptionHandling();
+
+        $network = Network::factory()->create();
+
+        $admin = User::factory()->administrator()->create();
+        $coordinator = User::factory()->networkCoordinator()->create();
+        $network->addCoordinator($coordinator);
+
+        $this->actingAs($admin);
+
+        $response = $this->get('/user/edit/' . $coordinator->id);
+        $response->assertStatus(200);
+
+        $crawler = new Crawler($response->getContent());
+
+        $tokens = $crawler->filter('input[name=_token]')->each(function (Crawler $node, $i) {
+            return $node;
+        });
+
+        $tokenValue = $tokens[0]->attr('value');
+
+        $response = $this->post('/profile/edit-admin-settings', [
+            '_token' => $tokenValue,
+            'id' => $coordinator->id,
+            'assigned_groups' => [],
+            'user_role' => Role::HOST,
+        ]);
+        $response->assertSessionHas('message');
+        $this->assertTrue($response->isRedirection());
+
+        // Demoting to host should remove as a network coordinator.
+        $this->assertFalse($network->coordinators->contains($coordinator));
     }
 }

--- a/tests/Feature/Networks/NetworkTest.php
+++ b/tests/Feature/Networks/NetworkTest.php
@@ -300,10 +300,7 @@ class NetworkTest extends TestCase
         $admin = User::factory()->administrator()->create();
         $this->actingAs($admin);
 
-        $network = new Network();
-        $network->name = 'Restarters';
-        $network->shortname = 'restarters';
-        $network->save();
+        $network = Network::where('shortname', 'restarters')->first();
 
         $response = $this->get('/networks/' . $network->id . '/edit', $network->attributesToArray());
         $response->assertSuccessful();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -94,6 +94,8 @@ abstract class TestCase extends BaseTestCase
             $network->name = 'Restarters';
             $network->shortname = 'restarters';
             $network->save();
+        } else {
+            error_log("Got network");
         }
 
         $this->withoutExceptionHandling();


### PR DESCRIPTION
When we demote someone from a role of network coordinator, we should remove them from any networks they are currently coordinating.

Some test fiddling to make it easier to run them in isolation.