### PR TITLE
Merge master fixes into develop

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy Preview Branch to restarters.dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch or PR ref to deploy (e.g. develop, master, refs/pull/744/head)'
+        required: true
+        default: 'develop'
+
+jobs:
+  deploy:
+    name: Deploy ${{ github.event.inputs.branch }} to restarters.dev
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to restarters-dev with overnight DB restore
+        run: flyctl deploy --config fly.preview.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -20,6 +20,12 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
 
+      - name: Ensure fly.preview.toml exists
+        run: |
+          if [ ! -f fly.preview.toml ]; then
+            git show origin/master:fly.preview.toml > fly.preview.toml
+          fi
+
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/app/Http/Controllers/PreviewDeployController.php
+++ b/app/Http/Controllers/PreviewDeployController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Helpers\Fixometer;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+use Illuminate\View\View;
+
+class PreviewDeployController extends Controller
+{
+    private const REPO = 'TheRestartProject/restarters.net';
+    private const WORKFLOW = 'preview-deploy.yml';
+
+    public function show(): View|RedirectResponse
+    {
+        if (! Fixometer::hasRole(Auth::user(), 'Administrator')) {
+            return redirect('/user/forbidden');
+        }
+
+        $token = config('services.github.deploy_pat');
+        $prs = [];
+        $error = null;
+
+        if ($token) {
+            $response = Http::withToken($token)
+                ->get("https://api.github.com/repos/" . self::REPO . "/pulls", [
+                    'state' => 'open',
+                    'per_page' => 50,
+                ]);
+
+            if ($response->successful()) {
+                $prs = collect($response->json())->map(fn($pr) => [
+                    'number' => $pr['number'],
+                    'title' => $pr['title'],
+                    'branch' => $pr['head']['ref'],
+                    'author' => $pr['user']['login'],
+                ])->all();
+            } else {
+                $error = 'Could not fetch PRs from GitHub (status ' . $response->status() . ')';
+            }
+        } else {
+            $error = 'GITHUB_DEPLOY_PAT is not configured. Set it as a Fly secret on restarters-dev.';
+        }
+
+        return view('admin.preview-deploy', compact('prs', 'error'));
+    }
+
+    public function deploy(Request $request): RedirectResponse
+    {
+        if (! Fixometer::hasRole(Auth::user(), 'Administrator')) {
+            return redirect('/user/forbidden');
+        }
+
+        $branch = $request->input('branch');
+
+        if (! $branch) {
+            return back()->withErrors(['branch' => 'Please select a branch.']);
+        }
+
+        $token = config('services.github.deploy_pat');
+
+        if (! $token) {
+            return back()->withErrors(['token' => 'GITHUB_DEPLOY_PAT is not configured.']);
+        }
+
+        $response = Http::withToken($token)
+            ->post("https://api.github.com/repos/" . self::REPO . "/actions/workflows/" . self::WORKFLOW . "/dispatches", [
+                'ref' => 'develop',
+                'inputs' => ['branch' => $branch],
+            ]);
+
+        if ($response->successful()) {
+            return back()->with('success', "Deploy of \"$branch\" triggered. Build takes ~15 minutes. Watch: https://github.com/" . self::REPO . "/actions");
+        }
+
+        return back()->withErrors(['deploy' => 'GitHub API error: ' . $response->status() . ' — ' . $response->body()]);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -96,4 +96,8 @@ return [
         ],
     ],
 
+    'github' => [
+        'deploy_pat' => env('GITHUB_DEPLOY_PAT'),
+    ],
+
 ];

--- a/docker/yesterday-startup.sh
+++ b/docker/yesterday-startup.sh
@@ -61,6 +61,10 @@ done
 mysql -e "CREATE DATABASE IF NOT EXISTS \`${DB_DATABASE:-restarters}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" 2>/dev/null
 mysql -e "CREATE USER IF NOT EXISTS '${DB_USERNAME:-restarters}'@'127.0.0.1' IDENTIFIED BY '${DB_PASSWORD:-restarters}';" 2>/dev/null
 mysql -e "GRANT ALL ON \`${DB_DATABASE:-restarters}\`.* TO '${DB_USERNAME:-restarters}'@'127.0.0.1'; FLUSH PRIVILEGES;" 2>/dev/null
