### PR TITLE
RES-2001 anonymise Discourse users when Restarters user deleted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
 #    networks:
 #      - app-network
 
-      - image: docker.io/bitnami/discourse:2
+      - image: docker.io/bitnami/discourse:latest
         name: restarters_discourse_sidekiq
         depends_on:
           - restarters_discourse

--- a/app/Console/Commands/DiscourseAnonymiseUser.php
+++ b/app/Console/Commands/DiscourseAnonymiseUser.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Group;
+use App\Helpers\Geocoder;
+use App\Services\DiscourseService;
+use App\User;
+use Illuminate\Console\Command;
+
+class DiscourseAnonymiseUser extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'discourse:anonymise {id}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Anonymise a user in Discourse';
+
+    private $discourseApiKey;
+    private $discourseApiUser;
+    private $discourseService;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(DiscourseService $discourseService)
+    {
+        parent::__construct();
+        $this->discourseService = $discourseService;
+
+        $discourseApiKey = env('DISCOURSE_APIKEY');
+        $discourseApiUser = env('DISCOURSE_APIUSER');
+
+        if (is_null($discourseApiKey) || empty($discourseApiKey)) {
+            $this->error('DISCOURSE_APIKEY is not set');
+            exit();
+        }
+
+        if (is_null($discourseApiUser) || empty($discourseApiUser)) {
+            $this->error('DISCOURSE_APIUSER is not set');
+            exit();
+        }
+
+        $this->discourseApiKey = $discourseApiKey;
+        $this->discourseApiUser = $discourseApiUser;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(DiscourseService $discourseService)
+    {
+        $id = $this->argument('id');
+        $user = User::findOrFail($id);
+
+        $this->discourseService->anonymise($user);
+    }
+}

--- a/app/Http/Controllers/API/AlertController.php
+++ b/app/Http/Controllers/API/AlertController.php
@@ -212,7 +212,6 @@ class AlertController extends Controller
         $alert = Alert::findOrFail($id);
 
         list($start, $end, $title, $html, $ctatitle, $ctalink) = $this->validateAlertParams($request, true);
-        echo "Start $start, $end";
 
         $alert->update([
             'start' => $start,

--- a/app/Listeners/DiscourseUserEventSubscriber.php
+++ b/app/Listeners/DiscourseUserEventSubscriber.php
@@ -117,6 +117,22 @@ class DiscourseUserEventSubscriber extends BaseEvent
         }
     }
 
+    public function onUserDeleted(UserDeleted $event)
+    {
+        if (config('restarters.features.discourse_integration') === true)
+        {
+            $user = $event->user;
+
+            try
+            {
+                $this->discourseService->anonymise($user);
+            } catch (\Exception $ex)
+            {
+                Log::error('Could not anonymise ' . $user->id . ' on Discourse: ' . $ex->getMessage());
+            }
+        }
+    }
+
     /**
      * Register the listeners for the subscriber.
      *
@@ -138,6 +154,11 @@ class DiscourseUserEventSubscriber extends BaseEvent
         $events->listen(
             \App\Events\UserRegistered::class,
             'App\Listeners\DiscourseUserEventSubscriber@onUserRegistered'
+        );
+
+        $events->listen(
+            \App\Events\UserDeleted::class,
+            'App\Listeners\DiscourseUserEventSubscriber@onUserDeleted'
         );
     }
 }

--- a/app/Listeners/DiscourseUserEventSubscriber.php
+++ b/app/Listeners/DiscourseUserEventSubscriber.php
@@ -143,11 +143,25 @@ class DiscourseUserEventSubscriber extends BaseEvent
      */
     public function subscribe($events)
     {
-        return [
-            \App\Events\UserEmailUpdated::class => 'onUserEmailUpdated',
-            \App\Events\UserLanguageUpdated::class => 'onUserLanguageUpdated',
-            \App\Events\UserRegistered::class => 'onUserRegistered',
-            \App\Events\UserDeleted::class => 'onUserDeleted'
-        ];
+        // We subscribe to all the events irrespective of whether the feature is enabled so that we can test them.
+        $events->listen(
+            \App\Events\UserEmailUpdated::class,
+            'App\Listeners\DiscourseUserEventSubscriber@onUserEmailUpdated'
+        );
+
+        $events->listen(
+            \App\Events\UserLanguageUpdated::class,
+            'App\Listeners\DiscourseUserEventSubscriber@onUserLanguageUpdated'
+        );
+
+        $events->listen(
+            \App\Events\UserRegistered::class,
+            'App\Listeners\DiscourseUserEventSubscriber@onUserRegistered'
+        );
+
+        $events->listen(
+            \App\Events\UserDeleted::class,
+            'App\Listeners\DiscourseUserEventSubscriber@onUserDeleted'
+        );
     }
 }

--- a/app/Listeners/DiscourseUserEventSubscriber.php
+++ b/app/Listeners/DiscourseUserEventSubscriber.php
@@ -5,6 +5,7 @@ namespace App\Listeners;
 use App\Events\UserEmailUpdated;
 use App\Events\UserLanguageUpdated;
 use App\Events\UserRegistered;
