### PR TITLE
RES-1984 Network Coordinator shouldn't see approval option

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -503,7 +503,9 @@ class GroupController extends Controller
             'id' => $id,
             'name' => $group->name,
             'audits' => $group->audits,
-            'networks' => Network::all()
+            'networks' => Network::all(),
+            'can_approve' => Fixometer::hasRole($user, 'Administrator') ||
+                Fixometer::hasRole($user, 'NetworkCoordinator') && $isCoordinatorForGroup
         ]);
     }
 

--- a/resources/views/group/edit.blade.php
+++ b/resources/views/group/edit.blade.php
@@ -19,7 +19,7 @@
               <div class="tab-pane active" id="details">
                 <div class="vue">
                   <GroupAddEditPage :idgroups="{{ $id }}"
-                                    :can-approve="{{ (Auth::user()->hasRole('Administrator') || Auth::user()->hasRole('NetworkCoordinator')) ? "true" : "false" }}"
+                                    :can-approve="{{ $can_approve ? "true": "false" }}"
                                     :can-network="{{ Auth::user()->hasRole('Administrator') ? "true" : "false" }}"
                   />
                 </div>

--- a/tests/Feature/Groups/GroupEditTest.php
+++ b/tests/Feature/Groups/GroupEditTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Group;
 use App\GroupTags;
+use App\Network;
 use App\Role;
 use App\User;
 use Carbon\Carbon;
@@ -188,5 +189,34 @@ class GroupEditTest extends TestCase
 
         $group->refresh();
         $this->assertEquals('info@test.com', $group->email);
+    }
+
+    public function testEditAsNetworkCoordinator() {
+        $network = Network::factory()->create();
+        $coordinator = User::factory()->restarter()->create();
+        $network->addCoordinator($coordinator);
+        $coordinator->refresh();
+        $this->actingAs($coordinator);
+
+        $idgroups = $this->createGroup(
+            'Test Group',
+            'https://therestartproject.org',
+            'London',
+            'Some text.',
+            true,
+            false,
+            'info@test.com'
+        );
+
+        $response = $this->get('/group/edit/' . $idgroups);
+        $response->assertStatus(200);
+
+        // Shouldn't be able to approve the group, as it has not yet been put in our network (by an admin).
+        $this->assertVueProperties($response, [
+            [],
+            [
+                ':can-approve' => 'false',
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
…for groups which are not in their network.

This will include groups which they have just created, unless they have a custom domain and the groups are auto-approved.