+# The production backup contains triggers with DEFINER='restarters'@'%'. Create that user locally
+# so trigger execution doesn't fail (bind-address=127.0.0.1 so '%' can't connect from outside).
+mysql -e "CREATE USER IF NOT EXISTS '${DB_USERNAME:-restarters}'@'%' IDENTIFIED BY '${DB_PASSWORD:-restarters}';" 2>/dev/null
+mysql -e "GRANT ALL ON \`${DB_DATABASE:-restarters}\`.* TO '${DB_USERNAME:-restarters}'@'%'; FLUSH PRIVILEGES;" 2>/dev/null
 
 log "MariaDB ready."
 

--- a/fly.preview.toml
+++ b/fly.preview.toml
@@ -1,0 +1,97 @@
+app = "restarters-dev"
+primary_region = "lhr"
+
+[build]
+  dockerfile = "Dockerfile.fly"
+  [build.args]
+    # Restore the overnight DB backup at startup (same logic as yesterday container)
+    STARTUP_SCRIPT = "yesterday-startup.sh"
+
+# Migrations run in startup.sh instead of release_command because
+# release_command machines don't have 6PN network access to the DB.
+
+[env]
+  APP_ENV = "staging"
+  APP_DEBUG = "false"
+  APP_URL = "https://restarters.dev"
+  # Use local embedded MariaDB (restored from backup at startup)
+  DB_CONNECTION = "mysql"
+  DB_HOST = "127.0.0.1"
+  DB_PORT = "3306"
+  DB_DATABASE = "restarters"
+  DB_USERNAME = "restarters"
+  DB_PASSWORD = "restarters_preview"
+  CACHE_DRIVER = "file"
+  SESSION_DRIVER = "file"
+  QUEUE_CONNECTION = "sync"
+  SESSION_DOMAIN = ""
+  LOG_CHANNEL = "stderr"
+  FILESYSTEM_DISK = "s3"
+  AWS_DEFAULT_REGION = "auto"
+  AWS_ENDPOINT = "https://fly.storage.tigris.dev"
+  AWS_USE_PATH_STYLE_ENDPOINT = "true"
+  FEATURE__WIKI_INTEGRATION = "false"
+  FEATURE__DISCOURSE_INTEGRATION = "false"
+  SENTRY_ENVIRONMENT = "preview"
+  MAIL_MAILER = "smtp"
+  MAIL_HOST = "restarters-dev-mail.internal"
+  MAIL_PORT = "1025"
+  MAIL_ENCRYPTION = ""
+  MAIL_FROM_ADDRESS = "dev@restarters.dev"
+  MAIL_FROM_NAME = "Restarters Dev (Preview)"
+  # Table type constants
+  TBL_USERS = "1"
+  TBL_GROUPS = "2"
+  TBL_EVENTS = "3"
+  TBL_DEVICES = "4"
+  TBL_IMAGES = "5"
+  TBL_LINKS = "6"
+  # Device status constants
+  DEVICE_FIXED = "1"
+  DEVICE_REPAIRABLE = "2"
+  DEVICE_DEAD = "3"
+  # Category IDs
+  MISC_CATEGORY_ID = "46"
+  MISC_CATEGORY_ID_POWERED = "46"
+  MISC_CATEGORY_ID_UNPOWERED = "50"
+  # Impact calculation constants
+  DISPLACEMENT_VALUE = "0.5"
+  EMISSION_RATIO_UNPOWERED = "17.70147059"
+  EMISSION_RATIO_POWERED = "32.06679233"
+  # Session
+  SESSION_COOKIE = "restarters_session"
+  SESSION_LIFETIME = "10080"
+  SESSION_TABLE = "laravel_sessions"
+  # Misc
+  L5_SWAGGER_GENERATE_ALWAYS = "false"
+  VITE_MANIFEST_PATH = "public/build/manifest.json"
+  BASIC_AUTH_ENABLED = "true"
+  BASIC_AUTH_PASSWORD = "project"
+  APP_SHOW_BRANCH = "true"
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[checks]
+  [checks.health]
+    port = 80
+    type = "http"
+    interval = "30s"
+    timeout = "10s"
+    # Long grace period covers full DB restore (~10 min)
+    grace_period = "900s"
+    method = "GET"
+    path = "/robots.txt"
+
+[mounts]
+  source = "app_logs_dev"
+  destination = "/var/log"
+
+[[vm]]
+  size = "performance-1x"
+  memory = 2048
+  swap_size_mb = 2048

