### PR TITLE
RES-1934 Make age field always appear in a consistent position

### DIFF
--- a/resources/js/components/EventDevice.vue
+++ b/resources/js/components/EventDevice.vue
@@ -25,8 +25,8 @@
                        :suppress-brand-warning="suppressBrandWarning"/>
           <DeviceModel class="mb-2" :model.sync="currentDevice.model" :icon-variant="add ? 'black' : 'brand'"
                        :disabled="disabled"/>
-          <DeviceWeight v-if="showWeight" :weight.sync="currentDevice.estimate" :disabled="disabled" :required="weightRequired" />
           <DeviceAge :age.sync="currentDevice.age" :disabled="disabled"/>
+          <DeviceWeight v-if="showWeight" :weight.sync="currentDevice.estimate" :disabled="disabled" :required="weightRequired" />
           <DeviceImages :idevents="idevents" :device="currentDevice" :add="add" :edit="edit" :disabled="disabled"
                         class="mt-2" @remove="removeImage($event)"/>
         </b-card>


### PR DESCRIPTION
The weight field doesn't always show (intentionally) and this can cause the position of the age field to move around.  Move the weight field down so that this inconsistency doesn't happen.