### PR TITLE
RES-2010 Communiteq problems blocks event approval

### DIFF
--- a/app/Providers/DiscourseServiceProvider.php
+++ b/app/Providers/DiscourseServiceProvider.php
@@ -46,6 +46,8 @@ class DiscourseServiceProvider extends ServiceProvider
                 ],
                 'http_errors' => false,
                 'handler' => $stack,
+                'timeout' => 5,
+                'connect_timeout' => 5
             ]);
         });
 


### PR DESCRIPTION
Add timeouts to use of Guzzle against Discourse hosting so that PHP script timeout doesn't kick in.