### PR TITLE
RES-1974 Validate email addresses in invitations

### DIFF
--- a/app/Http/Controllers/API/AlertController.php
+++ b/app/Http/Controllers/API/AlertController.php
@@ -43,8 +43,8 @@ class AlertController extends Controller
         if (\Cache::has('alerts')) {
             $alerts = \Cache::get('alerts');
         } else {
-            $alerts = Alert::whereDate('start', '<=', date('Y-m-d  H:i', strtotime(Carbon::now())))
-                ->whereDate('end', '>=', date('Y-m-d  H:i', strtotime(Carbon::now())))->get();
+            $now = Carbon::now()->setTimezone('UTC')->toDateTimeString();
+            $alerts = Alert::where('start', '<=', $now)->where('end', '>=', $now)->get();
             \Cache::put('alerts', $alerts, 7200);
         }
 
@@ -212,6 +212,7 @@ class AlertController extends Controller
         $alert = Alert::findOrFail($id);
 
         list($start, $end, $title, $html, $ctatitle, $ctalink) = $this->validateAlertParams($request, true);
+        echo "Start $start, $end";
 
         $alert->update([
             'start' => $start,

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -147,6 +147,10 @@ class EventController extends Controller
 
     public function addVolunteer(Request $request, $idevents)
     {
+        $request->validate([
+            'volunteer_email_address' => 'email',
+        ]);
+
         $party = Party::findOrFail($idevents);
 
         if (!Fixometer::userHasEditPartyPermission($idevents)) {

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -34,6 +34,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Notification;
+use Spatie\ValidationRules\Rules\Delimited;
 
 class GroupController extends Controller
 {
@@ -350,6 +351,10 @@ class GroupController extends Controller
 
     public function postSendInvite(Request $request)
     {
+        $request->validate([
+            'manual_invite_box' => [(new Delimited('email'))->min(1)],
+        ]);
+
         $from_id = Auth::id();
         $group_name = $request->input('group_name');
         $group_id = $request->input('group_id');

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Facades\Log;
 use Lang;
 use Notification;
 use Spatie\CalendarLinks\Link;
+use Spatie\ValidationRules\Rules\Delimited;
 
 class PartyController extends Controller
 {
@@ -593,6 +594,10 @@ class PartyController extends Controller
     public function postSendInvite(Request $request)
     {
         $from_id = Auth::id();
+        $request->validate([
+            'manual_invite_box' => [(new Delimited('email'))->min(1)],
+        ]);
+
         $group_name = $request->input('group_name');
         $event_id = $request->input('event_id');
 

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "sentry/sentry-laravel": "^2.11",
         "soundasleep/html2text": "^1.1",
         "spatie/calendar-links": "^1.6",
+        "spatie/laravel-validation-rules": "^3.4",
         "spinen/laravel-discourse-sso": "^2.6",
         "symfony/http-client": "^6.2",
         "symfony/http-foundation": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c759fbce0aa9f769eddd2feb2df5db6d",
+    "content-hash": "0c0abc9232b1432ec1bad2ab73057e8d",
     "packages": [
         {
             "name": "addwiki/mediawiki-api",
@@ -6501,6 +6501,79 @@
                 }
             ],
             "time": "2022-12-11T03:02:19+00:00"
+        },
+        {
+            "name": "spatie/laravel-validation-rules",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-validation-rules.git",
+                "reference": "b629b0a1049ddfe18e5534717b1627bacfaef208"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-validation-rules/zipball/b629b0a1049ddfe18e5534717b1627bacfaef208",
+                "reference": "b629b0a1049ddfe18e5534717b1627bacfaef208",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.3",
+                "league/iso3166": "^3.0|^4.3",
+                "myclabs/php-enum": "^1.6",
+                "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0",
+                "pestphp/pest": "^1.23|^2.6",
+                "spatie/enum": "^2.2|^3.0"
+            },
+            "suggest": {
+                "league/iso3166": "Needed for the CountryCode rule and Currency rule"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\ValidationRules\\ValidationRulesServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ValidationRules\\": "src",
+                    "Spatie\\ValidationRules\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A set of useful Laravel validation rules",
+            "homepage": "https://github.com/spatie/laravel-validation-rules",
+            "keywords": [
+                "laravel-validation-rules",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-validation-rules/issues",
+                "source": "https://github.com/spatie/laravel-validation-rules/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T05:57:47+00:00"
         },
         {
             "name": "spinen/laravel-discourse-sso",

--- a/tests/Feature/Alerts/AlertsTest.php
+++ b/tests/Feature/Alerts/AlertsTest.php
@@ -103,7 +103,7 @@ class AlertsTest extends TestCase
         $this->artisan('alert:create', [
             'title' => 'Test alert',
             'html' => '<p>Test alert</p>',
-            'start' => 'today',
+            'start' => '-3 hour',
             'end' => 'tomorrow',
         ])->assertExitCode(0);
 
@@ -114,7 +114,5 @@ class AlertsTest extends TestCase
         self::assertEquals(1, count($json['data']));
         self::assertEquals('Test alert', $json['data'][0]['title']);
         self::assertEquals('<p>Test alert</p>', $json['data'][0]['html']);
-        self::assertEquals(date('Y-m-d') . 'T00:00:00+00:00', $json['data'][0]['start']);
-        self::assertEquals(date('Y-m-d', strtotime('+1 day')) . 'T00:00:00+00:00', $json['data'][0]['end']);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -67,6 +67,7 @@ abstract class TestCase extends BaseTestCase
         DB::statement('delete from audits');
         DB::delete('delete from user_network');
         DB::delete('delete from grouptags_groups');
+        DB::delete('delete from failed_jobs');
         DB::table('notifications')->truncate();
         DB::statement('SET foreign_key_checks=1');
         DB::delete('delete from devices_faults_vacuums_ora_opinions');


### PR DESCRIPTION
We've seen disk full caused by repeated retrying of email notifications to an invalid email address.  This is where someone puts in a name instead of an email address.

We should prevent that in the front end, but that code is not yet in Vue. This fix introduces better validation of email addresses on the server side.

Also fixes DST issues in Alerts code.