### PR TITLE
RES-2029 Filter autocomplete on powered vs unpowered.

### DIFF
--- a/resources/js/components/DeviceType.vue
+++ b/resources/js/components/DeviceType.vue
@@ -59,7 +59,17 @@ export default {
       return this.$store.getters['items/list'];
     },
     suggestions() {
-      return this.itemTypes.map(i => i.type)
+      const ret = []
+
+      this.itemTypes.forEach(i => {
+        if (i.type && i.type.length) {
+          if (this.powered === i.powered) {
+            ret.push(i.type)
+          }
+        }
+      })
+
+      return ret
     },
     notASuggestion() {
       if (!this.currentType || !this.itemTypes.length) {


### PR DESCRIPTION
The autocomplete of item type should filter by powered vs unpowered to ensure that if we have bad historical data we don't suggest an unpowered item for a powered one by mistake.