### PR TITLE
RES-1942 Negative attendee count

### DIFF
--- a/app/Console/Commands/FixVolunteerCount.php
+++ b/app/Console/Commands/FixVolunteerCount.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands;
+
+use DB;
+use Illuminate\Console\Command;
+use App\Party;
+
+class FixVolunteerCount extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dev:fixvolunteercount';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix the volunteer count for all events';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $events = Party::all();
+
+        foreach ($events as $event) {
+            $actual = DB::table('events_users')->where('event', $event->idevents)->where('status', 1)->count();
+
+            if ($actual > $event->volunteers) {
+                if ($event->volunteers < 0) {
+                    $this->info("Event {$event->idevents} has negative count {$event->volunteers}, $actual have confirmed");
+                } else {
+                    $this->info("Event {$event->idevents} has count {$event->volunteers}, but more ($actual) have confirmed");
+                }
+
+                $event->volunteers = $actual;
+                $event->save();
+            } else if ($event->volunteers < 0) {
+                $this->info("Event {$event->idevents} has negative count {$event->volunteers}, fewewr ($actual) have confirmed");
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -714,12 +714,9 @@ class PartyController extends Controller
 
         if (! empty($user_event)) {
             // Update event invite
-            EventsUsers::where('status', $hash)->where('event', $event_id)->update([
+            EventsUsers::where('status', $hash)->where('event', $event_id)->first()->update([
                 'status' => 1,
             ]);
-
-            // Increment volunteers column to include latest invite
-            $event = Party::find($event_id);
 
             $this->notifyHostsOfRsvp($user_event, $event_id);
 

--- a/resources/js/components/EventAttendanceCount.vue
+++ b/resources/js/components/EventAttendanceCount.vue
@@ -42,7 +42,7 @@ export default {
     }
   },
   mounted() {
-    this.current = this.count !== null ? this.count : 0
+    this.current = this.count !== null ? Math.max(this.count, 0) : 0
   },
   methods: {
     inc() {
@@ -57,7 +57,14 @@ export default {
     },
     set() {
       // This is triggered on keyup as the change even doesn't fire while you're still in the field.
-      this.$emit('change', this.current)
+      this.current = parseInt(this.current)
+
+      if (this.current > 0) {
+        this.$emit('change', this.current)
+      } else {
+        // Don't allow them to type a negative value.
+        this.current = 0
+      }
     }
   }
 }

--- a/tests/Feature/Events/AddRemoveVolunteerTest.php
+++ b/tests/Feature/Events/AddRemoveVolunteerTest.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Notification;
 use Symfony\Component\DomCrawler\Crawler;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Queue;
+use function PHPUnit\Framework\assertEquals;
 
 class AddRemoveVolunteerTest extends TestCase
 {
@@ -150,6 +151,10 @@ class AddRemoveVolunteerTest extends TestCase
         $response = $this->get('/party/view/'.$event->idevents);
         $response->assertSee('Invites sent!');
 
+        // Invited volunteers shouldn't affect the count.
+        $event->refresh();
+        assertEquals(0, $event->volunteers);
+
         $response = $this->put('/api/events/' . $event->idevents . '/volunteers', [
             'volunteer_email_address' => $restarter->email,
             'full_name' => $restarter->name,
@@ -165,6 +170,10 @@ class AddRemoveVolunteerTest extends TestCase
             'id' => $volunteer->idevents_users,
         ])->assertSee('true');
 
+        // Invited volunteers shouldn't affect the count.
+        $event->refresh();
+        assertEquals(0, $event->volunteers);
+
         // Add by name only
         $response = $this->put('/api/events/' . $event->idevents . '/volunteers', [
             'full_name' => 'Jo Bloggins',
@@ -178,6 +187,10 @@ class AddRemoveVolunteerTest extends TestCase
         $this->post('/party/remove-volunteer/', [
             'id' => $volunteer->idevents_users,
         ])->assertSee('true');
+
+        // Invited volunteers shouldn't affect the count.
+        $event->refresh();
+        assertEquals(0, $event->volunteers);
 
         // Add anonymous.
         $response = $this->put('/api/events/' . $event->idevents . '/volunteers', []);

--- a/tests/Feature/Events/InviteEventTest.php
+++ b/tests/Feature/Events/InviteEventTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\TestCase;
 use App\Notifications\JoinEvent;
 use Illuminate\Support\Facades\Queue;
+use function PHPUnit\Framework\assertEquals;
 
 class InviteEventTest extends TestCase
 {
@@ -70,6 +71,10 @@ class InviteEventTest extends TestCase
                 return true;
             }
         );
+
+        // Invited volunteers shouldn't update the count.
+        $event->refresh();
+        assertEquals(0, $event->volunteers);
     }
 
     public function testInviteReal()
@@ -93,6 +98,8 @@ class InviteEventTest extends TestCase
         $group = Group::findOrFail($idgroups);
         $idevents = $this->createEvent($idgroups, 'tomorrow');
         $event = Party::findOrFail($idevents);
+        $event->refresh();
+        assertEquals(1, $event->volunteers);
 
         // We want the event handler to kick in and synchronise to Discourse.
         $this->artisan("queue:work --stop-when-empty");
@@ -117,6 +124,10 @@ class InviteEventTest extends TestCase
             'event' => $event->idevents,
             'role' => 4,
         ]);
+
+        // Invited volunteers shouldn't update the count.
+        $event->refresh();
+        assertEquals(1, $event->volunteers);
 
         // Admin approves the event.
         $admin = User::factory()->administrator()->create();
@@ -159,6 +170,10 @@ class InviteEventTest extends TestCase
         $events = $this->getVueProperties($response5)[1][':initial-events'];
         $this->assertNotFalse(strpos($events, '"attending":true'));
 
+        // Count should now include them.
+        $event->refresh();
+        assertEquals(1, $event->volunteers);
+
         // Invite again - different code path when they're already there.
         $response = $this->post('/party/invite', [
             'group_name' => $group->name,
@@ -192,6 +207,9 @@ class InviteEventTest extends TestCase
                                 'full_name' => null,
                            ]);
         $this->actingAs($host);
+
+        $event->refresh();
+        assertEquals(1, $event->volunteers);
 
         // Should have no group members and therefore no invitable members.
         $response = $this->get('/party/get-group-emails-with-names/'.$event->idevents);
@@ -227,6 +245,10 @@ class InviteEventTest extends TestCase
 
         $response5->assertSessionHas('success');
 
+        // Invited volunteers shouldn't update the count.
+        $event->refresh();
+        assertEquals(1, $event->volunteers);
+
         // Invited member should not show up as invitable.
         $response6 = $this->get('/party/get-group-emails-with-names/'.$event->idevents);
         $members = json_decode($response6->getContent());
@@ -252,6 +274,10 @@ class InviteEventTest extends TestCase
         $this->assertTrue($response8->isRedirection());
         $redirectTo = $response8->getTargetUrl();
         $this->assertNotFalse(strpos($redirectTo, '/party/view/'.$event->idevents));
+
+        // Should now show.
+        $event->refresh();
+        assertEquals(2, $event->volunteers);
 
         // Now a group member and confirmed so should not show as invitable.
         $this->get('/logout');
@@ -385,11 +411,17 @@ class InviteEventTest extends TestCase
         $group = Group::findOrFail($idgroups);
         $idevents = $this->createEvent($idgroups, 'tomorrow');
         $event = Party::findOrFail($idevents);
+        assertEquals(1, $event->volunteers);
 
         $unique_shareable_code = Fixometer::generateUniqueShareableCode(\App\Party::class, 'shareable_code');
         $event->update([
                            'shareable_code' => $unique_shareable_code,
                        ]);
+
+
+        // Invited volunteers shouldn't update the count.
+        $event->refresh();
+        assertEquals(1, $event->volunteers);
 
         // Accept the invite via the code.
         $this->actingAs($user);
@@ -401,6 +433,11 @@ class InviteEventTest extends TestCase
             'url' => url("/party/view/{$event->idevents}"),
             'name' => $event->venue
         ]), false);
