### PR TITLE
Daily MySQL backup to Google Drive

### DIFF
--- a/.fly/scripts/startup.sh
+++ b/.fly/scripts/startup.sh
@@ -66,6 +66,11 @@ if ! crontab -l 2>/dev/null | grep -q 'queue-watchdog'; then
     ( crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/queue-watchdog.sh" ) | crontab -
 fi
 
+# Ensure database backup is in crontab (image crontab may predate this entry)
+if ! crontab -l 2>/dev/null | grep -q 'db-backup'; then
+    ( crontab -l 2>/dev/null; echo "0 2 * * * /usr/local/bin/db-backup.sh" ) | crontab -
+fi
+
 # Run DB setup in a subshell so failures never prevent supervisord from starting
 (
     # Wait for MySQL to be reachable

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -72,10 +72,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gettext-base \
     redis-server \
     procps \
+    default-mysql-client \
     libpng-dev libjpeg62-turbo-dev libfreetype6-dev libzip-dev libicu-dev libxml2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install pdo_mysql bcmath zip intl gd exif pcntl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install rclone for Google Drive backups
+RUN curl https://rclone.org/install.sh | bash
 
 # Install xmlrpc
 RUN pecl install channel://pecl.php.net/xmlrpc-1.0.0RC3 && docker-php-ext-enable xmlrpc
@@ -126,8 +130,12 @@ COPY docker/logrotate-fly.conf /etc/logrotate.d/restarters
 COPY docker/queue-watchdog.sh /usr/local/bin/queue-watchdog.sh
 RUN chmod +x /usr/local/bin/queue-watchdog.sh
 
-# Set up cron: Laravel scheduler + queue watchdog (kills hung jobs, supervisord restarts worker)
-RUN printf '* * * * * cd /var/www && php artisan schedule:run >> /dev/null 2>&1\n* * * * * /usr/local/bin/queue-watchdog.sh\n' | crontab -
+# Copy database backup script
+COPY docker/db-backup.sh /usr/local/bin/db-backup.sh
+RUN chmod +x /usr/local/bin/db-backup.sh
+
+# Set up cron: Laravel scheduler + queue watchdog (kills hung jobs, supervisord restarts worker) + daily DB backup
+RUN printf '* * * * * cd /var/www && php artisan schedule:run >> /dev/null 2>&1\n* * * * * /usr/local/bin/queue-watchdog.sh\n0 2 * * * /usr/local/bin/db-backup.sh\n' | crontab -
 
 # Set working directory
 WORKDIR /var/www

--- a/docker/db-backup.sh
+++ b/docker/db-backup.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Daily MySQL backup to Google Drive
+# Cron runs this daily at 2am UTC; logs to /var/log/db-backup.log
+
+LOG=/var/log/db-backup.log
+
+# Cron does not inherit container env vars — read from the init process.
+while IFS= read -r -d '' var; do
+    case "$var" in DB_*|GDRIVE_*|RCLONE_*) export "$var" ;; esac
+done < /proc/1/environ
+
+# Exit silently if GDRIVE_BACKUP_FOLDER_ID is not set (dev environments)
+if [ -z "$GDRIVE_BACKUP_FOLDER_ID" ]; then
+    exit 0
+fi
+
+# Log timestamp
+echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Starting database backup..." >> "$LOG"
+
+# Verify required env vars
+MISSING=""
+for var in DB_HOST DB_DATABASE DB_USERNAME DB_PASSWORD GDRIVE_BACKUP_FOLDER_ID; do
+    if [ -z "$(eval echo \$$var)" ]; then
+        MISSING="$MISSING $var"
+    fi
+done
+
+if [ -n "$MISSING" ]; then
+    echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): ERROR - missing environment variables:$MISSING" >> "$LOG"
+    exit 1
+fi
+
+# Create temporary backup file
+BACKUP_FILE="/tmp/db-backup-$(date +%Y%m%d-%H%M%S).sql.gz"
+BACKUP_NAME="$(basename "$BACKUP_FILE")"
+
+# Dump database to compressed file
+if ! mysqldump \
+    -h "$DB_HOST" \
+    -u "$DB_USERNAME" \
+    -p"$DB_PASSWORD" \
+    --single-transaction \
+    --quick \
+    --lock-tables=false \
+    "$DB_DATABASE" 2>>"$LOG" | gzip > "$BACKUP_FILE"; then
+    echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): ERROR - mysqldump failed" >> "$LOG"
+    rm -f "$BACKUP_FILE"
+    exit 1
+fi
+
+# Upload to Google Drive using rclone
+if ! rclone copy "$BACKUP_FILE" "gdrive:$GDRIVE_BACKUP_FOLDER_ID/" \
+    --log-file="$LOG" \
+    --log-level=INFO 2>>"$LOG"; then
+    echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): ERROR - rclone upload failed" >> "$LOG"
+    rm -f "$BACKUP_FILE"
+    exit 1
+fi
+
+echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Uploaded $BACKUP_NAME to Google Drive" >> "$LOG"
+
+# Clean up local backup file
+rm -f "$BACKUP_FILE"
+
+# Keep only the last 7 daily backups on Google Drive
+# List all backups in reverse chronological order and delete older ones
+BACKUPS=$(rclone lsf "gdrive:$GDRIVE_BACKUP_FOLDER_ID/" --format=p 2>/dev/null | grep 'db-backup-.*\.sql\.gz' | sort -r)
+BACKUP_COUNT=$(echo "$BACKUPS" | grep -c 'db-backup')
+
+if [ "$BACKUP_COUNT" -gt 7 ]; then
+    BACKUPS_TO_DELETE=$(echo "$BACKUPS" | tail -n +8)
+    while IFS= read -r backup; do
+        if [ -n "$backup" ]; then
+            echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Deleting old backup: $backup" >> "$LOG"
+            rclone delete "gdrive:$GDRIVE_BACKUP_FOLDER_ID/$backup" 2>>"$LOG" || true
+        fi
+    done <<< "$BACKUPS_TO_DELETE"
+fi
+
+echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Database backup completed successfully" >> "$LOG"


