### PR TITLE
Feature: Public Events API Endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ WIKI_COOKIE_PREFIX=wiki_db
 WIKI_HOST=mediawiki
 
 FEATURE__DISCOURSE_INTEGRATION=true
+FEATURE__PUBLIC_EVENTS_API=false
 # Always put quotes around Discourse secrets, because they might contain the hash symbol.
 DISCOURSE_SECRET="ASDF"
 DISCOURSE_URL=http://talk.restarters.test

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ electronic repairs. Please read more at http://rstrt.org/FAQ
 
 Compiled version of the specs is available at: https://therestartproject.github.io/restarters.net/Index.html.
 
+## Public events API
+
+The public events API is documented in [docs/public-events-api.md](docs/public-events-api.md). Enable it with `FEATURE__PUBLIC_EVENTS_API=true`.
+
 ## Funding and future development
 
 The first version of the tool (2015) was the core Fixometer engine. This was

--- a/app/ApiClient.php
+++ b/app/ApiClient.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ApiClient extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'token_hash',
+        'token_hint',
+        'scopes',
+        'allowed_origins',
+        'allowed_network_ids',
+        'rate_limit_per_minute',
+        'active',
+        'expires_at',
+        'last_used_at',
+    ];
+
+    protected $hidden = [
+        'token_hash',
+    ];
+
+    protected $casts = [
+        'scopes' => 'array',
+        'allowed_origins' => 'array',
+        'allowed_network_ids' => 'array',
+        'active' => 'boolean',
+        'expires_at' => 'datetime',
+        'last_used_at' => 'datetime',
+    ];
+
+    public function hasScope($scope)
+    {
+        return in_array($scope, $this->scopes ?: [], true);
+    }
+
+    public function hasExpired()
+    {
+        return $this->expires_at && Carbon::now()->greaterThan($this->expires_at);
+    }
+}

--- a/app/Console/Commands/ApiClientsCreate.php
+++ b/app/Console/Commands/ApiClientsCreate.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Network;
+use App\Services\ApiClientService;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class ApiClientsCreate extends Command
+{
+    protected $signature = 'api-clients:create
+                            {--name= : Display name for the integration client}
+                            {--scopes=events:read : Comma-separated scopes}
+                            {--origins= : Comma-separated allowed origins}
+                            {--networks= : Comma-separated allowed network IDs}
+                            {--rate=120 : Requests per minute}
+                            {--expires-at= : Expiration datetime}';
+
+    protected $description = 'Create a read-only integration API client and print its secret once';
+
+    public function handle(ApiClientService $apiClientService): int
+    {
+        $name = trim((string) $this->option('name'));
+
+        if ($name === '') {
+            $this->error('The --name option is required.');
+            return 1;
+        }
+
+        $rate = (int) $this->option('rate');
+        if ($rate < 1) {
+            $this->error('The --rate option must be greater than zero.');
+            return 1;
+        }
+
+        $scopes = $this->parseCsvOption((string) $this->option('scopes'));
+        $origins = $this->parseCsvOption((string) $this->option('origins'));
+        $networkIds = array_values(array_filter(array_map('intval', $this->parseCsvOption((string) $this->option('networks'))), function ($id) {
+            return $id > 0;
+        }));
+
+        if (! empty($networkIds) && Network::whereIn('id', $networkIds)->count() !== count($networkIds)) {
+            $this->error('One or more network IDs do not exist.');
+            return 1;
+        }
+
+        $expiresAt = null;
+        if ($this->option('expires-at')) {
+            $expiresAt = Carbon::parse((string) $this->option('expires-at'));
+        }
+
+        [$client, $plainToken] = $apiClientService->create([
+            'name' => $name,
+            'scopes' => $scopes ?: ['events:read'],
+            'allowed_origins' => $origins ?: null,
+            'allowed_network_ids' => $networkIds ?: null,
+            'rate_limit_per_minute' => $rate,
+            'active' => true,
+            'expires_at' => $expiresAt,
+        ]);
+
+        $this->info('API client created.');
+        $this->line("ID: {$client->id}");
+        $this->line("Name: {$client->name}");
+        $this->line("Token ID: {$client->token_hint}");
+        $this->line("Token: {$plainToken}");
+        $this->warn('Store this token now. It will not be shown again.');
+
+        return 0;
+    }
+
+    private function parseCsvOption(string $value): array
+    {
+        if (trim($value) === '') {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('trim', explode(',', $value))));
+    }
+}

