### PR TITLE
Validate group website URL and show inline error

### DIFF
--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -1102,11 +1102,13 @@ class GroupController extends Controller
                                    'name' => ['required', 'unique:groups', 'max:255'],
                                    'location' => ['required', 'max:255'],
                                    'description' => ['required'],
+                                   'website' => ['nullable', 'url', 'max:255'],
                                ]);
         } else {
             $request->validate([
                                    'name' => ['max:255'],
                                    'location' => ['max:255'],
+                                   'website' => ['nullable', 'url', 'max:255'],
                                    'archived_at' => ['nullable', 'date'],
                                ]);
         }

--- a/lang/en/groups.php
+++ b/lang/en/groups.php
@@ -20,6 +20,7 @@ return [
   'groups_about_group' => 'Tell us about your group',
   'groups_website' => 'Your website',
   'groups_website_small' => 'Don\'t have a website? Feel free to add a Facebook group or similar',
+  'groups_website_invalid' => 'Please enter a full website address starting with http:// or https://',
   'groups_email' => 'Email address',
   'groups_email_small' => 'A public contact email address for your group (optional)',
   'groups_group_small' => 'e.g. \'Restarters Torino\' or \'Nottingham Fixers\'',

--- a/lang/fr-BE/groups.php
+++ b/lang/fr-BE/groups.php
@@ -16,6 +16,7 @@ return [
   'groups_about_group' => 'Parlez-nous de votre Repair Café',
   'groups_website' => 'Votre site web',
   'groups_website_small' => 'Vous n\'avez pas de site web? Vous pouvez aussi ajouter une page Facebook ou autre',
+  'groups_website_invalid' => 'Veuillez saisir une adresse de site web complète commençant par http:// ou https://',
   'groups_email' => 'Adresse électronique',
   'groups_email_small' => 'Une adresse électronique de contact public pour votre Repair Café (facultatif)',
   'groups_group_small' => 'Par exemple \'Restarters Torino\' ou \'Réparateurs de Paris\'',

--- a/lang/fr/groups.php
+++ b/lang/fr/groups.php
@@ -16,6 +16,7 @@ return [
   'groups_about_group' => 'Parlez-nous de votre Repair Café',
   'groups_website' => 'Votre site web',
   'groups_website_small' => 'Vous n\'avez pas de site web? Vous pouvez aussi ajouter une page Facebook ou autre',
+  'groups_website_invalid' => 'Veuillez saisir une adresse de site web complète commençant par http:// ou https://',
   'groups_email' => 'Adresse électronique',
   'groups_email_small' => 'Une adresse électronique de contact public pour votre Repair Café (facultatif)',
   'groups_group_small' => 'Par exemple \'Restarters Torino\' ou \'Réparateurs de Paris\'',

--- a/resources/js/components/GroupWebsite.test.js
+++ b/resources/js/components/GroupWebsite.test.js
@@ -1,0 +1,30 @@
+import Vue from "vue";
+import { BootstrapVue } from 'bootstrap-vue'
+Vue.use(BootstrapVue)
+
+import { mount } from '@vue/test-utils'
+import LangMixin from 'resources/js/mixins/lang.js'
+import GroupWebsite from './GroupWebsite.vue'
+
+test('renders the help text and no error when hasError is false', () => {
+  const wrapper = mount(GroupWebsite, {
+    mixins: [LangMixin],
+    propsData: { website: null, hasError: false },
+  })
+
+  expect(wrapper.find('.group-website-error').exists()).toBe(false)
+  // hasError class should not be present on the input
+  expect(wrapper.find('input').classes()).not.toContain('hasError')
+})
+
+test('renders an inline error message and hasError styling when hasError is true', () => {
+  const wrapper = mount(GroupWebsite, {
+    mixins: [LangMixin],
+    propsData: { website: 'EDP', hasError: true },
+  })
+
+  const error = wrapper.find('.group-website-error')
+  expect(error.exists()).toBe(true)
+  expect(error.text().length).toBeGreaterThan(0)
+  expect(wrapper.find('input').classes()).toContain('hasError')
+})

--- a/resources/js/components/GroupWebsite.vue
+++ b/resources/js/components/GroupWebsite.vue
@@ -2,7 +2,10 @@
   <b-form-group>
     <label for="group_website">{{ __('groups.groups_website') }}:</label>
     <b-input type="url" id="group_website" name="website" v-model="currentwebsite" :class="{ hasError: hasError }"/>
-    <small>{{ __('groups.groups_website_small') }}</small>
+    <small v-if="hasError" class="form-text text-danger group-website-error">
+      {{ __('groups.groups_website_invalid') }}
+    </small>
+    <small v-else>{{ __('groups.groups_website_small') }}</small>
   </b-form-group>
 </template>
 <script>

--- a/tests/Feature/Groups/GroupCreateTest.php
+++ b/tests/Feature/Groups/GroupCreateTest.php
@@ -75,6 +75,26 @@ class GroupCreateTest extends TestCase
         $this->assertNull($this->createGroup('Test Group', 'https://therestartproject.org', 'zzzzzzzzzzz123', 'Some text', false));
     }
 
+    public function testCreateRejectsInvalidWebsite(): void
+    {
+        // A bare token like 'EDP' is not a valid URL. Without server-side validation
+        // we previously accepted it and then choked further down the pipeline, which
+        // surfaced as a 500 / "Request failed" hang in the UI. Validate up front.
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $this->expectException(ValidationException::class);
+        $this->assertNull($this->createGroup('Test Group', 'EDP', 'London', 'Some text.', false));
+    }
+
+    public function testCreateAcceptsBlankWebsite(): void
+    {
+        // Website is optional. Empty / null values must still be accepted.
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+
+        $idgroups = $this->createGroup('Test Group', '', 'London', 'Some text.');
+        $this->assertNotNull($idgroups);
+    }
+
     public function roles(): array {
         return [
             [ 'Administrator'],


### PR DESCRIPTION
## Summary

Reported: when creating a group, typing a bare token like \`EDP\` into the website field "just hangs" — the form gives no feedback and the user is stuck.

Root cause: \`GroupWebsite.vue\` only signalled the existing vuelidate URL failure as a red CSS class with no message, so a user wasn't told *why* save was blocked. There was also no server-side validation, so any bad value that did slip through would surface much further down the pipeline as an opaque 500.

Two changes:
- `GroupWebsite.vue` now renders an inline error message when the parent's vuelidate URL check fails, so the user understands what they need to fix.
- `API/GroupController::validateGroupParams` now requires a valid URL on the website field (`nullable|url|max:255`) on both create and edit, so bad input is rejected with a 422 + a real validation message instead of leaking through.

Field stays optional — blank/null is accepted.

## Test plan
- [x] Jest: `resources/js/components/GroupWebsite.test.js` (2 tests) — passes locally
- [ ] CI: `tests/Feature/Groups/GroupCreateTest.php::testCreateRejectsInvalidWebsite` asserts the API now rejects `EDP`
- [ ] CI: `testCreateAcceptsBlankWebsite` asserts that blank values still work
- [ ] Manual: hit /group/create, enter `EDP` for website, see the new inline error message