### PR TITLE
RES-1928 Event duplication is confusing

### DIFF
--- a/resources/js/components/EventAddEdit.vue
+++ b/resources/js/components/EventAddEdit.vue
@@ -304,9 +304,6 @@ export default {
   },
   methods: {
     async submit() {
-      // Events are created via form submission - we don't yet have an API call to do this over AJAX.  Therefore
-      // this page and the subcomponents have form inputs with suitable names.
-      //
       // Check the form is valid.
       this.$v.$touch()
 

--- a/resources/js/components/EventAddEditPage.vue
+++ b/resources/js/components/EventAddEditPage.vue
@@ -52,8 +52,8 @@ export default {
     return {
       currentid: null,
       currentdup: null,
-      event: null,
       bump: 1,
+      event: null,
       justCreated: false
     }
   },
@@ -67,7 +67,7 @@ export default {
         return null
       }
 
-      let title = this.event.venue ? this.event.venue : this.event.location
+      let title = this.event.title ? this.event.title : this.event.location
 
       // Escape it
       const div = document.createElement('div')

--- a/resources/js/components/EventAddEditPage.vue
+++ b/resources/js/components/EventAddEditPage.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <h1>{{ __('events.add_new_event') }}</h1>
+    <h1>
+      <span v-if="!currentid">{{ __('events.add_new_event') }}</span>
+      <span v-html="editTitle" />
+    </h1>
     <b-card no-body class="box mt-4">
       <b-card-body class="p-4">
         <EventAddEdit :duplicate-from="duplicateFrom" :idevents="currentid" :groups="groups" :csrf="csrf"
@@ -14,10 +17,11 @@
 <script>
 import EventAddEdit from './EventAddEdit'
 import auth from '../mixins/auth'
+import event from '../mixins/event'
 
 export default {
   components: {EventAddEdit},
-  mixins: [auth],
+  mixins: [auth, event],
   props: {
     duplicateFrom: {
       type: Number,
@@ -47,18 +51,65 @@ export default {
   data() {
     return {
       currentid: null,
+      currentdup: null,
+      event: null,
       bump: 1,
       justCreated: false
+    }
+  },
+  computed: {
+    editTitle() {
+      if (!this.currentid) {
+        return null
+      }
+
+      if (!this.event) {
+        return null
+      }
+
+      let title = this.event.venue ? this.event.venue : this.event.location
+
+      // Escape it
+      const div = document.createElement('div')
+      div.innerText = title
+      title = div.innerHTML
+
+      let ret =  this.$lang.get('events.editing', {
+        event: '<a style="color:black; text-decoration:underline" href="/party/view/' + this.currentid  +'">' + title + '</a>'
+      })
+
+      return ret
     }
   },
   created() {
     // We have a data prop for this so that we can switch to the edit view after creation.
     this.currentid = this.idevents
+    this.currentdup = this.duplicateFrom
   },
   methods: {
-    eventCreated(id) {
+    async eventCreated(id) {
+      // Get the new event into store - we need it for the title on this page.
+      this.event = await this.$store.dispatch('events/fetch', {
+        id
+      })
+
       this.currentid = id
+      this.currentdup = null
       this.justCreated = true
+
+      // We want to change the URL.  If we had a full SPA we could do this with Vue Router, but we don't, so modify
+      // the history state directly.
+      // Get host and path from current URL
+      try {
+        // Get just the host from the current URL
+        let host = window.location.host
+        let protocol = window.location.protocol
+
+        window.history.replaceState({}, "", protocol + "//" + host + "/party/edit/" + id)
+      } catch (e) {
+        console.log('Failed to update path')
+      }
+
       this.bump++
     }
   }

--- a/resources/js/components/EventAddEditPage.vue
+++ b/resources/js/components/EventAddEditPage.vue
@@ -6,7 +6,7 @@
     </h1>
     <b-card no-body class="box mt-4">
       <b-card-body class="p-4">
-        <EventAddEdit :duplicate-from="duplicateFrom" :idevents="currentid" :groups="groups" :csrf="csrf"
+        <EventAddEdit :duplicate-from="currentdup" :idevents="currentid" :groups="groups" :csrf="csrf"
                       @created="eventCreated" @edited="justCreated = false" :just-created="justCreated"
                       :can-approve="canApprove" :can-network="canNetwork"
                       :key="bump" />


### PR DESCRIPTION
Recent changes to use the API for event creation left event duplication confusing.  The duplicate was created, but the user was left on the same page and understandably thought that the duplicate hadn't been made.

This PR ensures that the page URL is updated correctly, that the page title is updated, and that we display the new event in edit mode.

Some of this is working around the fact that we don't have a genuine SPA.  