### PR TITLE
Show human-readable API errors instead of 'Request failed with status N'

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -11,7 +11,8 @@
         "^.+\\.(js|jsx)$": "babel-jest"
     },
     "roots": [
-        "<rootDir>/resources/js/components"
+        "<rootDir>/resources/js/components",
+        "<rootDir>/resources/js/misc"
     ],
     "modulePaths": [
         "<rootDir>"

--- a/resources/js/components/EventAttendee.vue
+++ b/resources/js/components/EventAttendee.vue
@@ -49,6 +49,7 @@
 import { DEFAULT_PROFILE, HOST } from '../constants'
 import ConfirmModal from './ConfirmModal.vue'
 import images from '../mixins/images'
+import { apiErrorMessage } from '../misc/apiError'
 
 export default {
   components: {ConfirmModal},
@@ -136,7 +137,7 @@ export default {
           id: this.attendee.idevents_users
         })
       } catch (e) {
-        this.error = e.message
+        this.error = apiErrorMessage(e)
       }
     },
     confirm() {

--- a/resources/js/components/GroupVolunteer.vue
+++ b/resources/js/components/GroupVolunteer.vue
@@ -58,6 +58,7 @@ import { DEFAULT_PROFILE, HOST, RESTARTER } from '../constants'
 import images from '../mixins/images'
 import ConfirmModal from './ConfirmModal.vue'
 import volunteers from '../store/volunteers'
+import { apiErrorMessage } from '../misc/apiError'
 
 export default {
   components: {ConfirmModal},
@@ -130,7 +131,7 @@ export default {
           eventId: this.volunteer.event,
         })
       } catch (e) {
-        this.error = e.message
+        this.error = apiErrorMessage(e)
       }
     },
     removeVolunteer() {
@@ -140,21 +141,21 @@ export default {
       try {
         await this.$store.dispatch('volunteers/remove', this.volunteer.id)
       } catch (e) {
-        this.error = e.message
+        this.error = apiErrorMessage(e)
       }
     },
     async makeVolunteerHost() {
       try {
         await this.$store.dispatch('volunteers/makehost', this.volunteer.id)
       } catch (e) {
-        this.error = e.message
+        this.error = apiErrorMessage(e)
       }
     },
     async removeHostRole() {
       try {
         await this.$store.dispatch('volunteers/removehost', this.volunteer.id)
       } catch (e) {
-        this.error = e.message
+        this.error = apiErrorMessage(e)
       }
     },
     confirm() {

--- a/resources/js/misc/apiError.js
+++ b/resources/js/misc/apiError.js
@@ -1,0 +1,45 @@
+// Extract a human-readable error message from an Axios (or fetch-style) error.
+//
+// Axios sets `error.message` to "Request failed with status code 500" by default,
+// which isn't useful to a user. The actual reason is usually in the response body:
+//   - Laravel validation responses: { message, errors: { field: [msg, ...] } }
+//   - Laravel/our API errors: { message: "..." } or { error: "..." }
+//   - Plain string bodies on some endpoints
+// We prefer the most specific message available and fall back to the generic
+// error.message so we still say something even when the server gives us nothing.
+
+export function apiErrorMessage(error) {
+  if (!error) return 'Request failed'
+
+  const data = error.response && error.response.data
+
+  if (data && typeof data === 'object') {
+    if (data.errors && typeof data.errors === 'object') {
+      for (const field of Object.keys(data.errors)) {
+        const messages = data.errors[field]
+        if (Array.isArray(messages) && messages.length && typeof messages[0] === 'string') {
+          return messages[0]
+        }
+        if (typeof messages === 'string' && messages) {
+          return messages
+        }
+      }
+    }
+    if (typeof data.message === 'string' && data.message.trim()) {
+      return data.message
+    }
+    if (typeof data.error === 'string' && data.error.trim()) {
+      return data.error
+    }
+  }
+
+  if (typeof data === 'string' && data.trim()) {
+    return data
+  }
+
+  if (typeof error.message === 'string' && error.message.trim()) {
+    return error.message
+  }
+
+  return 'Request failed'
+}

--- a/resources/js/misc/apiError.test.js
+++ b/resources/js/misc/apiError.test.js
@@ -1,0 +1,100 @@
+import { apiErrorMessage } from './apiError'
+
+describe('apiErrorMessage', () => {
+  test('returns Laravel validation field message when present', () => {
+    const error = {
+      message: 'Request failed with status code 422',
+      response: {
+        status: 422,
+        data: {
+          message: 'The given data was invalid.',
+          errors: {
+            website: ['The website must be a valid URL.'],
+          },
+        },
+      },
+    }
+    expect(apiErrorMessage(error)).toBe('The website must be a valid URL.')
+  })
+
+  test('returns first field message when multiple validation errors', () => {
+    const error = {
+      response: {
+        data: {
+          errors: {
+            name: ['Name is required.'],
+            email: ['Email is not valid.'],
+          },
+        },
+      },
+    }
+    const msg = apiErrorMessage(error)
+    expect(msg === 'Name is required.' || msg === 'Email is not valid.').toBe(true)
+  })
+
+  test('returns response.data.message for non-validation API errors', () => {
+    const error = {
+      message: 'Request failed with status code 500',
+      response: {
+        status: 500,
+        data: { message: 'Could not contact the geocoder.' },
+      },
+    }
+    expect(apiErrorMessage(error)).toBe('Could not contact the geocoder.')
+  })
+
+  test('returns response.data.error when message field absent', () => {
+    const error = {
+      message: 'Request failed with status code 400',
+      response: { data: { error: 'Group name already taken.' } },
+    }
+    expect(apiErrorMessage(error)).toBe('Group name already taken.')
+  })
+
+  test('returns plain string response body when present', () => {
+    const error = {
+      message: 'Request failed with status code 500',
+      response: { data: 'Internal Server Error' },
+    }
+    expect(apiErrorMessage(error)).toBe('Internal Server Error')
+  })
+
+  test('falls back to error.message when no response body', () => {
+    const error = { message: 'Network Error' }
+    expect(apiErrorMessage(error)).toBe('Network Error')
+  })
+
+  test('returns generic fallback for null/undefined error', () => {
+    expect(apiErrorMessage(null)).toBe('Request failed')
+    expect(apiErrorMessage(undefined)).toBe('Request failed')
+  })
+
+  test('prefers field error over top-level message', () => {
+    const error = {
+      response: {
+        data: {
+          message: 'The given data was invalid.',
+          errors: { website: ['The website field must be a URL.'] },
+        },
+      },
+    }
+    expect(apiErrorMessage(error)).toBe('The website field must be a URL.')
+  })
+
+  test('ignores empty/whitespace fields and tries the next one', () => {
+    const error = {
+      message: 'Request failed',
+      response: { data: { message: '   ', error: 'real error' } },
+    }
+    expect(apiErrorMessage(error)).toBe('real error')
+  })
+
+  test('handles validation errors object where value is a single string', () => {
+    const error = {
+      response: {
+        data: { errors: { name: 'Name already taken' } },
+      },
+    }
+    expect(apiErrorMessage(error)).toBe('Name already taken')
+  })
+})


### PR DESCRIPTION
## Summary

UI currently shows `Axios Error: Request failed with status code 500` (axios' default `error.message`) in a `b-alert` to the user, which doesn't say anything about what actually went wrong.

Adds `resources/js/misc/apiError.js` with `apiErrorMessage(error)` — a small helper that pulls the most useful text out of an Axios error, preferring (in order):

1. Laravel validation field message (`response.data.errors.<field>[0]`)
2. `response.data.message`
3. `response.data.error`
4. plain-string response body
5. `error.message` (the old fallback)
6. `"Request failed"` as last resort

Applies it in the catch blocks that currently display the raw axios message in a user-visible alert.

## Test plan
- [x] Jest unit tests in `resources/js/misc/apiError.test.js` cover all six branches plus null/undefined/empty input (10 tests, all green locally)
- [ ] CI runs Jest with the new tests
- [ ] Manual: hit a 422 / 500 endpoint from GroupVolunteer or EventAttendee and confirm the displayed message reflects the server's response body