### PR TITLE
RES-1898 Add Cambridge Metabase Dashboard link

### DIFF
--- a/resources/views/networks/show.blade.php
+++ b/resources/views/networks/show.blade.php
@@ -72,9 +72,13 @@
                 <h2 id="about-grp">{{ __('networks.general.about') }}</h2>
 
                 <div class="events__description">
-                    <p>{!! Str::limit(strip_tags($network->description), 160, '...') !!}</p>
-                    @if( strlen($network->description) > 160 )
-                    <button data-toggle="modal" data-target="#group-description"><span>{{ __('partials.read_more') }}</span></button>
+                    @if(strlen($network->description) <= 160)
+                        {!! $network->description !!}
+                    @else
+                        <p>{!! Str::limit(strip_tags($network->description), 160, '...') !!}</p>
+                        @if( strlen($network->description) > 160 )
+                        <button data-toggle="modal" data-target="#group-description"><span>{{ __('partials.read_more') }}</span></button>
+                        @endif
                     @endif
                 </div><!-- /events__description -->
 


### PR DESCRIPTION
Change the network description so that if the description is short enough not to need truncation, then we insert it as HTML rather than stripping the tags.  This allows the Cambridgeshire Metabase link to be inserted, as long as we use a tinyurl version of it.

This is messy, but this page needs Vueification, so I don't think it's worth investing too much time in it.