### PR TITLE
RES-2015 Host can't create event

### DIFF
--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -573,6 +573,7 @@ class GroupController extends Controller
     {
         $user = $this->getUser();
         $host = $request->get('host', false);
+        $volunteer = User::findOrFail($iduser);
 
         $group = Group::findOrFail($id);
         $is_host_of_group = Fixometer::userHasEditGroupPermission($id, $user->id);
@@ -587,6 +588,11 @@ class GroupController extends Controller
         if (!is_null($userGroupAssociation)) {
             $userGroupAssociation->role = $host ? Role::HOST : Role::RESTARTER;
             $userGroupAssociation->save();
+
+            if ($host) {
+                $group->refresh();
+                $group->makeMemberAHost($volunteer);
+            }
         }
     }
 

--- a/tests/Feature/Groups/GroupHostTest.php
+++ b/tests/Feature/Groups/GroupHostTest.php
@@ -46,7 +46,8 @@ class GroupHostTest extends TestCase
             $this->network->addCoordinator($user);
         }
 
-        $host = User::factory()->host()->create();
+        $host = User::factory()->create();
+        $this->assertEquals(Role::RESTARTER, $host->role);
         $this->group->addVolunteer($host);
 
         $skill1 = Skills::create([
@@ -74,6 +75,8 @@ class GroupHostTest extends TestCase
             'host' => true,
         ]);
         $response->assertSuccessful();
+        $host->refresh();
+        $this->assertEquals(Role::HOST, $host->role);
 
         $response = $this->get("/api/v2/groups/{$this->idgroups}/volunteers");
         $response->assertSuccessful();


### PR DESCRIPTION
The function to change the role of a member to Host was lost in recent API changes.  This restores it and adds a test.