### PR TITLE
RES-2019 Reinstate function to add multiple items.

### DIFF
--- a/resources/js/components/EventDevice.vue
+++ b/resources/js/components/EventDevice.vue
@@ -337,11 +337,16 @@ export default {
         } else {
           this.missingCategory = false
 
-          await this.$store.dispatch('devices/add', this.currentDevice)
+          // The API only creates a single device, so we loop on the client to create multiple.
+          const toAdd = JSON.parse(JSON.stringify(this.currentDevice))
+
+          for (let i = 0; i < this.currentDevice.quantity; i++) {
+            toAdd.eventid = this.eventid
+            await this.$store.dispatch('devices/add', toAdd)
+          }
 
           this.$emit('close')
         }
-
       } catch (e) {
         console.error('Edit failed', e)
         this.axiosError = e

--- a/resources/js/components/EventDevice.vue
+++ b/resources/js/components/EventDevice.vue
@@ -338,13 +338,15 @@ export default {
           this.missingCategory = false
 
           // The API only creates a single device, so we loop on the client to create multiple.
-          const toAdd = JSON.parse(JSON.stringify(this.currentDevice))
+          let toAdd = this.currentDevice
+          toAdd = JSON.parse(JSON.stringify(toAdd))
 
           for (let i = 0; i < this.currentDevice.quantity; i++) {
-            toAdd.eventid = this.eventid
+            toAdd.id = this.currentDevice.id--
             await this.$store.dispatch('devices/add', toAdd)
           }
 
+          console.log('Close')
           this.$emit('close')
         }
       } catch (e) {

--- a/resources/js/store/devices.js
+++ b/resources/js/store/devices.js
@@ -38,8 +38,6 @@ export default {
       })
     },
     add (state, params) {
-      let exists = false
-
       if (params.id) {
         if (!state.devicesByEvent[params.eventid]) {
           Vue.set(state.devicesByEvent, params.eventid, [])
@@ -52,7 +50,6 @@ export default {
 
         Vue.set(state.devicesById, params.id, params)
         console.log('Set images', params.images)
-        // Vue.set(state.devicesById[params.id], 'images', params.images)
       }
 
       return params
@@ -114,8 +111,10 @@ export default {
     async add ({commit, dispatch, rootGetters}, params) {
       const formData = new FormData()
 
-      params['eventid'] = params['event_id']
-      delete params['event_id']
+      if (params.event_id) {
+        params['eventid'] = params['event_id']
+        delete params['event_id']
+      }
 
       for (var key in params) {
         if (params[key]) {


### PR DESCRIPTION
This was lost in recent API changes.

It's not immediately clear why the `JSON.parse` and setting of `eventid` is necessary, but it will be a consequence of reactive changes from the store, and this works.