### PR TITLE
RES-1926 Event handler is looking for data which doesn't get passed

### DIFF
--- a/app/Listeners/EditWordpressPostForEvent.php
+++ b/app/Listeners/EditWordpressPostForEvent.php
@@ -52,7 +52,7 @@ class EditWordpressPostForEvent
                 $group = Group::where('idgroups', $theParty->group)->first();
 
                 $custom_fields = [
-                    ['key' => 'party_grouphash', 'value' => $data['group']],
+                    ['key' => 'party_grouphash', 'value' => $theParty->group],
                     ['key' => 'party_groupcountry', 'value' => Fixometer::getCountryFromCountryCode($group->country_code)],
                     ['key' => 'party_groupcity', 'value' => $group->area],
                     ['key' => 'party_venue', 'value' => $data['venue']],

--- a/tests/Feature/Events/WordpressEventPushTest.php
+++ b/tests/Feature/Events/WordpressEventPushTest.php
@@ -103,7 +103,6 @@ class WordpressEventPushTest extends TestCase
             'event_end_utc' => Carbon::parse('4pm tomorrow')->toIso8601String(),
             'latitude' => 1,
             'longitude' => 2,
-            'group' => 3,
             'online' => FALSE,
             'venue' => 'Cloud 9',
             'location' => 'Cloud 10',


### PR DESCRIPTION
`EditWordpressPostForEvent` is looking in the data passed to the (Laravel) event for the id of the group.  That isn't always present, and doesn't need to be because we have the (Restarters) event in hand and can pull the group from there.