### PR TITLE
RES-2012 Speed up /api/v2/networks/N/groups call

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -245,6 +245,7 @@ class Group extends Model implements Auditable
         }
 
         $allPastEvents = Party::past()
+            ->with('allDevices')
             ->where('events.group', $this->idgroups)
             ->get();
 

--- a/app/Http/Controllers/API/NetworkController.php
+++ b/app/Http/Controllers/API/NetworkController.php
@@ -132,6 +132,15 @@ class NetworkController extends Controller
      *          )
      *      ),
      *      @OA\Parameter(
+     *          name="includeStats",
+     *          description="Include the stats for each group.  This makes the call significantly slower.  Default false.",
+     *          required=false,
+     *          in="query",
+     *          @OA\Schema(
+     *              type="boolean"
+     *          )
+     *      ),
+     *      @OA\Parameter(
      *          name="includeArchived",
      *          description="Include archived groups",
      *          required=false,

--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -274,9 +274,13 @@ class Group extends JsonResource
      */
     public function toArray($request)
     {
-        $stats = $this->resource->getGroupStats();
-        $stats['events'] = $stats['parties'];
-        unset($stats['parties']);
+        $stats = [];
+
+        if ($request->get('includeStats', false)) {
+            $stats = $this->resource->getGroupStats();
+            $stats['events'] = $stats['parties'];
+            unset($stats['parties']);
+        }
 
         $networkData = gettype($this->network_data) == 'string' ? json_decode($this->network_data, true) : $this->network_data;
 


### PR DESCRIPTION
This call is slow due to collection of statistics.  This PR defaults statistics off unless `includeStats` is set true on the request.  