### PR TITLE
Restore legacy CSS paths /css/wiki.css and /global/css/app.css

### DIFF
--- a/tests/Integration/legacyassets.test.js
+++ b/tests/Integration/legacyassets.test.js
@@ -1,0 +1,25 @@
+const { test } = require('./fixtures')
+const { expect } = require('@playwright/test')
+
+// The MediaWiki wiki imports our CSS via absolute URLs that pre-date the
+// Mix -> Vite migration. Vite outputs hashed filenames under /build/, so
+// these public, unhashed paths only work if the Vite build also writes copies
+// to the legacy locations. Vite plugin in vite.config.js does that copy.
+
+test('GET /css/wiki.css returns CSS (legacy path used by wiki)', async ({page, baseURL}) => {
+  const response = await page.request.get(baseURL + '/css/wiki.css')
+  expect(response.status()).toBe(200)
+  const contentType = response.headers()['content-type'] || ''
+  expect(contentType.toLowerCase()).toMatch(/css/)
+  const body = await response.text()
+  expect(body.length).toBeGreaterThan(100)
+})
+
+test('GET /global/css/app.css returns CSS (legacy path used by wiki)', async ({page, baseURL}) => {
+  const response = await page.request.get(baseURL + '/global/css/app.css')
+  expect(response.status()).toBe(200)
+  const contentType = response.headers()['content-type'] || ''
+  expect(contentType.toLowerCase()).toMatch(/css/)
+  const body = await response.text()
+  expect(body.length).toBeGreaterThan(100)
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,37 @@ import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue2';
 import laravelTranslations from 'vite-plugin-laravel-translations';
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
+import { existsSync, readFileSync, mkdirSync, copyFileSync } from 'fs';
+
+// The MediaWiki wiki references our CSS at unhashed legacy public URLs
+// (/css/wiki.css, /global/css/app.css). These paths pre-date the Mix -> Vite
+// migration; Vite outputs hashed files under /build/, so we copy the relevant
+// built CSS back to the legacy locations to preserve those public URLs.
+function legacyCssAliases() {
+    return {
+        name: 'legacy-css-aliases',
+        apply: 'build',
+        writeBundle() {
+            const manifestPath = resolve(__dirname, 'public/build/manifest.json');
+            if (!existsSync(manifestPath)) return;
+            const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+            const aliases = {
+                'resources/wiki/css/app.scss': 'public/css/wiki.css',
+                'resources/global/css/app.scss': 'public/global/css/app.css',
+            };
+            for (const [entry, dest] of Object.entries(aliases)) {
+                const built = manifest[entry] && manifest[entry].file;
+                if (!built) continue;
+                const src = resolve(__dirname, 'public/build', built);
+                const out = resolve(__dirname, dest);
+                if (!existsSync(src)) continue;
+                mkdirSync(dirname(out), { recursive: true });
+                copyFileSync(src, out);
+            }
+        },
+    };
+}
 
 export default defineConfig({
     define: {
@@ -24,6 +54,7 @@ export default defineConfig({
         }),
         vue(),
         laravelTranslations(),
+        legacyCssAliases(),
         {
             name: 'jquery-global',
             transform(code, id) {


### PR DESCRIPTION
## Summary

The MediaWiki wiki imports our CSS via absolute URLs that pre-date the Mix -> Vite migration: `https://restarters.net/css/wiki.css` and `https://restarters.net/global/css/app.css`. After the migration these 404 in production because Vite outputs to `/public/build/assets/` with hashed filenames.

This adds a Vite plugin (`writeBundle` hook) that reads the manifest and copies the compiled SCSS outputs back to the legacy public paths, preserving the external contract used by the wiki.

## Test plan
- [ ] CI: new Playwright integration tests in `tests/Integration/legacyassets.test.js` fetch both URLs and assert 200 + CSS content
- [ ] Verified plugin logic locally against current `public/build/manifest.json`:
  - `resources/wiki/css/app.scss` -> 167KB copy at `public/css/wiki.css`
  - `resources/global/css/app.scss` -> 232KB copy at `public/global/css/app.css`
- [ ] After deploy, hit https://restarters.net/css/wiki.css and https://restarters.net/global/css/app.css and confirm 200