### PR TITLE
RES-1927 First month in events table is not translated

### DIFF
--- a/resources/js/mixins/event.js
+++ b/resources/js/mixins/event.js
@@ -47,10 +47,12 @@ export default {
     },
     dayofmonth() {
       // Local time.
+      moment.locale(this.$lang.getLocale())
       return this.event ? (new moment(this.event.event_date_local).format('DD')) : null
     },
     month() {
       // Local time.
+      moment.locale(this.$lang.getLocale())
       return this.event ? (new moment(this.event.event_date_local).format('MMM').toUpperCase()) : null
     },
     timezone() {


### PR DESCRIPTION
This is because we failed to set the locale when getting the month (and also day of month).  The locale will get set later, inside the `date` computed, which means that for subsequent rows in the table we'll be using the correct locale.