+use App\Events\UserDeleted;
 use App\Services\DiscourseService;
 use Illuminate\Support\Facades\Log;
 
@@ -126,6 +127,8 @@ class DiscourseUserEventSubscriber extends BaseEvent
             try
             {
                 $this->discourseService->anonymise($user);
+                $user->username = null;
+                $user->save();
             } catch (\Exception $ex)
             {
                 Log::error('Could not anonymise ' . $user->id . ' on Discourse: ' . $ex->getMessage());
@@ -140,25 +143,11 @@ class DiscourseUserEventSubscriber extends BaseEvent
      */
     public function subscribe($events)
     {
-        // We subscribe to all the events irrespective of whether the feature is enabled so that we can test them.
-        $events->listen(
-            \App\Events\UserEmailUpdated::class,
-            'App\Listeners\DiscourseUserEventSubscriber@onUserEmailUpdated'
-        );
-
-        $events->listen(
-            \App\Events\UserLanguageUpdated::class,
-            'App\Listeners\DiscourseUserEventSubscriber@onUserLanguageUpdated'
-        );
-
-        $events->listen(
-            \App\Events\UserRegistered::class,
-            'App\Listeners\DiscourseUserEventSubscriber@onUserRegistered'
-        );
-
-        $events->listen(
-            \App\Events\UserDeleted::class,
-            'App\Listeners\DiscourseUserEventSubscriber@onUserDeleted'
-        );
+        return [
+            \App\Events\UserEmailUpdated::class => 'onUserEmailUpdated',
+            \App\Events\UserLanguageUpdated::class => 'onUserLanguageUpdated',
+            \App\Events\UserRegistered::class => 'onUserRegistered',
+            \App\Events\UserDeleted::class => 'onUserDeleted'
+        ];
     }
 }

--- a/app/Services/DiscourseService.php
+++ b/app/Services/DiscourseService.php
@@ -617,4 +617,41 @@ class DiscourseService
         Log::info('Response status: ' . $response->getStatusCode());
         Log::info($response->getBody());
     }
+
+    public function anonymise($user)
+    {
+        Log::info("Anonymise {$user->id}");
+        $client = app('discourse-client');
+
+        // Get Discourse user id
+        $endpoint = "/users/by-external/{$user->id}.json";
+
+        $response = $client->request(
+            'GET',
+            $endpoint
+        );
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        if (empty($json['user'])) {
+            throw new \Exception("User {$user->id} not found in Discourse");
+        }
+
+        $discourseUserId = $json['user']['id'];
+
+        if ($discourseUserId) {
+            $response = $client->request(
+                'PUT',
+                "/admin/users/$discourseUserId/anonymize.json"
+            );
+
+            $json = json_decode($response->getBody()->getContents(), true);
+
+            if (empty($json['success'])) {
+                throw new \Exception("Failed to anonymise user {$user->id}");
+            }
+        }
+
+        Log::info('Response status: ' . $response->getStatusCode());
+        Log::info($response->getBody());
+    }
 }

--- a/tests/Feature/Admin/Users/UserDeletedNotificationTest.php
+++ b/tests/Feature/Admin/Users/UserDeletedNotificationTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Events\UserDeleted;
 use App\Notifications\AdminUserDeleted;
 use App\User;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
