### PR TITLE
RES-1968 Can't create multiple devices with a barrier to entry

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -169,10 +169,10 @@ class DeviceController extends Controller
             event(new DeviceCreatedOrUpdated($device[$i]));
 
             // Update barriers
-            if (isset($barrier) && ! empty($barrier) && $repair_status == 3) { // Only sync when repair status is end-of-life
+            if (isset($barrier) && ! empty($barrier) && $repair_status == Device::REPAIR_STATUS_ENDOFLIFE) {
                Device::find($device[$i]->iddevices)->barriers()->sync($barrier);
             } else {
-                Device::find($device[$i]->iddevices)->barriers()->sync([]);
+               Device::find($device[$i]->iddevices)->barriers()->sync([]);
             }
 
             // If the number of devices exceeds set amount then show the following message
@@ -194,8 +194,8 @@ class DeviceController extends Controller
 
             $barriers = [];
 
-            foreach ($device[$i]->barriers as $barrier) {
-                $barriers[] = $barrier->id;
+            foreach ($device[$i]->barriers as $b) {
+                $barriers[] = $b->id;
             }
 
             $device[$i]->barrier = $barriers;
@@ -339,8 +339,8 @@ class DeviceController extends Controller
 
             $barriers = [];
 
-            foreach ($device->barriers as $barrier) {
-                $barriers[] = $barrier->id;
+            foreach ($device->barriers as $b) {
+                $barriers[] = $b->id;
             }
 
             $device->barrier = $barriers;

--- a/tests/Feature/Devices/EditTest.php
+++ b/tests/Feature/Devices/EditTest.php
@@ -35,6 +35,10 @@ class EditTest extends TestCase
         $iddevices = $rsp['devices'][0]['iddevices'];
         self::assertNotNull($iddevices);
 
+        # Add a barrier to repair - there was a bug in this case with quantity > 1.
+        $this->device_inputs['repair_status'] = Device::REPAIR_STATUS_ENDOFLIFE;
+        $this->device_inputs['barrier'] = [1];
+
         # Edit the quantity.
         $atts = $this->device_inputs;
         $atts['quantity'] = 2;
@@ -255,5 +259,18 @@ class EditTest extends TestCase
         self::assertEquals(0, $device->professional_help);
         self::assertEquals(1, $device->do_it_yourself);
         self::assertEquals(0, $device->more_time_needed);
+    }
+
+    public function testBarrierMultiple()
+    {
+        $atts = $this->device_inputs;
+        $atts['quantity'] = 2;
+        $atts['repair_status'] = Device::REPAIR_STATUS_ENDOFLIFE;
+        $atts['barrier'] = [1];
+
+        $rsp = $this->post('/device/create', $atts);
+        self::assertTrue($rsp['success']);
+        $iddevices = $rsp['devices'][0]['iddevices'];
+        self::assertNotNull($iddevices);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -94,8 +94,6 @@ abstract class TestCase extends BaseTestCase
             $network->name = 'Restarters';
             $network->shortname = 'restarters';
             $network->save();
-        } else {
-            error_log("Got network");
         }
 
         $this->withoutExceptionHandling();


### PR DESCRIPTION
A local loop variable was overwriting the input value, which only showed up when we made multiple passes through to create multiple devices.