### PR TITLE
Stuck queue job for deleted event

### DIFF
--- a/app/Listeners/DeviceUpdatedAt.php
+++ b/app/Listeners/DeviceUpdatedAt.php
@@ -19,19 +19,26 @@ class DeviceUpdatedAt extends BaseEvent
     {
         // We've been passed a device id, and we want to record in the event and group that the devices have been
         // updated.
+        //
+        // The device and/or event might not exist in the DB, so take care using them.
         $device = Device::find($event->iddevices);
 
-        // Use a local for the time to avoid a window where the times could be different.
-        $now = \Carbon\Carbon::now();
+        if ($device) {
+            // Use a local for the time to avoid a window where the times could be different.
+            $now = \Carbon\Carbon::now();
 
-        // Update the event.
-        $event = Party::find($device->event);
-        $event->devices_updated_at = $now;
-        $event->save();
+            // Update the event.
+            $event = Party::find($device->event);
 
-        // Update the group.
-        $group = Group::find($event->group);
-        $group->devices_updated_at = $now;
-        $group->save();
+            if ($event) {
+                $event->devices_updated_at = $now;
+                $event->save();
+
+                // Update the group.
+                $group = Group::find($event->group);
+                $group->devices_updated_at = $now;
+                $group->save();
+            }
+        }
     }
 }

--- a/tests/Feature/Devices/EditTest.php
+++ b/tests/Feature/Devices/EditTest.php
@@ -291,14 +291,10 @@ class EditTest extends TestCase
 
         $job = new DeviceCreatedOrUpdated($device);
 
-        # Delete the event and device from the DB.
-        EventsUsers::where('event', $idevents)->forcedelete();
-        Device::where('iddevices', $iddevices)->forcedelete();
-        Party::where('idevents', $idevents)->forcedelete();
+        # Delete the event (will stay in DB as soft delete).
+        Party::where('idevents', $idevents)->delete();
 
         $handler = new DeviceUpdatedAt();
         $handler->handle($job);
-
-        $this->assertTrue(false);
     }
 }


### PR DESCRIPTION
What looks to have happened here is:

- Event created
- Device updated, generating queue job
- Event deleted before queued job is processed
- Queued job then throws and exception
- This retries a lot, causing some disk full