### PR TITLE
RES-1944 group location not persisted

### DIFF
--- a/lang/en/events.php
+++ b/lang/en/events.php
@@ -157,7 +157,7 @@ return [
   'image_delete_error' => 'Sorry, but the image can\'t be deleted.',
   'delete_permission' => 'You do not have permission to delete this event.',
   'delete_success' => 'Event has been deleted.',
-  'geocode_failed' => 'The address you entered could not be found. Please try a more general address.',
+  'geocode_failed' => 'Location not found. If you are unable to find the location of your event, please try a more general location (such as village/town), or a specific street address, rather than a building name.',
   'create_failed' => 'Event could <strong>not</strong> be created. Please look at the reported errors, correct them, and try again.',
   'edit_succeeded' => 'Event updated!',
   'edit_failed' => 'Event could not be edited.',

--- a/lang/en/groups.php
+++ b/lang/en/groups.php
@@ -56,7 +56,7 @@ return [
   'edit_group' => 'Edit group',
   'edit_group_save_changes' => 'Save changes',
   'edit_group_text' => 'Go ahead and change or improve your group\'s profile.',
-  'groups_location_small' => 'I.e the place where the fixing happens!',
+  'groups_location_small' => 'The venue or area where your group operates',
   'group_image' => 'Group image',
   'tag-1' => 'Tag 1',
   'tag-2' => 'Tag 2',
@@ -144,7 +144,7 @@ return [
   'nearest_groups' => 'These are the groups that are within 50 km of :location',
   'nearest_groups_change' => '(change)',
   'invitation_pending' => 'You have an invitation to this group.  Please click <a href=":accept">here</a> if you would like to join.',
-  'geocode_failed' => 'The address you entered could not be found. Please try a more general address.',
+  'geocode_failed' => 'Location not found. If you are unable to find the location of your group, please try a more general location (such as village/town), or a specific street address, rather than a building name.',
   'discourse_title' => 'This is a discussion group for anyone who follows :group.
 
 Find the group\'s main page here: :link.

--- a/lang/fr-BE/events.php
+++ b/lang/fr-BE/events.php
@@ -154,7 +154,7 @@ return [
   'image_delete_error' => 'Désolé, mais l\'image ne peut pas être supprimée.',
   'delete_permission' => 'Vous n\'avez pas la permission de supprimer cet événement',
   'delete_success' => 'L\'événement a été supprimé.',
-  'geocode_failed' => 'L\'adresse que vous avez encodée n\'a pas pu être trouvée. Veuillez essayer une adresse plus générale.',
+  'geocode_failed' => 'Lieu non trouvé. Si vous ne parvenez pas à trouver le lieu où se trouve votre événement, essayez d\'indiquer un lieu plus général (tel qu\'un village ou une ville) ou une adresse spécifique, plutôt qu\'un nom de bâtiment.',
   'create_failed' => 'L\'événement <strong>n\'a pas pu</strong> être créé. Veuillez regarder les erreurs, les corriger, et essayer à nouveau.',
   'edit_succeeded' => 'L\'édition du l\'événement Café a réussi',
   'edit_failed' => 'L\'événement n\'a pas pu être édité.',

--- a/lang/fr-BE/groups.php
+++ b/lang/fr-BE/groups.php
@@ -48,7 +48,7 @@ return [
   'edit_group' => 'Editer Repair Café',
   'edit_group_save_changes' => 'Sauvegarder',
   'edit_group_text' => 'Allez-y! Changez ou améliorez le profil de votre Repair Café',
-  'groups_location_small' => 'Ex: l\'endroit où les réparations ont lieu!',
+  'groups_location_small' => 'Le lieu ou la région où votre Repair Café opère',
   'group_image' => 'Image du Repair Café',
   'tag-1' => 'Tag 1',
   'tag-2' => 'Tag 2',
@@ -142,7 +142,7 @@ return [
   'delete_group_confirm' => 'Veuillez confirmer que vous voulez supprimer :name',
   'delete_succeeded' => 'Repair Café <strong>:name</strong> a été supprimé.',
   'duplicate' => 'Ce nom (:name) existe déjà.  Si c\'est le vôtre, veuillez vous rendre dans la page Repair Cafés, utiliser le menu et l\'éditer.',
-  'geocode_failed' => 'L\'adresse que vous avez encodée n\'a pas pu être trouvée. Veuillez essayer une adresse plus générale.',
+  'geocode_failed' => 'Lieu non trouvé. Si vous ne parvenez pas à trouver le lieu où se trouve votre Repair Café, essayez d\'indiquer un lieu plus général (tel qu\'un village ou une ville) ou une adresse spécifique, plutôt qu\'un nom de bâtiment.',
   'discourse_title' => 'Il s\'agit d\'un groupe de discussion pour tous ceux qui suivent le Repair Café :group.
 
 Vous trouverez la page principale du Repair Café ici : :link.

--- a/lang/fr/events.php
+++ b/lang/fr/events.php
@@ -154,7 +154,7 @@ return [
   'image_delete_error' => 'Désolé, mais l\'image ne peut pas être supprimée.',
   'delete_permission' => 'Vous n\'avez pas la permission de supprimer cet événement',
   'delete_success' => 'L\'événement a été supprimé.',
-  'geocode_failed' => 'L\'adresse que vous avez encodée n\'a pas pu être trouvée. Veuillez essayer une adresse plus générale.',
+  'geocode_failed' => 'Lieu non trouvé. Si vous ne parvenez pas à trouver le lieu où se trouve votre événement, essayez d\'indiquer un lieu plus général (tel qu\'un village ou une ville) ou une adresse spécifique, plutôt qu\'un nom de bâtiment.',
   'create_failed' => 'L\'événement <strong>n\'a pas pu</strong> être créé. Veuillez regarder les erreurs, les corriger, et essayer à nouveau.',
   'edit_succeeded' => 'L\'édition du l\'événement Café a réussi',
   'edit_failed' => 'L\'événement n\'a pas pu être édité.',

--- a/lang/fr/groups.php
+++ b/lang/fr/groups.php
@@ -48,7 +48,7 @@ return [
   'edit_group' => 'Editer Repair Café',
   'edit_group_save_changes' => 'Sauvegarder',
   'edit_group_text' => 'Allez-y! Changez ou améliorez le profil de votre Repair Café',
-  'groups_location_small' => 'Ex: l\'endroit où les réparations ont lieu!',
+  'groups_location_small' => 'Le lieu ou la région où votre Repair Café opère',
   'group_image' => 'Image du Repair Café',
   'tag-1' => 'Tag 1',
   'tag-2' => 'Tag 2',
@@ -142,7 +142,7 @@ return [
   'delete_group_confirm' => 'Veuillez confirmer que vous voulez supprimer :name',
   'delete_succeeded' => 'Repair Café <strong>:name</strong> a été supprimé.',
   'duplicate' => 'Ce nom (:name) existe déjà.  Si c\'est le vôtre, veuillez vous rendre dans la page Repair Cafés, utiliser le menu et l\'éditer.',
-  'geocode_failed' => 'L\'adresse que vous avez encodée n\'a pas pu être trouvée. Veuillez essayer une adresse plus générale.',
+  'geocode_failed' => 'Lieu non trouvé. Si vous ne parvenez pas à trouver le lieu où se trouve votre Repair Café, essayez d\'indiquer un lieu plus général (tel qu\'un village ou une ville) ou une adresse spécifique, plutôt qu\'un nom de bâtiment.',
   'discourse_title' => 'Il s\'agit d\'un groupe de discussion pour tous ceux qui suivent le Repair Café :group.
 
 Vous trouverez la page principale du Repair Café ici : :link.

--- a/lang/no/groups.php
+++ b/lang/no/groups.php
@@ -46,7 +46,7 @@ return [
   'edit_group' => 'Edit group',
   'edit_group_save_changes' => 'Save changes',
   'edit_group_text' => 'Go ahead and change or improve your group\'s profile.',
-  'groups_location_small' => 'I.e the place where the fixing happens!',
+  'groups_location_small' => 'The venue or area where your group operates',
   'group_image' => 'Group image',
   'tag-1' => 'Tag 1',
   'tag-2' => 'Tag 2',

--- a/resources/js/components/GroupAddEdit.vue
+++ b/resources/js/components/GroupAddEdit.vue
@@ -47,9 +47,6 @@
       <input type="text" id="lng" name="lng" v-model="lng"  style="width: 1px; height: 1px; position: fixed; bottom: 65px; left: 10px; border: 0;" />
       <input type="text" id="location" name="location" v-model="location"  style="width: 1px; height: 1px; position: fixed; bottom: 65px; left: 20px; border: 0;" />
 
-      <div class="address">
-        Address {{ location }},, {{ postcode }},  {{ lat }}, {{ lng }}
-      </div>
       <GroupLocation
           :all-groups="groups"
           :value.sync="location"

--- a/resources/js/components/GroupAddEdit.vue
+++ b/resources/js/components/GroupAddEdit.vue
@@ -47,6 +47,9 @@
       <input type="text" id="lng" name="lng" v-model="lng"  style="width: 1px; height: 1px; position: fixed; bottom: 65px; left: 10px; border: 0;" />
       <input type="text" id="location" name="location" v-model="location"  style="width: 1px; height: 1px; position: fixed; bottom: 65px; left: 20px; border: 0;" />
 
+      <div class="address">
+        Address {{ location }},, {{ postcode }},  {{ lat }}, {{ lng }}
+      </div>
       <GroupLocation
           :all-groups="groups"
           :value.sync="location"

--- a/resources/js/components/GroupLocation.vue
+++ b/resources/js/components/GroupLocation.vue
@@ -8,6 +8,7 @@
           classname="form-control group-location"
           :placeholder="__('groups.groups_location_placeholder')"
           @placechanged="placeChanged"
+          @change="resetValues"
           aria-describedby="locationHelpBlock"
           types="geocode"
           ref="autocomplete"
@@ -106,12 +107,21 @@ export default {
     },
   },
   methods: {
-    placeChanged(addressData, placeResultData) {
+    async placeChanged(addressData, placeResultData) {
+      // nextTick which means the change event will get processed before we emit our new values.
+      await this.$nextTick()
       this.currentValue = placeResultData.formatted_address
       this.$emit('update:value', this.currentValue)
       this.$emit('update:lat', addressData.latitude)
       this.$emit('update:lng', addressData.longitude)
     },
+    resetValues() {
+      // This means that if the input changes, we will assume it's invalid unless we subsequently (because of
+      // the nextTick above) get a valid placeChanged event.
+      this.$emit('update:value', null)
+      this.$emit('update:lat', null)
+      this.$emit('update:lng', null)
+    }
   }
 }
 </script>

--- a/resources/js/components/VenueAddress.vue
+++ b/resources/js/components/VenueAddress.vue
@@ -9,6 +9,7 @@
             classname="form-control"
             :placeholder="__('events.field_venue_placeholder')"
             @placechanged="placeChanged"
+            @change="resetValues"
             aria-describedby="locationHelpBlock"
             types="geocode"
             ref="autocomplete"
@@ -164,11 +165,20 @@ export default {
     clearTimeout(this.timer)
   },
   methods: {
-    placeChanged(addressData, placeResultData) {
+    async placeChanged(addressData, placeResultData) {
+      // nextTick which means the change event will get processed before we emit our new values.
+      await this.$nextTick()
       this.currentValue = placeResultData.formatted_address
       this.$emit('update:value', this.currentValue)
       this.$emit('update:lat', addressData.latitude)
       this.$emit('update:lng', addressData.longitude)
+    },
+    resetValues() {
+      // This means that if the input changes, we will assume it's invalid unless we subsequently (because of
+      // the nextTick above) get a valid placeChanged event.
+      this.$emit('update:value', null)
+      this.$emit('update:lat', null)
+      this.$emit('update:lng', null)
     },
     useGroup() {
       this.$refs.autocomplete.update(this.groupLocation)


### PR DESCRIPTION
If the value entered is not geocodable, then we leave the old values in place and so the change appears to work but is lost.

This fettles use of `vue-auto-complete` so that we will reset the values to null (therefore invalid) until a valid geocoded result is given.

It's perhaps not obvious that you need to select one from the dropdown list.  I think people will realise that, but please consider whether or not we need a text change.