+use Illuminate\Support\Facades\Event;
 
 class UserDeletedNotificationTest extends TestCase
 {
@@ -25,6 +27,8 @@ class UserDeletedNotificationTest extends TestCase
         $restarter->delete();
 
         $this->artisan("queue:work --stop-when-empty");
+
+        Event::assertDispatched(UserDeleted::class);
 
         Notification::assertSentTo(
             [$admins], AdminUserDeleted::class

--- a/tests/Feature/Admin/Users/UserDeletedNotificationTest.php
+++ b/tests/Feature/Admin/Users/UserDeletedNotificationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Events\UserDeleted;
+use App\Listeners\DiscourseUserEventSubscriber;
 use App\Notifications\AdminUserDeleted;
 use App\User;
 use Illuminate\Support\Facades\Notification;
@@ -27,8 +28,6 @@ class UserDeletedNotificationTest extends TestCase
         $restarter->delete();
 
         $this->artisan("queue:work --stop-when-empty");
-
-        Event::assertDispatched(UserDeleted::class);
 
         Notification::assertSentTo(
             [$admins], AdminUserDeleted::class

--- a/tests/Feature/Users/Registration/DiscourseAccountCreationTest.php
+++ b/tests/Feature/Users/Registration/DiscourseAccountCreationTest.php
@@ -34,15 +34,19 @@ class DiscourseAccountCreationTest extends TestCase
     /** @test */
     public function user_registration_triggers_discourse_sync_attempt()
     {
-        config('restarters.features.discourse_integration', true);
-        $this->instance(DiscourseUserEventSubscriber::class, Mockery::mock(DiscourseUserEventSubscriber::class, function ($mock) {
-            $mock->shouldReceive('onUserRegistered')->once();
-        }));
+        if (config('restarters.features.discourse_integration')) {
+            $this->instance(DiscourseUserEventSubscriber::class,
+                Mockery::mock(DiscourseUserEventSubscriber::class, function ($mock) {
+                    $mock->shouldReceive('onUserRegistered')->once();
+                }));
 
-        $response = $this->post('/user/register/', $this->userAttributes());
+            $response = $this->post('/user/register/', $this->userAttributes());
 
-        $response->assertStatus(302);
-        $response->assertRedirect('dashboard');
+            $response->assertStatus(302);
+            $response->assertRedirect('dashboard');
+        } else {
+            $this->assertTrue(true);
+        }
     }
 
     /** @test */
@@ -68,7 +72,6 @@ class DiscourseAccountCreationTest extends TestCase
             );
 
             $json = json_decode($response->getBody()->getContents(), true);
-            error_log("Debugging: Discourse response: " . print_r($json, true));
             $this->assertEquals($atts['name'], $json['user']['username']);
         } else {
             $this->assertTrue(true);

--- a/tests/Feature/Users/Registration/DiscourseAccountCreationTest.php
+++ b/tests/Feature/Users/Registration/DiscourseAccountCreationTest.php
@@ -68,6 +68,7 @@ class DiscourseAccountCreationTest extends TestCase
             );
 
             $json = json_decode($response->getBody()->getContents(), true);
+            error_log("Debugging: Discourse response: " . print_r($json, true));
             $this->assertEquals($atts['name'], $json['user']['username']);
         } else {
             $this->assertTrue(true);

--- a/tests/Feature/Users/Registration/DiscourseAccountCreationTest.php
+++ b/tests/Feature/Users/Registration/DiscourseAccountCreationTest.php
@@ -16,7 +16,7 @@ use Mockery;
 use Tests\TestCase;
 use Tests\Feature\MockInterface;
 
-class DiscourseAccountCreationTests extends TestCase
+class DiscourseAccountCreationTest extends TestCase
 {
     /** @test */
     public function user_registration_triggers_user_registered_event()

--- a/tests/Feature/Users/Registration/DiscourseAccountDeletionTest.php
+++ b/tests/Feature/Users/Registration/DiscourseAccountDeletionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Events\UserDeleted;
+use App\Events\UserRegistered;
+use App\Listeners\AddUserToDiscourseGroup;
+use App\Listeners\DiscourseUserEventSubscriber;
+use App\Providers\DiscourseServiceProvider;
+use App\Role;
+use App\User;
+use DB;
+use Hash;
+use HieuLe\WordpressXmlrpcClient\WordpressClient;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\TestCase;
+use Tests\Feature\MockInterface;
+
+class DiscourseAccountDeletionTest extends TestCase
+{
+    /** @test */
+    public function user_deletion_triggers_anonymise()
+    {
+        // Soft-deleting a user should trigger a call to the method which will anonymise the user on Discourse.
+        config('restarters.features.discourse_integration', true);
+        $this->instance(DiscourseUserEventSubscriber::class, Mockery::mock(DiscourseUserEventSubscriber::class, function ($mock) {
+            $mock->shouldReceive('onUserDeleted')->once();
+        }));
+
+        Event::fake();
+
+        $user = User::factory()->restarter()->create();
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+        $response = $this->post('/user/soft-delete', [
+            'id' => $user->id
+        ]);
+        $response->assertSessionHas('danger');
+        $this->assertTrue($response->isRedirection());
+
+        Event::assertDispatched(UserDeleted::class);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,6 +31,8 @@ use Illuminate\Support\Facades\Queue;
 use Symfony\Component\DomCrawler\Crawler;
 use Osteel\OpenApi\Testing\ValidatorBuilder;
 use Osteel\OpenApi\Testing\Exceptions\ValidationException;
+use ReflectionFunction;
+use Illuminate\Events\Dispatcher;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -462,5 +464,23 @@ abstract class TestCase extends BaseTestCase
         $atts['groupid'] = $atts['group'];
 
         return $atts;
+    }
+
+    public function assertListenerIsAttachedToEvent($listener, $event)
+    {
+        $dispatcher = app(Dispatcher::class);
+
+        foreach ($dispatcher->getListeners(is_object($event) ? get_class($event) : $event) as $listenerClosure) {
+            $reflection = new ReflectionFunction($listenerClosure);
+            $listenerClass = $reflection->getStaticVariables()['listener'];
+
+            if ($listenerClass === $listener) {
+                $this->assertTrue(true);
+
+                return;
+            }
+        }
+
+        $this->assertTrue(false, sprintf('Event %s does not have the %s listener attached to it', $event, $listener));
     }
 }


### PR DESCRIPTION
This adds an event listener which will use Discourse's API to anonymise Discourse users as their account is soft-deleted on Restarters.

There's also an `artisan` command to anonymise an individual user.  We'd need to manually run this for the live soft-deleted users - easy enough as a one off.  I've not written a migration script.