### PR TITLE
RES-1956 Discourse problems blocking queue handler

### DIFF
--- a/app/Listeners/AddUserToDiscourseThreadForEvent.php
+++ b/app/Listeners/AddUserToDiscourseThreadForEvent.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Queue\InteractsWithQueue;
 
 class AddUserToDiscourseThreadForEvent implements ShouldQueue {
     private $discourseService;
+    public $tries = 1;
 
     public function __construct(DiscourseService $discourseService)
     {


### PR DESCRIPTION
Our externally hosted Discourse is misbehaving.  If API requests take a long time, it can block the Laravel queue handler, which then times out and exits.

This PR is a hack to keep the queue functional.