--- a/app/Console/Commands/ApiClientsRevoke.php
+++ b/app/Console/Commands/ApiClientsRevoke.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\ApiClient;
+use Illuminate\Console\Command;
+
+class ApiClientsRevoke extends Command
+{
+    protected $signature = 'api-clients:revoke {id : API client ID}';
+
+    protected $description = 'Revoke an integration API client';
+
+    public function handle(): int
+    {
+        $client = ApiClient::find($this->argument('id'));
+
+        if (! $client) {
+            $this->error('API client not found.');
+            return 1;
+        }
+
+        $client->active = false;
+        $client->save();
+
+        $this->info("Revoked API client {$client->id} ({$client->name}).");
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/ApiClientsRotate.php
+++ b/app/Console/Commands/ApiClientsRotate.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\ApiClient;
+use App\Services\ApiClientService;
+use Illuminate\Console\Command;
+
+class ApiClientsRotate extends Command
+{
+    protected $signature = 'api-clients:rotate {id : API client ID}';
+
+    protected $description = 'Rotate an integration API client token';
+
+    public function handle(ApiClientService $apiClientService): int
+    {
+        $client = ApiClient::find($this->argument('id'));
+
+        if (! $client) {
+            $this->error('API client not found.');
+            return 1;
+        }
+
+        $plainToken = $apiClientService->rotate($client);
+
+        $this->info("Rotated API client {$client->id} ({$client->name}).");
+        $this->line("Token ID: {$client->token_hint}");
+        $this->line("Token: {$plainToken}");
+        $this->warn('Store this token now. It will not be shown again.');
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/API/PublicEventController.php
+++ b/app/Http/Controllers/API/PublicEventController.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Group;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\GroupLocation;
+use App\Party;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PublicEventController extends Controller
+{
+    public function listEvents(Request $request): JsonResponse
+    {
+        return $this->listWithFilters($request);
+    }
+
+    public function showEvent(Request $request, $id): JsonResponse
+    {
+        $query = $this->buildBaseEventQuery();
+        $this->applyClientRestrictions($query, $request);
+
+        $event = $query->where('events.idevents', $id)->firstOrFail();
+
+        return response()->json([
+            'data' => $this->toPublicEventArray($event),
+        ]);
+    }
+
+    public function listGroupEvents(Request $request, $id): JsonResponse
+    {
+        Group::findOrFail($id);
+
+        return $this->listWithFilters($request, function (Builder $query) use ($id) {
+            $query->where('events.group', $id);
+        });
+    }
+
+    private function listWithFilters(Request $request, ?callable $filter = null): JsonResponse
+    {
+        $validated = $request->validate([
+            'start' => ['nullable', 'date'],
+            'end' => ['nullable', 'date'],
+            'updated_start' => ['nullable', 'date'],
+            'updated_end' => ['nullable', 'date'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $query = $this->buildBaseEventQuery();
+        $this->applyClientRestrictions($query, $request);
+
+        if ($filter) {
+            $filter($query);
+        }
+
+        $this->applyDateFilters($query, $validated);
+
+        $maxUpdatedAt = (clone $query)->max('events.updated_at');
+
+        $perPage = (int) ($validated['per_page'] ?? 50);
+        $paginator = $query->paginate($perPage);
+
+        return response()->json([
+            'data' => $paginator->getCollection()->map(function (Party $event) {
+                return $this->toPublicEventArray($event);
+            })->values(),
+            'meta' => [
+                'page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'last_page' => $paginator->lastPage(),
+            ],
+            'sync' => [
+                'generated_at' => Carbon::now()->toIso8601String(),
+                'max_updated_at' => $maxUpdatedAt ? Carbon::parse($maxUpdatedAt)->toIso8601String() : null,
+            ],
+        ]);
+    }
+
+    private function buildBaseEventQuery(): Builder
+    {
+        return Party::query()
+            ->with(['theGroup.groupImage.image'])
+            ->join('groups', 'groups.idgroups', '=', 'events.group')
+            ->whereNull('events.deleted_at')
+            ->where('events.approved', true)
+            ->where('groups.approved', true)
+            ->whereNull('groups.archived_at')
+            ->distinct()
+            ->select('events.*')
+            ->orderBy('events.event_start_utc', 'asc');
+    }
+
+    private function applyClientRestrictions(Builder $query, Request $request): void
+    {
+        $client = $request->attributes->get('apiClient');
+        $allowedNetworkIds = $client ? ($client->allowed_network_ids ?: []) : [];
+
+        if (! empty($allowedNetworkIds)) {
+            $query->join('group_network as permitted_network', 'permitted_network.group_id', '=', 'groups.idgroups')
+                ->whereIn('permitted_network.network_id', $allowedNetworkIds);
+        }
+    }
+
+    private function applyDateFilters(Builder $query, array $validated): void
+    {
+        if (! empty($validated['start'])) {
+            $query->where('events.event_start_utc', '>=', Carbon::parse($validated['start'])->setTimezone('UTC')->toIso8601String());
+        } else {
+            $query->where('events.event_end_utc', '>=', Carbon::now()->setTimezone('UTC')->toIso8601String());
+        }
+
+        if (! empty($validated['end'])) {
+            $query->where('events.event_end_utc', '<=', Carbon::parse($validated['end'])->setTimezone('UTC')->toIso8601String());
+        }
+
+        if (! empty($validated['updated_start'])) {
+            $query->where('events.updated_at', '>=', Carbon::parse($validated['updated_start'])->setTimezone('UTC')->toDateTimeString());
+        }
+
+        if (! empty($validated['updated_end'])) {
+            $query->where('events.updated_at', '<=', Carbon::parse($validated['updated_end'])->setTimezone('UTC')->toDateTimeString());
+        }
+    }
+
+    private function toPublicEventArray(Party $event): array
+    {
+        $group = $event->theGroup;
+
+        $data = [
+            'id' => $event->idevents,
+            'start' => $event->event_start_utc,
+            'end' => $event->event_end_utc,
+            'timezone' => $event->timezone,
+            'title' => $event->venue ?? $event->location,
+            'location' => $event->location,
+            'online' => (bool) $event->online,
+            'lat' => $event->latitude,
+            'lng' => $event->longitude,
+            'group' => [
+                'id' => $group->idgroups,
+                'name' => $group->name,
+                'image' => $group->groupImage && is_object($group->groupImage) && is_object($group->groupImage->image)
+                    ? $group->groupImage->image->path
+                    : null,
+                'location' => GroupLocation::make($group)->resolve(),
+                'updated_at' => Carbon::parse($group->updated_at)->toIso8601String(),
+                'archived_at' => $group->archived_at ? Carbon::parse($group->archived_at)->toIso8601String() : null,
+                'summary' => true,
+            ],
+            'description' => $event->free_text,
+            'updated_at' => Carbon::parse($event->updated_at)->toIso8601String(),
+            'approved' => (bool) $event->approved,
+            'full' => true,
+        ];
+
+        if ($event->link) {
+            $data['link'] = $event->link;
+        }
+
+        return $data;
+    }
+}

--- a/app/Http/Controllers/ApiClientAdminController.php
+++ b/app/Http/Controllers/ApiClientAdminController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\ApiClient;
+use App\Helpers\Fixometer;
+use App\Network;
+use App\Services\ApiClientService;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ApiClientAdminController extends Controller
+{
+    public function index()
+    {
+        if ($redirect = $this->redirectIfUnauthorized()) {
+            return $redirect;
+        }
+
+        $networks = Network::orderBy('name', 'asc')->get();
+        $networkLookup = $networks->keyBy('id');
+
+        $clients = ApiClient::orderByDesc('active')
+            ->orderBy('name', 'asc')
+            ->get()
+            ->each(function ($client) use ($networkLookup) {
+                $client->allowed_network_names = collect($client->allowed_network_ids ?: [])
+                    ->map(function ($networkId) use ($networkLookup) {
+                        $network = $networkLookup->get($networkId);
+
+                        return $network ? $network->name : null;
+                    })
+                    ->filter()
+                    ->values()
+                    ->all();
+            });
+
+        return view('admin.api-clients', [
+            'clients' => $clients,
+            'networks' => $networks,
+        ]);
+    }
+
+    public function store(Request $request, ApiClientService $apiClientService)
+    {
+        if ($redirect = $this->redirectIfUnauthorized()) {
+            return $redirect;
+        }
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'allowed_origins' => ['nullable', 'string'],
+            'allowed_network_ids' => ['nullable', 'array'],
+            'allowed_network_ids.*' => ['integer', 'exists:networks,id'],
+            'rate_limit_per_minute' => ['required', 'integer', 'min:1', 'max:10000'],
+            'expires_at' => ['nullable', 'date'],
+        ]);
+
+        [$client, $plainToken] = $apiClientService->create([
+            'name' => trim($validated['name']),
+            'scopes' => ['events:read'],
+            'allowed_origins' => $this->parseDelimitedList($validated['allowed_origins'] ?? null) ?: null,
+            'allowed_network_ids' => ! empty($validated['allowed_network_ids']) ? array_map('intval', $validated['allowed_network_ids']) : null,
+            'rate_limit_per_minute' => (int) $validated['rate_limit_per_minute'],
+            'active' => true,
+            'expires_at' => ! empty($validated['expires_at']) ? Carbon::parse($validated['expires_at']) : null,
+        ]);
+
+        return redirect()
+            ->route('admin.api-clients')
+            ->with('success', 'API client created.')
+            ->with('generated_api_token', [
+                'action' => 'created',
+                'name' => $client->name,
+                'token' => $plainToken,
+                'token_hint' => $client->token_hint,
+            ]);
+    }
+
+    public function rotate($id, ApiClientService $apiClientService)
+    {
+        if ($redirect = $this->redirectIfUnauthorized()) {
+            return $redirect;
+        }
+
+        $client = ApiClient::findOrFail($id);
+        $plainToken = $apiClientService->rotate($client);
+
+        return redirect()
+            ->route('admin.api-clients')
+            ->with('success', 'API client rotated.')
+            ->with('generated_api_token', [
+                'action' => 'rotated',
+                'name' => $client->name,
+                'token' => $plainToken,
+                'token_hint' => $client->token_hint,
+            ]);
+    }
+
+    public function revoke($id)
+    {
+        if ($redirect = $this->redirectIfUnauthorized()) {
+            return $redirect;
+        }
+
+        $client = ApiClient::findOrFail($id);
+        $client->active = false;
+        $client->save();
+
+        return redirect()
+            ->route('admin.api-clients')
+            ->with('success', 'API client revoked.');
+    }
+
+    private function parseDelimitedList($value): array
+    {
+        if (! $value) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('trim', preg_split('/[\r\n,]+/', $value))));
+    }
+
+    private function redirectIfUnauthorized()
+    {
+        if (! Fixometer::hasRole(Auth::user(), 'Administrator')) {
+            return redirect('/user/forbidden');
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -69,6 +69,10 @@ class Kernel extends HttpKernel
         'verifyUserConsent' => \App\Http\Middleware\VerifyUserConsent::class,
         'AcceptUserInvites' => \App\Http\Middleware\AcceptUserInvites::class,
         'ensureAPIToken' => \App\Http\Middleware\EnsureAPIToken::class,
+        'apiClient' => \App\Http\Middleware\AuthenticateApiClient::class,
+        'apiClientOrigin' => \App\Http\Middleware\EnforceApiClientOrigin::class,
+        'publicEventsApiEnabled' => \App\Http\Middleware\EnsurePublicEventsApiEnabled::class,
+        'publicApiCors' => \App\Http\Middleware\PublicApiCors::class,
 
         /**** OTHER MIDDLEWARE ****/
         'localize' => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRoutes::class,

--- a/app/Http/Middleware/AuthenticateApiClient.php
+++ b/app/Http/Middleware/AuthenticateApiClient.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\ApiClient;
+use Closure;
+use Illuminate\Http\Request;
+
+class AuthenticateApiClient
+{
+    public function handle(Request $request, Closure $next, $requiredScope = null)
+    {
+        $bearerToken = $request->bearerToken();
+
+        if (! $bearerToken) {
+            return $this->unauthorized();
+        }
+
+        $client = ApiClient::where('token_hash', hash('sha256', $bearerToken))->first();
+
+        if (! $client || ! $client->active || $client->hasExpired()) {
+            return $this->unauthorized();
+        }
+
+        if ($requiredScope && ! $client->hasScope($requiredScope)) {
+            return response()->json([
+                'message' => 'Forbidden.',
+            ], 403);
+        }
+
+        $request->attributes->set('apiClient', $client);
+
+        $response = $next($request);
+
+        $client->last_used_at = now();
+        $client->save();
+
+        return $response;
+    }
+
+    private function unauthorized()
+    {
+        return response()->json([
+            'message' => 'Unauthenticated.',
+        ], 401);
+    }
+}

--- a/app/Http/Middleware/EnforceApiClientOrigin.php
+++ b/app/Http/Middleware/EnforceApiClientOrigin.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\ApiClient;
+use Closure;
+use Illuminate\Http\Request;
+
+class EnforceApiClientOrigin
+{
+    public function handle(Request $request, Closure $next)
+    {
+        /** @var ApiClient|null $client */
+        $client = $request->attributes->get('apiClient');
+
+        if (! $client) {
+            return response()->json([
+                'message' => 'Unauthenticated.',
+            ], 401);
+        }
+
+        $requestOrigin = $request->headers->get('Origin');
+        $allowedOrigins = $this->normalizeOrigins($client->allowed_origins);
+
+        if ($requestOrigin && ! empty($allowedOrigins)) {
+            $normalizedRequestOrigin = $this->normalizeOrigin($requestOrigin);
+
+            if (! in_array($normalizedRequestOrigin, $allowedOrigins, true)) {
+                return response()->json([
+                    'message' => 'Origin not allowed.',
+                ], 403);
+            }
+        }
+
+        return $next($request);
+    }
+
+    private function normalizeOrigins($origins)
+    {
+        if (! $origins) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(function ($origin) {
+            return $this->normalizeOrigin($origin);
+        }, $origins)));
+    }
+
+    private function normalizeOrigin($origin)
+    {
+        if (! $origin) {
+            return null;
+        }
+
+        return strtolower(rtrim(trim($origin), '/'));
+    }
+}

--- a/app/Http/Middleware/EnsurePublicEventsApiEnabled.php
+++ b/app/Http/Middleware/EnsurePublicEventsApiEnabled.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class EnsurePublicEventsApiEnabled
+{
+    public function handle($request, Closure $next)
+    {
+        if (! config('restarters.features.public_events_api', false)) {
+            abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/PublicApiCors.php
+++ b/app/Http/Middleware/PublicApiCors.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class PublicApiCors
+{
+    public function handle($request, Closure $next)
+    {
+        if ($request->isMethod('OPTIONS')) {
+            return $this->addHeaders($request, response()->noContent());
+        }
+
+        return $this->addHeaders($request, $next($request));
+    }
+
+    private function addHeaders($request, $response)
+    {
+        $origin = $request->headers->get('Origin');
+        $allowOrigin = $origin ?: '*';
+
+        $response->headers->set('Access-Control-Allow-Origin', $allowOrigin);
+        $response->headers->set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        $response->headers->set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+        $response->headers->set('Access-Control-Max-Age', '3600');
+        $response->headers->set('Vary', 'Origin', false);
+
+        return $response;
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -71,5 +71,13 @@ class RouteServiceProvider extends ServiceProvider
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(300)->by($request->user()?->id ?: $request->ip());
         });
+
+        RateLimiter::for('public-api', function (Request $request) {
+            $client = $request->attributes->get('apiClient');
+            $perMinute = $client ? $client->rate_limit_per_minute : 120;
+            $clientId = $client ? $client->id : 'anonymous';
+
+            return Limit::perMinute($perMinute)->by($clientId.':'.$request->ip());
+        });
     }
 }

--- a/app/Services/ApiClientService.php
+++ b/app/Services/ApiClientService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services;
+
+use App\ApiClient;
+use Illuminate\Support\Str;
+
+class ApiClientService
+{
+    public function create(array $attributes)
+    {
+        $plainToken = Str::random(64);
+        $client = ApiClient::create(array_merge($attributes, [
+            'token_hash' => hash('sha256', $plainToken),
+            'token_hint' => $this->makeTokenHint($plainToken),
+        ]));
+
+        return [$client, $plainToken];
+    }
+
+    public function rotate(ApiClient $client)
+    {
+        $plainToken = Str::random(64);
+
+        $client->token_hash = hash('sha256', $plainToken);
+        $client->token_hint = $this->makeTokenHint($plainToken);
+        $client->active = true;
+        $client->save();
+
+        return $plainToken;
+    }
+
+    public function makeTokenHint($plainToken)
+    {
+        return substr($plainToken, 0, 6).'...'.substr($plainToken, -4);
+    }
+}

--- a/config/restarters.php
+++ b/config/restarters.php
@@ -4,6 +4,7 @@ return [
 
     'features' => [
         'discourse_integration' => env('FEATURE__DISCOURSE_INTEGRATION', true),
+        'public_events_api' => env('FEATURE__PUBLIC_EVENTS_API', false),
     ],
 
     'wiki' => [

--- a/database/factories/ApiClientFactory.php
+++ b/database/factories/ApiClientFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\ApiClient;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ApiClientFactory extends Factory
+{
+    protected $model = ApiClient::class;
+
+    public function definition()
+    {
+        $plainToken = 'token_'.$this->faker->unique()->lexify('????????????????');
+
+        return [
+            'name' => $this->faker->company(),
+            'token_hash' => hash('sha256', $plainToken),
+            'token_hint' => substr($plainToken, 0, 6).'...'.substr($plainToken, -4),
+            'scopes' => ['events:read'],
+            'allowed_origins' => null,
+            'allowed_network_ids' => null,
+            'rate_limit_per_minute' => 120,
+            'active' => true,
+            'expires_at' => null,
+            'last_used_at' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_04_02_000000_create_api_clients_table.php
+++ b/database/migrations/2026_04_02_000000_create_api_clients_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('api_clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('token_hash', 64)->unique();
+            $table->string('token_hint', 20);
+            $table->json('scopes')->nullable();
+            $table->json('allowed_origins')->nullable();
+            $table->json('allowed_network_ids')->nullable();
+            $table->unsignedInteger('rate_limit_per_minute')->default(120);
+            $table->boolean('active')->default(true);
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('api_clients');
+    }
+};

--- a/docs/public-events-api.md
+++ b/docs/public-events-api.md
@@ -1,0 +1,42 @@
+# Public Events API
+
+This project exposes a read-only public events API behind the `FEATURE__PUBLIC_EVENTS_API` feature flag.
+
+## Endpoints
+
+- `GET /api/public/v2/events`
+- `GET /api/public/v2/events/{id}`
+- `GET /api/public/v2/groups/{id}/events`
+
+## Authentication
+
+Send a bearer token in the `Authorization` header:
+
+`Authorization: Bearer <token>`
+
+Query-string API tokens are not accepted for this API.
+
+## Managing clients
+
+Administrators can create, rotate, and revoke public API clients from `/admin/api-clients`.
+
+CLI fallbacks are also available:
+
+- `php artisan api-clients:create --name="Example integration"`
+- `php artisan api-clients:rotate 123`
+- `php artisan api-clients:revoke 123`
+
+Tokens are stored only as hashes. The plaintext token is shown exactly once when created or rotated.
+
+## Filters
+
+`GET /api/public/v2/events` and `GET /api/public/v2/groups/{id}/events` support:
+
+- `start`
+- `end`
+- `updated_start`
+- `updated_end`
+- `page`
+- `per_page`
+
+If `start` is omitted, the API defaults to upcoming and in-progress events.

--- a/resources/views/admin/api-clients.blade.php
+++ b/resources/views/admin/api-clients.blade.php
@@ -1,0 +1,167 @@
+@extends('layouts.app')
+
+@section('content')
+<section class="admin">
+  <div class="container">
+      @if (\Session::has('success'))
+          <div class="alert alert-success">
+              {!! \Session::get('success') !!}
+          </div>
+      @endif
+
+      @if (\Session::has('danger'))
+          <div class="alert alert-danger">
+              {!! \Session::get('danger') !!}
+          </div>
+      @endif
+
+      @if ($errors->any())
+          <div class="alert alert-danger">
+              <ul class="mb-0">
+                  @foreach ($errors->all() as $error)
+                      <li>{{ $error }}</li>
+                  @endforeach
+              </ul>
+          </div>
+      @endif
+
+      @if (\Session::has('generated_api_token'))
+          @php($generatedToken = \Session::get('generated_api_token'))
+          <div class="alert alert-warning">
+              <h2 class="h5">New token generated for {{ $generatedToken['name'] }}</h2>
+              <p class="mb-2">This token is shown once. Store it now. If it is lost, rotate the client to mint a new token.</p>
+              <p class="mb-1"><strong>Token ID:</strong> <code>{{ $generatedToken['token_hint'] }}</code></p>
+              <p class="mb-0"><strong>Token:</strong> <code>{{ $generatedToken['token'] }}</code></p>
+          </div>
+      @endif
+
+      <div class="row mb-30">
+          <div class="col-12">
+              <div class="d-flex align-items-center">
+                  <h1 class="mb-0">API clients</h1>
+              </div>
+              <p class="mt-3">Create and manage bearer-token clients for the public events API. Only the masked token ID is stored after creation.</p>
+          </div>
+      </div>
+
+      <div class="row mb-4">
+          <div class="col-12">
+              <div class="card">
+                  <div class="card-body">
+                      <h2 class="h4">Create API client</h2>
+                      <form method="POST" action="{{ route('admin.api-clients.store') }}">
+                          @csrf
+                          <div class="form-group">
+                              <label for="name">Name</label>
+                              <input id="name" name="name" class="form-control" value="{{ old('name') }}" required>
+                          </div>
+
+                          <div class="form-group">
+                              <label for="allowed_origins">Allowed origins</label>
+                              <textarea id="allowed_origins" name="allowed_origins" class="form-control" rows="3" placeholder="https://example.org, https://subdomain.example.org">{{ old('allowed_origins') }}</textarea>
+                              <small class="form-text text-muted">Leave blank to allow any origin. Separate multiple origins with commas or new lines.</small>
+                          </div>
+
+                          <div class="form-group">
+                              <label for="allowed_network_ids">Allowed networks</label>
+                              <select id="allowed_network_ids" name="allowed_network_ids[]" class="form-control" multiple size="6">
+                                  @foreach ($networks as $network)
+                                      <option value="{{ $network->id }}" @selected(in_array($network->id, old('allowed_network_ids', [])))>{{ $network->name }}</option>
+                                  @endforeach
+                              </select>
+                              <small class="form-text text-muted">Leave empty to allow all networks.</small>
+                          </div>
+
+                          <div class="form-group">
+                              <label for="rate_limit_per_minute">Rate limit per minute</label>
+                              <input id="rate_limit_per_minute" name="rate_limit_per_minute" type="number" min="1" class="form-control" value="{{ old('rate_limit_per_minute', 120) }}" required>
+                          </div>
+
+                          <div class="form-group">
+                              <label for="expires_at">Expires at</label>
+                              <input id="expires_at" name="expires_at" type="datetime-local" class="form-control" value="{{ old('expires_at') }}">
+                              <small class="form-text text-muted">Leave blank for a non-expiring token.</small>
+                          </div>
+
+                          <div class="form-group mb-0">
+                              <label>Scope</label>
+                              <input class="form-control" value="events:read" readonly>
+                          </div>
+
+                          <button type="submit" class="btn btn-primary mt-3">Create client</button>
+                      </form>
+                  </div>
+              </div>
+          </div>
+      </div>
+
+      <div class="row">
+          <div class="col-12">
+              <div class="table-responsive table-section">
+                  <table class="table table-hover table-striped">
+                      <thead>
+                          <tr>
+                              <th>Name</th>
+                              <th>Status</th>
+                              <th>Token ID</th>
+                              <th>Networks</th>
+                              <th>Allowed origins</th>
+                              <th>Rate</th>
+                              <th>Expires</th>
+                              <th>Last used</th>
+                              <th>Actions</th>
+                          </tr>
+                      </thead>
+                      <tbody>
+                          @forelse ($clients as $client)
+                              <tr>
+                                  <td>
+                                      <strong>{{ $client->name }}</strong><br>
+                                      <small class="text-muted">{{ implode(', ', $client->scopes ?: []) }}</small>
+                                  </td>
+                                  <td>{{ $client->active ? 'Active' : 'Revoked' }}</td>
+                                  <td><code>{{ $client->token_hint }}</code></td>
+                                  <td>
+                                      @if (!empty($client->allowed_network_names))
+                                          {{ implode(', ', $client->allowed_network_names) }}
+                                      @else
+                                          All networks
+                                      @endif
+                                  </td>
+                                  <td>
+                                      @if (!empty($client->allowed_origins))
+                                          {{ implode(', ', $client->allowed_origins) }}
+                                      @else
+                                          All origins
+                                      @endif
+                                  </td>
+                                  <td>{{ $client->rate_limit_per_minute }}/min</td>
+                                  <td>{{ $client->expires_at ? $client->expires_at->toDayDateTimeString() : 'Never' }}</td>
+                                  <td>{{ $client->last_used_at ? $client->last_used_at->toDayDateTimeString() : 'Never' }}</td>
+                                  <td class="d-flex">
+                                      <form method="POST" action="{{ route('admin.api-clients.rotate', $client->id) }}" class="mr-2">
+                                          @csrf
+                                          <button type="submit" class="btn btn-sm btn-outline-primary">Rotate</button>
+                                      </form>
+
+                                      @if ($client->active)
+                                          <form method="POST" action="{{ route('admin.api-clients.revoke', $client->id) }}">
+                                              @csrf
+                                              <button type="submit" class="btn btn-sm btn-danger">Revoke</button>
+                                          </form>
+                                      @endif
+                                  </td>
+                              </tr>
+                          @empty
+                              <tr>
+                                  <td colspan="9">No API clients created yet.</td>
+                              </tr>
+                          @endforelse
+                      </tbody>
+                  </table>
+              </div>
+          </div>
+      </div>
+  </div>
+</section>
+@endsection

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -112,6 +112,7 @@
                                   <li><a href="{{ route('skills') }}">Skills</a></li>
                                   <li><a href="{{ route('tags') }}">Group tags</a></li>
                                   <li><a href="{{ route('category') }}">Categories</a></li>
+                                  <li><a href="{{ route('admin.api-clients') }}">API clients</a></li>
                                   <li><a href="{{ route('users') }}">Users</a></li>
                                   <li><a href="{{ route('roles') }}">Roles</a></li>
                                   <li><a href="{{ route('networks.index') }}">@lang('networks.general.networks')</a></li>

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,6 +68,21 @@ Route::get('/talk/topics/{tag?}', [API\DiscourseController::class, 'discussionTo
 // Timezones
 Route::get('/timezones', [App\Http\Controllers\ApiController::class, 'timezones']);
 
+Route::prefix('public/v2')
+    ->withoutMiddleware('throttle:api')
+    ->middleware(['publicEventsApiEnabled', 'publicApiCors'])
+    ->group(function () {
+        Route::options('{any}', function () {
+            return response()->noContent();
+        })->where('any', '.*');
+
+        Route::middleware(['apiClient:events:read', 'apiClientOrigin', 'throttle:public-api'])->group(function () {
+            Route::get('/events', [API\PublicEventController::class, 'listEvents']);
+            Route::get('/events/{id}', [API\PublicEventController::class, 'showEvent']);
+            Route::get('/groups/{id}/events', [API\PublicEventController::class, 'listGroupEvents']);
+        });
+    });
+
 // We are working towards a new and more coherent API.
 Route::prefix('v2')->group(function() {
     Route::middleware(\App\Http\Middleware\APISetLocale::class)->group(function() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\DeviceUrlController;
 use App\Http\Controllers\InformationAlertCookieController;
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\ApiClientAdminController;
 use App\Http\Controllers\BattcatOraController;
 use App\Http\Controllers\BrandsController;
 use App\Http\Controllers\CalendarEventsController;
@@ -286,6 +287,10 @@ Route::middleware('auth', 'verifyUserConsent', 'ensureAPIToken')->group(function
     //Admin Controller
     Route::prefix('admin')->group(function () {
         Route::get('/stats', [AdminController::class, 'stats']);
+        Route::get('/api-clients', [ApiClientAdminController::class, 'index'])->name('admin.api-clients');
+        Route::post('/api-clients', [ApiClientAdminController::class, 'store'])->name('admin.api-clients.store');
+        Route::post('/api-clients/{id}/rotate', [ApiClientAdminController::class, 'rotate'])->name('admin.api-clients.rotate');
+        Route::post('/api-clients/{id}/revoke', [ApiClientAdminController::class, 'revoke'])->name('admin.api-clients.revoke');
     });
 
     //Category Controller

--- a/tests/Feature/Admin/ApiClientManagementTest.php
+++ b/tests/Feature/Admin/ApiClientManagementTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\ApiClient;
+use App\Network;
+use App\Role;
+use Tests\TestCase;
+
+class ApiClientManagementTest extends TestCase
+{
+    public function testAdministratorCanViewApiClientsPage()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $response = $this->get('/admin/api-clients');
+        $response->assertSuccessful();
+        $response->assertSee('API clients');
+    }
+
+    public function testNonAdministratorCannotAccessApiClientsPage()
+    {
+        $this->loginAsTestUser(Role::RESTARTER);
+
+        $response = $this->get('/admin/api-clients');
+        $response->assertRedirect('/user/forbidden');
+    }
+
+    public function testAdministratorCanCreateApiClientFromAdminPage()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+        $network = Network::factory()->create(['name' => 'Allowed Network']);
+
+        $response = $this->post('/admin/api-clients', [
+            'name' => 'Display integration',
+            'allowed_origins' => "https://allowed.example\nhttps://second.example",
+            'allowed_network_ids' => [$network->id],
+            'rate_limit_per_minute' => 77,
+            'expires_at' => '2030-01-01T12:00',
+        ]);
+
+        $response->assertRedirect('/admin/api-clients');
+        $response->assertSessionHas('generated_api_token');
+
+        $client = ApiClient::where('name', 'Display integration')->first();
+        $this->assertNotNull($client);
+        $this->assertEquals(['events:read'], $client->scopes);
+        $this->assertEquals(['https://allowed.example', 'https://second.example'], $client->allowed_origins);
+        $this->assertEquals([$network->id], $client->allowed_network_ids);
+        $this->assertEquals(77, $client->rate_limit_per_minute);
+        $this->assertNotEmpty($client->token_hash);
+        $this->assertNotEmpty($client->token_hint);
+    }
+
+    public function testAdministratorCanRotateApiClientFromAdminPage()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $client = ApiClient::factory()->create([
+            'token_hash' => hash('sha256', 'before_rotate'),
+            'token_hint' => 'before...1234',
+            'active' => false,
+        ]);
+
+        $response = $this->post("/admin/api-clients/{$client->id}/rotate");
+        $response->assertRedirect('/admin/api-clients');
+        $response->assertSessionHas('generated_api_token');
+
+        $client->refresh();
+        $this->assertNotEquals(hash('sha256', 'before_rotate'), $client->token_hash);
+        $this->assertNotEquals('before...1234', $client->token_hint);
+        $this->assertTrue($client->active);
+    }
+
+    public function testAdministratorCanRevokeApiClientFromAdminPage()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $client = ApiClient::factory()->create([
+            'active' => true,
+        ]);
+
+        $response = $this->post("/admin/api-clients/{$client->id}/revoke");
+        $response->assertRedirect('/admin/api-clients');
+
+        $client->refresh();
+        $this->assertFalse($client->active);
+    }
+}

--- a/tests/Feature/Commands/ApiClientCommandsTest.php
+++ b/tests/Feature/Commands/ApiClientCommandsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use App\ApiClient;
+use App\Network;
+use Tests\TestCase;
+
+class ApiClientCommandsTest extends TestCase
+{
+    public function testCreateCommandCreatesApiClient()
+    {
+        $network = Network::factory()->create();
+
+        $this->artisan('api-clients:create', [
+            '--name' => 'CLI client',
+            '--origins' => 'https://allowed.example,https://second.example',
+            '--networks' => (string) $network->id,
+            '--rate' => 99,
+            '--expires-at' => '2030-01-01 10:00:00',
+        ])->assertExitCode(0);
+
+        $client = ApiClient::where('name', 'CLI client')->first();
+        $this->assertNotNull($client);
+        $this->assertEquals(['events:read'], $client->scopes);
+        $this->assertEquals(['https://allowed.example', 'https://second.example'], $client->allowed_origins);
+        $this->assertEquals([$network->id], $client->allowed_network_ids);
+        $this->assertEquals(99, $client->rate_limit_per_minute);
+        $this->assertTrue($client->active);
+        $this->assertNotEmpty($client->token_hash);
+        $this->assertNotEmpty($client->token_hint);
+    }
+
+    public function testRotateCommandChangesTokenAndReactivatesClient()
+    {
+        $client = ApiClient::factory()->create([
+            'active' => false,
+            'token_hash' => hash('sha256', 'before_rotate'),
+            'token_hint' => 'before...1234',
+        ]);
+
+        $this->artisan('api-clients:rotate', [
+            'id' => $client->id,
+        ])->assertExitCode(0);
+
+        $client->refresh();
+        $this->assertTrue($client->active);
+        $this->assertNotEquals(hash('sha256', 'before_rotate'), $client->token_hash);
+        $this->assertNotEquals('before...1234', $client->token_hint);
+    }
+
+    public function testRevokeCommandDisablesClient()
+    {
+        $client = ApiClient::factory()->create([
+            'active' => true,
+        ]);
+
+        $this->artisan('api-clients:revoke', [
+            'id' => $client->id,
+        ])->assertExitCode(0);
+
+        $client->refresh();
+        $this->assertFalse($client->active);
+    }
+}

--- a/tests/Feature/Events/PublicEventsApiTest.php
+++ b/tests/Feature/Events/PublicEventsApiTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Tests\Feature\Events;
+
+use App\ApiClient;
+use App\Group;
+use App\Network;
+use App\Party;
+use App\Role;
+use Carbon\Carbon;
+use Illuminate\Cache\RateLimiter as CacheRateLimiter;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Tests\TestCase;
+
+class PublicEventsApiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['restarters.features.public_events_api' => true]);
+    }
+
+    public function testPublicEventsApiRequiresBearerKey()
+    {
+        $response = $this->get('/api/public/v2/events');
+        $response->assertStatus(401);
+    }
+
+    public function testPublicEventsApiIgnoresQueryTokenAuth()
+    {
+        $response = $this->get('/api/public/v2/events?api_token=not_a_valid_public_key');
+        $response->assertStatus(401);
+    }
+
+    public function testPublicEventsApiListsOnlyUpcomingApprovedEventsByDefault()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $approvedGroupId = $this->createGroup('Public API Group', 'https://example.com', 'London', 'Some text', true, true);
+        $futureApprovedId = $this->createEvent($approvedGroupId, 'tomorrow', true, true);
+        $pastApprovedId = $this->createEvent($approvedGroupId, 'yesterday', true, true);
+        $futureUnapprovedId = $this->createEvent($approvedGroupId, 'next week', true, false);
+
+        $unapprovedGroupId = $this->createGroup('Hidden Group', 'https://example.com', 'London', 'Some text', true, false);
+        $hiddenEventId = $this->createEvent($unapprovedGroupId, 'next week', true, true);
+
+        $archivedGroupId = $this->createGroup('Archived Group', 'https://example.com', 'London', 'Some text', true, true);
+        $archivedEventId = $this->createEvent($archivedGroupId, 'next week', true, true);
+        $archivedGroup = Group::findOrFail($archivedGroupId);
+        $archivedGroup->archived_at = '2022-01-01 00:00:00';
+        $archivedGroup->save();
+
+        $token = $this->createPublicApiToken();
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)->get('/api/public/v2/events');
+        $response->assertSuccessful();
+
+        $json = json_decode($response->getContent(), true);
+        $ids = array_column($json['data'], 'id');
+
+        $this->assertContains($futureApprovedId, $ids);
+        $this->assertNotContains($pastApprovedId, $ids);
+        $this->assertNotContains($futureUnapprovedId, $ids);
+        $this->assertNotContains($hiddenEventId, $ids);
+        $this->assertNotContains($archivedEventId, $ids);
+
+        $this->assertArrayHasKey('meta', $json);
+        $this->assertArrayHasKey('sync', $json);
+        $this->assertArrayHasKey('generated_at', $json['sync']);
+        $this->assertArrayHasKey('max_updated_at', $json['sync']);
+        $this->assertArrayHasKey('description', $json['data'][0]);
+        $this->assertArrayNotHasKey('stats', $json['data'][0]);
+        $this->assertArrayNotHasKey('network_data', $json['data'][0]);
+        $this->assertArrayNotHasKey('networks', $json['data'][0]['group']);
+    }
+
+    public function testPublicEventsApiSupportsGroupFilters()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $group1Id = $this->createGroup('Group One', 'https://example.com', 'London', 'Some text', true, true);
+        $group2Id = $this->createGroup('Group Two', 'https://example.com', 'London', 'Some text', true, true);
+
+        $event1 = $this->createEvent($group1Id, 'tomorrow', true, true);
+        $event2 = $this->createEvent($group2Id, 'tomorrow', true, true);
+
+        $token = $this->createPublicApiToken();
+
+        $groupResponse = $this->withHeader('Authorization', 'Bearer '.$token)->get("/api/public/v2/groups/{$group1Id}/events");
+        $groupResponse->assertSuccessful();
+        $groupJson = json_decode($groupResponse->getContent(), true);
+        $groupIds = array_column($groupJson['data'], 'id');
+        $this->assertContains($event1, $groupIds);
+        $this->assertNotContains($event2, $groupIds);
+    }
+
+    public function testPublicEventsApiRespectsAllowedNetworkRestrictions()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $group1Id = $this->createGroup('Restricted Group One', 'https://example.com', 'London', 'Some text', true, true);
+        $group2Id = $this->createGroup('Restricted Group Two', 'https://example.com', 'London', 'Some text', true, true);
+
+        $event1 = $this->createEvent($group1Id, 'tomorrow', true, true);
+        $event2 = $this->createEvent($group2Id, 'tomorrow', true, true);
+
+        $allowedNetwork = Network::factory()->create();
+        $blockedNetwork = Network::factory()->create();
+        $allowedNetwork->addGroup(Group::findOrFail($group1Id));
+        $blockedNetwork->addGroup(Group::findOrFail($group2Id));
+
+        $token = $this->createPublicApiToken([
+            'allowed_network_ids' => [$allowedNetwork->id],
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)->get('/api/public/v2/events');
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true);
+        $ids = array_column($json['data'], 'id');
+
+        $this->assertContains($event1, $ids);
+        $this->assertNotContains($event2, $ids);
+    }
+
+    public function testPublicEventsApiEnforcesAllowedOriginsWhenConfigured()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+        $groupId = $this->createGroup('Origin Test Group', 'https://example.com', 'London', 'Some text', true, true);
+        $this->createEvent($groupId, 'tomorrow', true, true);
+
+        $token = $this->createPublicApiToken([
+            'allowed_origins' => ['https://allowed.example'],
+        ]);
+
+        $forbidden = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'Origin' => 'https://disallowed.example',
+        ])->get('/api/public/v2/events');
+        $forbidden->assertStatus(403);
+
+        $allowed = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'Origin' => 'https://allowed.example',
+        ])->get('/api/public/v2/events');
+        $allowed->assertSuccessful();
+    }
+
+    public function testPublicEventsApiRejectsExpiredTokens()
+    {
+        $token = $this->createPublicApiToken([
+            'expires_at' => Carbon::now()->subMinute(),
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)->get('/api/public/v2/events');
+        $response->assertStatus(401);
+    }
+
+    public function testPublicEventsApiRejectsClientsWithoutRequiredScope()
+    {
+        $token = $this->createPublicApiToken([
+            'scopes' => ['groups:read'],
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)->get('/api/public/v2/events');
+        $response->assertStatus(403);
+    }
+
+    public function testPublicEventsApiAppliesPerClientRateLimits()
+    {
+        $client = ApiClient::factory()->create([
+            'rate_limit_per_minute' => 2,
+        ]);
+
+        $makeRequest = function () use ($client) {
+            $request = Request::create('/api/public/v2/events', 'GET', [], [], [], [
+                'REMOTE_ADDR' => '127.0.0.1',
+            ]);
+            $request->attributes->set('apiClient', $client);
+
+            return $request;
+        };
+
+        $rateLimiter = app(CacheRateLimiter::class);
+        $limit = $rateLimiter->limiter('public-api')($makeRequest());
+        $rateLimiter->clear(md5('public-api'.$limit->key));
+
+        $middleware = new ThrottleRequests($rateLimiter);
+
+        $first = $middleware->handle($makeRequest(), function () {
+            return response()->json(['ok' => true]);
+        }, 'public-api');
+
+        $second = $middleware->handle($makeRequest(), function () {
+            return response()->json(['ok' => true]);
+        }, 'public-api');
+
+        $this->assertEquals(200, $first->getStatusCode());
+        $this->assertEquals(200, $second->getStatusCode());
+
+        $this->expectException(ThrottleRequestsException::class);
+
+        $middleware->handle($makeRequest(), function () {
+            return response()->json(['ok' => true]);
+        }, 'public-api');
+    }
+
+    public function testPublicEventsApiShowEventReturnsOnlyPublicApprovedEvents()
+    {
+        $this->withExceptionHandling();
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $groupId = $this->createGroup('Show Event Group', 'https://example.com', 'London', 'Some text', true, true);
+        $approvedEventId = $this->createEvent($groupId, 'tomorrow', true, true);
+        $unapprovedEventId = $this->createEvent($groupId, 'next week', true, false);
+
+        $token = $this->createPublicApiToken();
+
+        $visible = $this->withHeader('Authorization', 'Bearer '.$token)->get("/api/public/v2/events/{$approvedEventId}");
+        $visible->assertSuccessful();
+        $json = json_decode($visible->getContent(), true);
+        $this->assertEquals($approvedEventId, $json['data']['id']);
+        $this->assertArrayNotHasKey('stats', $json['data']);
+        $this->assertArrayNotHasKey('network_data', $json['data']);
+        $this->assertArrayNotHasKey('networks', $json['data']['group']);
+
+        $hidden = $this->withHeader('Authorization', 'Bearer '.$token)->get("/api/public/v2/events/{$unapprovedEventId}");
+        $hidden->assertStatus(404);
+    }
+
+    public function testPublicEventsApiSupportsUpdatedWindowFilters()
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $groupId = $this->createGroup('Updated Window Group', 'https://example.com', 'London', 'Some text', true, true);
+        $eventId = $this->createEvent($groupId, 'tomorrow', true, true);
+
+        $event = Party::findOrFail($eventId);
+        $event->timestamps = false;
+        $event->updated_at = Carbon::parse('2000-01-01 00:00:00')->toDateTimeString();
+        $event->save();
+
+        $token = $this->createPublicApiToken();
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)->get(
+            '/api/public/v2/events?updated_start='.urlencode(Carbon::parse('2010-01-01')->toIso8601String())
+        );
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true);
+        $this->assertEquals([], $json['data']);
+    }
+
+    private function createPublicApiToken(array $attributes = []): string
+    {
+        $token = 'public_api_token_'.uniqid();
+
+        ApiClient::factory()->create(array_merge([
+            'token_hash' => hash('sha256', $token),
+            'token_hint' => substr($token, 0, 6).'...'.substr($token, -4),
+            'scopes' => ['events:read'],
+            'active' => true,
+            'expires_at' => null,
+        ], $attributes));
+
+        return $token;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,7 @@ use App\User;
 use App\UserGroups;
 use App\Xref;
 use App\Alert;
+use App\ApiClient;
 use Auth;
 use Carbon\Carbon;
 use DB;
@@ -28,6 +29,7 @@ use Hash;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
 use Symfony\Component\DomCrawler\Crawler;
 use Osteel\OpenApi\Testing\ValidatorBuilder;
 use Osteel\OpenApi\Testing\Exceptions\ValidationException;
@@ -66,6 +68,9 @@ abstract class TestCase extends BaseTestCase
         UsersSkills::truncate();
         Skills::truncate();
         Alert::truncate();
+        if (Schema::hasTable('api_clients')) {
+            ApiClient::truncate();
+        }
         DB::statement('delete from audits');
         DB::delete('delete from user_network');
         DB::delete('delete from users_preferences');


### PR DESCRIPTION
## Description

This adds a public, read-only API endpoint to allow third-party platforms to query Restarters repair events.

We already implemented something similar in the fork https://github.com/iFixit/restarters/pull/48 but considered it would be beneficial to query all Restarter networks. Having a standard compatible API across instances would be very helpful.

That said, the reason for the new endpoint is because we are building a centralized community events page on [iFixit](www.ifixit.com) with a calendar and map view that shows all repair events from our instance and it would be nice to include events from other Restarter networks/instances.

<details>
<summary>Screenshots</summary>

<img width="1221" height="604" alt="image" src="https://github.com/user-attachments/assets/a3b76878-4890-4fb7-9c3b-811977de0e11" />

<img width="1300" height="778" alt="image" src="https://github.com/user-attachments/assets/e1b2afff-43c9-4702-aaff-32142360ca2d" />
</details>

If you have feedback or want to make changes to the API, then please let us know. 

We'd love to move quickly here since we're hoping to launch the feature on iFixit in a few weeks.

### CR Notes

All endpoints are behind the `FEATURE__PUBLIC_EVENTS_API` feature flag (default off), so there is no impact to the existing application until explicitly enabled. The API exposes three read-only GET endpoints under `/api/public/v2` for listing events, showing a single event, and listing events for a specific group.

Authentication uses bearer tokens with per-client rate limiting and optional origin and network restrictions. Only approved events from approved, non-archived groups are returned in responses.

An admin UI is available at `/admin/api-clients` and three artisan commands (`api-clients:create`, `api-clients:rotate`, `api-clients:revoke`) are provided for managing API clients. The full test suite and endpoint documentation are in `docs/public-events-api.md`.
