### PR TITLE
Add timeouts to wiki API HTTP calls to prevent login 504s

### DIFF
--- a/app/Listeners/LogInToWiki.php
+++ b/app/Listeners/LogInToWiki.php
@@ -89,7 +89,7 @@ class LogInToWiki
         try {
             Log::info("Log in to wiki $user->mediawiki");
             $cookieJar = new CookieJar();
-            $guzzleClient = (new ClientFactory(['cookies' => $cookieJar]))->getClient();
+            $guzzleClient = (new ClientFactory(['cookies' => $cookieJar, 'timeout' => 10, 'connect_timeout' => 5]))->getClient();
             $auth = new UserAndPassword($user->mediawiki, $user->password);
             $api = new ActionApi(env('WIKI_URL').'/api.php', $auth, $guzzleClient);
             $api->getToken('csrf');

--- a/app/Providers/MediawikiServiceProvider.php
+++ b/app/Providers/MediawikiServiceProvider.php
@@ -4,8 +4,9 @@ namespace App\Providers;
 
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
+use Addwiki\Mediawiki\Api\Client\Action\ActionApi;
 use Addwiki\Mediawiki\Api\Client\Auth\UserAndPassword;
-use Addwiki\Mediawiki\Api\Client\MediaWiki;
+use Addwiki\Mediawiki\Api\Guzzle\ClientFactory;
 use Addwiki\Mediawiki\Api\MediawikiFactory;
 use Addwiki\Mediawiki\Api\Service\UserCreator;
 
@@ -31,13 +32,15 @@ class MediawikiServiceProvider extends ServiceProvider
         $this->app->singleton(MediawikiFactory::class, function () {
             try {
                 Log::debug('Connect to Mediawiki');
-                $mw = MediaWiki::newFromEndpoint(
+                $guzzleClient = (new ClientFactory(['timeout' => 10, 'connect_timeout' => 5]))->getClient();
+                $api = new ActionApi(
                     env('WIKI_URL').'/api.php',
-                    new UserAndPassword(env('WIKI_APIUSER'), env('WIKI_APIPASSWORD'))
+                    new UserAndPassword(env('WIKI_APIUSER'), env('WIKI_APIPASSWORD')),
+                    $guzzleClient
                 );
                 Log::debug('...connected');
 
-                return new MediawikiFactory($mw->action());
+                return new MediawikiFactory($api);
             } catch (\Throwable $ex) {
                 Log::error('Failed to instantiate Wiki API classes: '.$ex->getMessage());
             }


### PR DESCRIPTION
## Summary

- `LogInToWiki::logUserIn()` now passes `timeout: 10s` and `connect_timeout: 5s` to the Guzzle client when logging a user into the wiki
- `MediawikiServiceProvider` now creates the `ActionApi` directly with the same timeout options, replacing `MediaWiki::newFromEndpoint()` which always created a client with no timeout
- Without these timeouts, a slow or unavailable wiki caused PHP-FPM workers to hang indefinitely, which surfaced as 504 errors from nginx

## Root cause

The wiki login listener runs synchronously during login (by design — it needs to set wiki cookies in the response). With Guzzle defaults (no timeout), a hanging wiki connection holds a PHP-FPM worker until the nginx proxy timeout fires, returning 504 to the user.

## Test plan

- [ ] Existing `WikiLoginTests` suite passes — including `login_succeeds_when_wiki_unavailable`
- [ ] Login works normally when wiki is up
- [ ] Login completes within ~10s when wiki is down/slow (previously could hang for 60–120s)