### PR TITLE
RES-1940 Approve dropdown wrongly showing for events after approval

### DIFF
--- a/resources/js/components/EventAddEdit.vue
+++ b/resources/js/components/EventAddEdit.vue
@@ -308,6 +308,12 @@ export default {
       }
 
       this.networkData = setFrom.network_data ? setFrom.network_data : {}
+
+      if (!this.creating) {
+        this.eventApproved = setFrom.approved
+      } else {
+        this.eventApproved = this.autoApprove
+      }
     }
 
     // If only one group, default to that.


### PR DESCRIPTION
Approval is working, but the approve dropdown shouldn't show once the event has been approved.  Make sure we set our local flag that controls this from the event data.