### PR TITLE
RES-2038 Make estimates on login/register/about pages less seemingly precise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,3 +144,6 @@ npm test
 - Image handling via intervention/image with custom sizing
 - Custom validation rules in `app/Rules/`
 - Event-driven architecture with model observers
+
+## Development Warnings
+- Don't try to test changes when you're running on Windows.

--- a/lang/de/login.php
+++ b/lang/de/login.php
@@ -11,7 +11,7 @@ return [
                             </ul>',
   'more' => 'Find out more',
   'stat_1' => 'Devices fixed',
-  'stat_2' => 'CO<sub>2</sub> emissions prevented',
+  'stat_2' => 'CO<sub>2</sub>e emissions prevented',
   'stat_3' => 'Waste prevented',
   'stat_4' => 'Events held',
   'login_title' => 'Sign in',

--- a/lang/en/login.php
+++ b/lang/en/login.php
@@ -11,7 +11,7 @@ return [
   'whatis' => 'Welcome to the Restarters community',
   'more' => 'Find out more',
   'stat_1' => 'Devices fixed',
-  'stat_2' => 'CO<sub>2</sub> emissions prevented',
+  'stat_2' => 'CO<sub>2</sub>e emissions prevented',
   'stat_3' => 'Waste prevented',
   'stat_4' => 'Events held',
   'login_title' => 'Sign in',

--- a/lang/fr-BE/login.php
+++ b/lang/fr-BE/login.php
@@ -11,7 +11,7 @@ return [
                             </ul>',
   'more' => 'En savoir plus',
   'stat_1' => 'Appareils réparés',
-  'stat_2' => 'Émissions de CO<sub>2</sub> évitées',
+  'stat_2' => 'Émissions de CO<sub>2</sub>e évitées',
   'stat_3' => 'Déchets<br>évités',
   'stat_4' => 'Événements<br>réalisés',
   'login_title' => 'Connexion',

--- a/lang/fr/login.php
+++ b/lang/fr/login.php
@@ -11,7 +11,7 @@ return [
                             </ul>',
   'more' => 'En savoir plus',
   'stat_1' => 'Appareils réparés',
-  'stat_2' => 'Émissions de CO<sub>2</sub> évitées',
+  'stat_2' => 'Émissions de CO<sub>2</sub>e évitées',
   'stat_3' => 'Déchets<br>évités',
   'stat_4' => 'Événements<br>réalisés',
   'login_title' => 'Connexion',

--- a/lang/it/login.php
+++ b/lang/it/login.php
@@ -11,7 +11,7 @@ return [
                             </ul>',
   'more' => 'Scopri altro',
   'stat_1' => 'Dispositivi riparati',
-  'stat_2' => 'Emissioni di CO<sub>2</sub> prevenute',
+  'stat_2' => 'Emissioni di CO<sub>2</sub>e prevenute',
   'stat_3' => 'Rifiuti evitati',
   'stat_4' => 'Eventi realizzati',
   'login_title' => 'Entra',

--- a/lang/ne/login.php
+++ b/lang/ne/login.php
@@ -4,7 +4,7 @@ return [
   'login_title' => 'Inloggen',
   'more' => 'Meer weten',
   'stat_1' => 'Herstelde toestellen',
-  'stat_2' => 'Vermeden CO<sub>2</sub> uitstoot',
+  'stat_2' => 'Vermeden CO<sub>2</sub>e uitstoot',
   'stat_3' => 'Vermeden afval',
   'stat_4' => 'georganiseerde activiteiten',
   'whatis' => 'Welkom in de Restart gemeenschap',

--- a/lang/nl-BE/login.php
+++ b/lang/nl-BE/login.php
@@ -4,7 +4,7 @@ return [
   'login_title' => 'Inloggen',
   'more' => 'Meer weten',
   'stat_1' => 'Herstelde toestellen',
-  'stat_2' => 'CO<sub>2</sub>-uitstoot vermeden',
+  'stat_2' => 'CO<sub>2</sub>e-uitstoot vermeden',
   'stat_3' => 'afval vermeden',
   'stat_4' => 'herstelactiviteiten',
   'whatis' => 'Welkom!',

--- a/lang/no/login.php
+++ b/lang/no/login.php
@@ -11,7 +11,7 @@ return [
                             </ul>',
   'more' => 'Find out more',
   'stat_1' => 'Devices fixed',
-  'stat_2' => 'CO<sub>2</sub> emissions prevented',
+  'stat_2' => 'CO<sub>2</sub>e emissions prevented',
   'stat_3' => 'Waste prevented',
   'stat_4' => 'Events held',
   'login_title' => 'Sign in',

--- a/resources/views/includes/info.blade.php
+++ b/resources/views/includes/info.blade.php
@@ -14,11 +14,23 @@
                 <div class="stat-header">@lang('login.stat_1')</div>
             </div>
             <div class="stats__stat">
-                <div class="stat-figure">{{ number_format(round($co2Total), 0, '.', ',') }} kg</div>
+                <div class="stat-figure">
+                    @if($co2Total >= 1000)
+                        {{ number_format(round($co2Total / 1000), 0, '.', ',') }} tonnes
+                    @else
+                        {{ number_format(round($co2Total), 0, '.', ',') }} kg
+                    @endif
+                </div>
                 <div class="stat-header">@lang('login.stat_2')</div>
             </div>
             <div class="stats__stat">
-                <div class="stat-figure">{{ number_format(round($wasteTotal), 0, '.', ',') }} kg</div>
+                <div class="stat-figure">
+                    @if($wasteTotal >= 1000)
+                        {{ number_format(round($wasteTotal / 1000), 0, '.', ',') }} tonnes
+                    @else
+                        {{ number_format(round($wasteTotal), 0, '.', ',') }} kg
+                    @endif
+                </div>
                 <div class="stat-header">@lang('login.stat_3')</div>
             </div>
             <div class="stats__stat">


### PR DESCRIPTION
Similar to the changes we made recently on the Fixometer section.

Currently we display the estimates for CO2e emissions and waste prevented emissions in kgs.

As it currently stands, we're displaying 2,789,606 kg for CO2e emissions prevented and 315,582 kg waste prevented.

This gives a suggestion of precision which isn't valid.  We should just be hinting at an order of magnitude.

Recently on the Fixometer section we changes this to use tonnes. So this displays as 2,790 tonnes estimated CO2e emissions prevented and 316 tonnes estimated waste prevented.  We should do the same on these pages.

We’ll make it adaptive such that it doesn’t look weird if you’ve just started with a fresh install and haven’t made it to a tonne yet.