### PR TITLE
RES-1971 Only show Add Event button on Dashboard when the user is a host

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -51,7 +51,7 @@ class DashboardController extends Controller
             ->whereNull('users_groups.deleted_at')
             ->orderBy('groups.name', 'ASC')
             ->groupBy('groups.idgroups', 'groups.name')
-            ->select(['groups.idgroups', 'groups.name'])
+            ->select(['groups.idgroups', 'groups.name', 'users_groups.role'])
             ->take(5)
             ->get();
 

--- a/resources/js/components/DashboardPage.vue
+++ b/resources/js/components/DashboardPage.vue
@@ -69,10 +69,6 @@ export default {
       required: true
     }
   },
-  data () {
-    return {
-    }
-  },
   created() {
     // Data is passed from the blade template to us via props.  We put it in the store for all components to use,
     // and so that as/when it changes then reactivity updates all the views.

--- a/resources/js/components/DashboardYourGroups.vue
+++ b/resources/js/components/DashboardYourGroups.vue
@@ -62,7 +62,7 @@
                   </p>
                 </div>
                 <div>
-                  <b-btn variant="primary" href="/party/create" class="text-nowrap">
+                  <b-btn variant="primary" href="/party/create" class="text-nowrap" v-if="amAHost">
                     {{ __('dashboard.add_event') }}
                   </b-btn>
                 </div>
@@ -91,6 +91,7 @@ import DashboardGroup from './DashboardGroup'
 import CollapsibleSection from './CollapsibleSection'
 import DashboardEvent from './DashboardEvent'
 import DashboardNoGroups from './DashboardNoGroups'
+import { HOST } from '../constants'
 
 export default {
   props: {
@@ -121,6 +122,19 @@ export default {
       return this.groups.filter(g => {
         return g.ingroup
       })
+    },
+    amAHost() {
+      let ret = false
+
+      this.myGroups.forEach(g => {
+        // Even if the user has Administrator role, their role on the group would be HOST or RESTARTER, not
+        // ADMINISTRATOR.
+        if (g.role === HOST) {
+          ret = true
+        }
+      })
+
+      return ret
     },
     events() {
       return this.$store.getters['events/getByGroup'](null).filter(e => e.upcoming).sort((a, b) => {


### PR DESCRIPTION
Check whether we have the host role on at least one group before showing the Add event button on the dashboard.