+
+
+        // Should now show.
+        $event->refresh();
+        assertEquals(2, $event->volunteers);
 
         // Try with invalid code.
         $this->expectException(NotFoundHttpException::class);

--- a/tests/Feature/Events/InviteEventTest.php
+++ b/tests/Feature/Events/InviteEventTest.php
@@ -172,7 +172,7 @@ class InviteEventTest extends TestCase
 
         // Count should now include them.
         $event->refresh();
-        assertEquals(1, $event->volunteers);
+        assertEquals(2, $event->volunteers);
 
         // Invite again - different code path when they're already there.
         $response = $this->post('/party/invite', [

--- a/tests/Feature/Events/JoinEventTest.php
+++ b/tests/Feature/Events/JoinEventTest.php
@@ -10,6 +10,7 @@ use App\User;
 use DB;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
+use function PHPUnit\Framework\assertEquals;
 
 class JoinEventTest extends TestCase
 {
@@ -30,6 +31,7 @@ class JoinEventTest extends TestCase
         // Joining should trigger adding to the Discourse thread.  Fake one.
         $event = \App\Party::find($idevents);
         $event->discourse_thread = 123;
+        assertEquals(1, $event->volunteers);
         $event->save();
 
         Queue::assertPushed(\Illuminate\Events\CallQueuedListener::class, function ($job) use ($event, $user) {
@@ -56,6 +58,10 @@ class JoinEventTest extends TestCase
             ],
         ]);
 
+        // Should show in count
+        $event->refresh();
+        assertEquals(2, $event->volunteers);
+
         // Say we can't attend.
         $this->followingRedirects();
         $response = $this->get('/party/cancel-invite/'.$event->idevents);
@@ -65,6 +71,9 @@ class JoinEventTest extends TestCase
                 ':is-attending' => 'false',
             ],
         ]);
+
+        $event->refresh();
+        assertEquals(1, $event->volunteers);
 
         Queue::assertPushed(\Illuminate\Events\CallQueuedListener::class, function ($job) use ($event, $user) {
             if ($job->class == RemoveUserFromDiscourseThreadForEvent::class) {


### PR DESCRIPTION
It's possible to end up with a negative attendee count, probably accidentally:

- Have a positive one.
- Type "-" in the box.

This PR firewalls against setting and showing negative values.

There are also cases in `EventsUsersObserver` which can cause this, especially relating to invitations.