### PR DESCRIPTION
## Summary

Implements automated daily MySQL backups uploaded to Google Drive via rclone. Backups run daily at 2am UTC and only the last 7 backups are retained.

## Implementation Details

- **db-backup.sh**: New script that:
  - Reads database and backup credentials from init process environ (same pattern as queue-watchdog.sh)
  - Uses mysqldump with `--single-transaction` and `--quick` for consistent InnoDB snapshots
  - Compresses output with gzip
  - Uploads to Google Drive using rclone
  - Automatically deletes backups older than 7 days
  - Logs all operations to /var/log/db-backup.log
  - Silent/no-op if GDRIVE_BACKUP_FOLDER_ID is not set (safe for dev environments)

- **Dockerfile.fly changes**:
  - Added `default-mysql-client` (for mysqldump)
  - Added rclone via official install script
  - Copy db-backup.sh to /usr/local/bin with executable permissions
  - Added daily cron entry: `0 2 * * * /usr/local/bin/db-backup.sh` (2am UTC)

- **.fly/scripts/startup.sh changes**:
  - Added startup registration pattern (mirrors queue-watchdog approach) to ensure db-backup persists through container restarts before full deployments

## Required Fly.io Secrets

The following secrets must be set in the Fly.io application for backups to work:

```bash
flyctl secrets set RCLONE_CONFIG_GDRIVE_TYPE=drive
flyctl secrets set RCLONE_CONFIG_GDRIVE_SCOPE=drive.file
flyctl secrets set 'RCLONE_CONFIG_GDRIVE_SERVICE_ACCOUNT_CREDENTIALS={...full service account JSON...}'
flyctl secrets set GDRIVE_BACKUP_FOLDER_ID=<Google Drive folder ID>
```

### Getting Service Account Credentials

1. Create a service account in Google Cloud Console
2. Generate a JSON key for the service account
3. Share the target Google Drive folder with the service account email
4. Use the full JSON key as `RCLONE_CONFIG_GDRIVE_SERVICE_ACCOUNT_CREDENTIALS`

### Notes on Fly.io Secrets

- `RCLONE_CONFIG_GDRIVE_SERVICE_ACCOUNT_CREDENTIALS` must be the complete JSON key file (multi-line JSON is supported)
- The service account needs `drive.file` scope to access shared folders
- If `GDRIVE_BACKUP_FOLDER_ID` is not set, the backup job silently exits (no errors in production if misconfigured)

## Test Plan

- [ ] PR approval and merge to develop
- [ ] Verify Dockerfile.fly builds successfully with rclone and mysql-client
- [ ] Deploy to Fly.io with secrets configured
- [ ] Check that /var/log/db-backup.log shows successful backup at 2am UTC the following day
- [ ] Verify backup files appear in Google Drive folder
- [ ] After 8 days, verify only 7 most recent backups remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)