### PR TITLE
RES-1941 Changes to network data on groups not persisting

### DIFF
--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -272,6 +272,13 @@ class Group extends JsonResource
         $stats['events'] = $stats['parties'];
         unset($stats['parties']);
 
+        $networkData = gettype($this->network_data) == 'string' ? json_decode($this->network_data, true) : $this->network_data;
+
+        if (getType($networkData) === 'array' && !count(array_keys($networkData))) {
+            // We don't want to return [] as the client expects an object, not an array.
+            $networkData = null;
+        }
+
         $ret = [
             'id' => $this->idgroups,
             'name' => $this->name,
@@ -286,7 +293,7 @@ class Group extends JsonResource
             'tags' => new TagCollection($this->group_tags),
             'timezone' => $this->timezone,
             'approved' => $this->approved ? true : false,
-            'network_data' => gettype($this->network_data) == 'string' ? json_decode($this->network_data, true) : $this->network_data,
+            'network_data' => $networkData,
             'full' => true,
             'email' => $this->email,
         ];

--- a/app/Http/Resources/Party.php
+++ b/app/Http/Resources/Party.php
@@ -245,6 +245,13 @@ class Party extends JsonResource
     public function toArray($request)
     {
         // We return information which can be public, and we rename fields to look more consistent.
+        $networkData = gettype($this->network_data) == 'string' ? json_decode($this->network_data, true) : $this->network_data;
+
+        if (getType($networkData) === 'array' && !count(array_keys($networkData))) {
+            // We don't want to return [] as the client expects an object, not an array.
+            $networkData = null;
+        }
+
         $ret = [
             'id' => $this->idevents,
             'start' => $this->event_start_utc,
@@ -260,7 +267,7 @@ class Party extends JsonResource
             'stats' => $this->resource->getEventStats(),
             'updated_at' => Carbon::parse($this->updated_at)->toIso8601String(),
             'approved' => $this->approved ? true : false,
-            'network_data' => gettype($this->network_data) == 'string' ? json_decode($this->network_data, true) : $this->network_data,
+            'network_data' => $networkData,
             'full' => true,
         ];
 

--- a/tests/Feature/Events/APIv2EventTest.php
+++ b/tests/Feature/Events/APIv2EventTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\DomCrawler\Crawler;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\TestCase;
+use function PHPUnit\Framework\assertEquals;
 
 class APIv2EventTest extends TestCase
 {
@@ -287,4 +288,22 @@ class APIv2EventTest extends TestCase
         ]);
     }
 
+    public function testEmptyNetworkData() {
+        $user = User::factory()->administrator()->create([
+            'api_token' => '1234',
+        ]);
+        $this->actingAs($user);
+
+        $idgroups = $this->createGroup();
+        $idevents = $this->createEvent($idgroups, 'tomorrow');
+
+        $party = Party::findOrFail($idevents);
+        $party->network_data = [];
+        $party->save();
+
+        $response = $this->get("/api/v2/events/$idevents");
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true);
+        assertEquals(null, $json['data']['network_data']);
+    }
 }


### PR DESCRIPTION
In the DB, we have some groups with `network_data` set to `"[]"`.  The server will encode this up into JSON, and then on the client side this will be an array not (as expected) an object.  That means when we set new network data values, they're not saved properly.

This fix strips out the `network_data` field from the API if it is of type array, and returns null instead.  The client will then default the network data to `{}`, an object, which works correctly.