### PR TITLE
RES-2003 group networks lost when archiving

### DIFF
--- a/resources/js/components/GroupActions.vue
+++ b/resources/js/components/GroupActions.vue
@@ -120,6 +120,10 @@ export default {
       group.id = this.idgroups
       group.archived_at = (new Date()).toISOString()
       group.description = group.free_text
+
+      // Make sure we don't stomp on the networks.
+      delete group.networks
+
       await this.$store.dispatch('groups/edit', group)
 
       await this.$store.dispatch('groups/fetch', {

--- a/resources/js/components/GroupHeading.vue
+++ b/resources/js/components/GroupHeading.vue
@@ -17,7 +17,7 @@
         <div class="pl-md-4 d-flex w-xs-100 w-md-50 maybeborder pt-3 p-md-0 d-flex flex-column justify-content-center">
           <div class="d-flex justify-content-between w-100">
             <div class="flex-wrap">
-              <b>{{ group.location }}</b> <br/>
+              <b>{{ location }}</b> <br/>
               <ExternalLink v-if="group.website" :href="group.website">{{ __('groups.website') }}</ExternalLink>
             </div>
             <GroupActions :idgroups="idgroups" :can-see-delete="canSeeDelete" :can-perform-delete="canPerformDelete"
@@ -63,6 +63,20 @@ export default {
     groupImage() {
       return this.group && this.group.group_image && this.group.group_image.image ? ('/uploads/mid_' + this.group.group_image.image.path) : DEFAULT_PROFILE
     },
+    location() {
+      // This is a bit of finagling to deal with us not yet having full use of APIs in the client.
+      let ret = null
+
+      if (this.group) {
+        if (typeof this.group.location === 'string') {
+          ret = this.group.location
+        } else {
+          ret = this.group.location.name
+        }
+      }
+
+      return ret
+    }
   },
   methods: {
     brokenGroupImage(event) {


### PR DESCRIPTION
This was because of some inconsistencies we have in the client side code relating to gradual implementation of the API.  Fix applied, and also fixed a display issue for the location when archiving.