### PR TITLE
RES-1983 Can't add volunteer to past events

### DIFF
--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -148,7 +148,7 @@ class EventController extends Controller
     public function addVolunteer(Request $request, $idevents)
     {
         $request->validate([
-            'volunteer_email_address' => 'email',
+            'volunteer_email_address' => ['nullable', 'email'],
         ]);
 
         $party = Party::findOrFail($idevents);

--- a/tests/Feature/Events/AddRemoveVolunteerTest.php
+++ b/tests/Feature/Events/AddRemoveVolunteerTest.php
@@ -177,6 +177,7 @@ class AddRemoveVolunteerTest extends TestCase
         // Add by name only
         $response = $this->put('/api/events/' . $event->idevents . '/volunteers', [
             'full_name' => 'Jo Bloggins',
+            'volunteer_email_address' => NULL,
         ]);
 
         $response->assertSuccessful();


### PR DESCRIPTION
The new API code wrongly assumed that the volunteer email address would always be provided.