--- a/resources/views/admin/preview-deploy.blade.php
+++ b/resources/views/admin/preview-deploy.blade.php
@@ -1,0 +1,68 @@
+@extends('layouts.app')
+
+@section('title')
+Deploy Preview Branch
+@endsection
+
+@section('content')
+<section>
+    <div class="container mt-4">
+        <h1>Deploy Preview Branch to restarters.dev</h1>
+        <p class="text-muted">Select a branch or open PR to deploy to the develop container. The container will rebuild and restore the latest overnight database backup (~15 minutes total).</p>
+
+        @if (session('success'))
+            <div class="alert alert-success">
+                {!! session('success') !!}
+            </div>
+        @endif
+
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                @foreach ($errors->all() as $e)
+                    <p class="mb-0">{{ $e }}</p>
+                @endforeach
+            </div>
+        @endif
+
+        @if ($error)
+            <div class="alert alert-warning">{{ $error }}</div>
+        @endif
+
+        <form method="POST" action="{{ route('admin.preview-deploy.deploy') }}">
+            @csrf
+
+            <div class="form-group">
+                <label for="branch"><strong>Branch to deploy</strong></label>
+                <select name="branch" id="branch" class="form-control" style="max-width: 500px;">
+                    <optgroup label="Main branches">
+                        <option value="develop">develop</option>
+                        <option value="master">master</option>
+                    </optgroup>
+                    @if (count($prs))
+                        <optgroup label="Open pull requests">
+                            @foreach ($prs as $pr)
+                                <option value="{{ $pr['branch'] }}">
+                                    #{{ $pr['number'] }} {{ $pr['title'] }} ({{ $pr['branch'] }})
+                                </option>
+                            @endforeach
+                        </optgroup>
+                    @endif
+                </select>
+            </div>
+
+            <button type="submit" class="btn btn-primary mt-2"
+                    onclick="return confirm('This will redeploy restarters.dev with the selected branch and restore the overnight database. Continue?')">
+                Deploy to restarters.dev
+            </button>
+        </form>
+
+        <hr class="mt-4">
+        <p class="text-muted small">
+            Deploys are queued as GitHub Actions runs.
+            <a href="https://github.com/{{ env('GITHUB_REPO', 'TheRestartProject/restarters.net') }}/actions/workflows/preview-deploy.yml" target="_blank">
+                View running workflows →
+            </a>
+        </p>
+    </div>
+</section>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\DeviceUrlController;
 use App\Http\Controllers\InformationAlertCookieController;
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\PreviewDeployController;
 use App\Http\Controllers\BattcatOraController;
 use App\Http\Controllers\BrandsController;
 use App\Http\Controllers\CalendarEventsController;
@@ -300,6 +301,8 @@ Route::middleware('auth', 'verifyUserConsent', 'ensureAPIToken')->group(function
     //Admin Controller
     Route::prefix('admin')->group(function () {
         Route::get('/stats', [AdminController::class, 'stats']);
+        Route::get('/preview-deploy', [PreviewDeployController::class, 'show'])->name('admin.preview-deploy.show');
+        Route::post('/preview-deploy', [PreviewDeployController::class, 'deploy'])->name('admin.preview-deploy.deploy');
     });
 
     //Category Controller


### PR DESCRIPTION
## Summary

- **Fix trigger definer error on yesterday startup** — restores DB as root via Unix socket so DEFINER privileges on triggers are respected during backup restore
- **Add PR preview deploy to restarters.dev** — web UI (`/admin/preview-deploy`) for admins to select any branch or open PR and trigger a rebuild of the `restarters-dev` container with the latest overnight DB backup

## Preview deploy setup (one-time)

On the `restarters-dev` Fly app, set these secrets:
```
fly secrets set GITHUB_DEPLOY_PAT=<token-with-workflow-scope> --app restarters-dev
fly secrets set GDRIVE_BACKUP_FOLDER_ID=... --app restarters-dev
fly secrets set RCLONE_CONFIG_GDRIVE_TEAM_DRIVE=... --app restarters-dev
# plus any other rclone/gdrive secrets from restarters-yesterday
```

Also ensure `FLY_API_TOKEN` is set in GitHub repo secrets (used by preview-deploy.yml).

## Test plan

- [ ] CI passes
- [ ] On `restarters.dev`, log in as admin → `/admin/preview-deploy` shows branch dropdown with open PRs
- [ ] Selecting a branch and submitting triggers the GitHub Actions `preview-deploy.yml` workflow