### PR TITLE
RES-1929 Crystallise timezone on past events

### DIFF
--- a/app/Console/Commands/CrystalliseEventTimezone.php
+++ b/app/Console/Commands/CrystalliseEventTimezone.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Party;
+use App\Services\DiscourseService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class CrystalliseEventTimezone extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'event:timezones';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set timezone on past events';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(DiscourseService $discourseService)
+    {
+        parent::__construct();
+        $this->discourseService = $discourseService;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $events = Party::past()->where('timezone', null)->get();
+
+        foreach ($events as $event) {
+            $event->timezone = $event->theGroup->timezone;
+            $event->save();
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -43,6 +43,8 @@ class Kernel extends ConsoleKernel
             ->emailOutputTo(env('SEND_COMMAND_LOGS_TO'), 'tech@therestartproject.org');
 
         $schedule->command('groups:country')->hourly();
+
+        $schedule->command('event:timezones')->hourly();
     }
 
     /**


### PR DESCRIPTION
Add a scheduled job which sets the timezone on events explicitly once they've passed.  This avoids the potential problem where groups change timezone later.  It also helps with some Metabase reports.