### PR TITLE
Group stats percentages are wrong

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -200,15 +200,15 @@ class GroupController extends Controller
 
         $counts = $Device->countByClustersYearStatus($group->idgroups);
         $template = [
-            0 => (object)[
+            0 => [
                 'counter' => 0,
                 'repair_status' => 1,
             ],
-            1 => (object)[
+            1 => [
                 'counter' => 0,
                 'repair_status' => 2,
             ],
-            2 => (object)[
+            2 => [
                 'counter' => 0,
                 'repair_status' => 3,
             ],
@@ -228,11 +228,12 @@ class GroupController extends Controller
             $year = $count->year;
             $cluster = $count->cluster;
             $repair_status = $count->repair_status;
+            $counter = $count->counter;
 
             if ($repair_status && $cluster) {
                 if (array_key_exists($cluster, $clusters['all'])) {
-                    $clusters['all'][$cluster][$repair_status - 1]->counter += $count->counter;
-                    $clusters['all'][$cluster]['total'] += $count->counter;
+                    $clusters['all'][$cluster][$repair_status - 1]['counter'] += $counter;
+                    $clusters['all'][$cluster]['total'] += $counter;
 
                     if (!array_key_exists($year, $clusters)) {
                         $clusters[$year] = [
@@ -243,8 +244,8 @@ class GroupController extends Controller
                         ];
                     }
 
-                    $clusters[$year][$cluster][$repair_status - 1]->counter += $count->counter;
-                    $clusters[$year][$cluster]['total'] += $count->counter;
+                    $clusters[$year][$cluster][$repair_status - 1]['counter'] += $counter;
+                    $clusters[$year][$cluster]['total'] += $counter;
                 }
             }
         }

--- a/app/Party.php
+++ b/app/Party.php
@@ -588,13 +588,13 @@ class Party extends Model implements Auditable
                 }
 
                 switch ($device->repair_status) {
-                    case 1:
+                    case Device::REPAIR_STATUS_FIXED:
                         $result['fixed_devices']++;
                         break;
-                    case 2:
+                    case Device::REPAIR_STATUS_REPAIRABLE:
                         $result['repairable_devices']++;
                         break;
-                    case 3:
+                    case Device::REPAIR_STATUS_ENDOFLIFE:
                         $result['dead_devices']++;
                         break;
                     default:

--- a/lang/en/groups.php
+++ b/lang/en/groups.php
@@ -85,7 +85,7 @@ return [
   'no_upcoming_events' => 'There are currently no upcoming events.',
   'no_past_events' => 'There are currently no past events for this group',
   'device_breakdown' => 'Device breakdown',
-  'total_devices' => 'Total devices worked on',
+  'total_devices' => 'Total items worked on',
   'most_repaired_devices' => 'Most repaired devices',
   'host' => 'Host',
   'website' => 'Website',

--- a/lang/fr-BE/groups.php
+++ b/lang/fr-BE/groups.php
@@ -82,7 +82,7 @@ return [
   'past' => 'Passé',
   'read_more' => 'Lire plus',
   'share_group_stats' => 'Partager les statistiques du Repair Café',
-  'total_devices' => 'Total des appareils qui ont été pris en charge',
+  'total_devices' => 'Total des éléments qui ont été pris en charge',
   'participants' => 'Participants',
   'hours_volunteered' => 'Heures de bénévolat',
   'waste_prevented' => 'Déchets évités',

--- a/lang/fr/groups.php
+++ b/lang/fr/groups.php
@@ -82,7 +82,7 @@ return [
   'past' => 'Passé',
   'read_more' => 'Lire plus',
   'share_group_stats' => 'Partager les statistiques du Repair Café',
-  'total_devices' => 'Total des appareils qui ont été pris en charge',
+  'total_devices' => 'Total des éléments qui ont été pris en charge',
   'participants' => 'Participants',
   'hours_volunteered' => 'Heures de bénévolat',
   'waste_prevented' => 'Déchets évités',

--- a/resources/js/components/GroupDevicesBreakdownCluster.vue
+++ b/resources/js/components/GroupDevicesBreakdownCluster.vue
@@ -27,9 +27,14 @@ export default {
       required: true
     }
   },
+  computed: {
+    total() {
+      return this.stats.fixed + this.stats.repairable + this.stats.dead
+    },
+  },
   methods: {
     pc(val) {
-      return this.stats.total ? (Math.round(10000 * val / this.stats.total) / 100) : 0
+      return this.total ? (Math.round(10000 * val / this.total) / 100) : 0
     },
     translate(category) {
       // Need to translate categories.  Might be null if there were no items.

--- a/resources/views/group/view.blade.php
+++ b/resources/views/group/view.blade.php
@@ -49,10 +49,20 @@
           $showCalendar = Auth::check() && (($group && $group->isVolunteer()) || App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator'));
 
           $device_stats = [
-              'fixed' => isset($group_device_count_status[0]) ? (int) $group_device_count_status[0]->counter : 0,
-              'repairable' => isset($group_device_count_status[1]) ? (int) $group_device_count_status[1]->counter : 0,
-              'dead' => isset($group_device_count_status[2]) ? (int) $group_device_count_status[2]->counter : 0,
-            ];
+              'fixed' => 0,
+              'repairable' => 0,
+              'dead' => 0
+          ];
+
+          foreach ($group_device_count_status as $count) {
+              if ($count->status == \App\Device::REPAIR_STATUS_FIXED) {
+                  $device_stats['fixed'] = $count->counter;
+              } else if ($count->status == \App\Device::REPAIR_STATUS_REPAIRABLE) {
+                  $device_stats['repairable'] = $count->counter;
+              } else if ($count->status == \App\Device::REPAIR_STATUS_ENDOFLIFE) {
+                  $device_stats['dead'] = $count->counter;
+              }
+          }
 
           $category_clusters = [
             1 => 'Computers and Home Office',

--- a/resources/views/group/view.blade.php
+++ b/resources/views/group/view.blade.php
@@ -64,9 +64,9 @@
           $cluster_stats = [];
 
           foreach ($category_clusters as $key => $category_cluster) {
-              $fixed = isset($clusters['all'][$key][0]) ? (int) $clusters['all'][$key][0]->counter : 0;
-              $repairable = isset($clusters['all'][$key][1]) ? (int) $clusters['all'][$key][1]->counter : 0;
-              $dead = isset($clusters['all'][$key][2]) ? (int) $clusters['all'][$key][2]->counter : 0;
+              $fixed = isset($clusters['all'][$key][0]) ? (int) $clusters['all'][$key][0]['counter'] : 0;
+              $repairable = isset($clusters['all'][$key][1]) ? (int) $clusters['all'][$key][1]['counter'] : 0;
+              $dead = isset($clusters['all'][$key][2]) ? (int) $clusters['all'][$key][2]['counter'] : 0;
               $total = $clusters['all'][$key]['total'] ? $clusters['all'][$key]['total'] : 0;
 
               //Seen and repaired stats


### PR DESCRIPTION
Two things here:

1. The total used in `GroupDevicesBreakdownCluster` is not the total within that cluster.  It's not completely clear what it actually is, but it's not what we need.  So fix that.
2.  The use of object literals in the `$template` variable is causing the different clusters to all share the same underlaying object.  That wasn't the intention and isn't obvious.  This results in all the clusters are being given the same values.  Scrap the object stuff and just use an associative array here and in the template where we retrieve it.