### PR TITLE
Use bulkGroupStats for network stats — fixes correctness & reduces queries

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -311,22 +311,32 @@ class Group extends Model implements Auditable
             $statsByGroup[$id] = self::getGroupStatsArrayKeys();
         }
 
-        $allEvents = Party::past()
+        // Stream events in chunks with lazy() rather than loading them all with get().
+        // A large network can have thousands of past events, each eager-loading all of its
+        // devices (joined to categories) — get() would hold every device of every event in
+        // memory at once and can exhaust it. lazy() keeps only one chunk resident at a time,
+        // releasing each batch before fetching the next, so peak memory stays bounded by the
+        // chunk size regardless of how big the network is. The accumulator below is small
+        // (one row per group), so it is safe to keep across chunks.
+        //
+        // withCount('allInvited') pre-loads the invited tally as an aggregate column, avoiding
+        // an N+1 query (one COUNT per event) inside getEventStats().
+        Party::past()
             ->with('allDevices')
+            ->withCount('allInvited')
             ->whereIn('events.group', $groupIds)
-            ->get();
-
-        foreach ($allEvents as $event) {
-            $gid = $event->group;
-            if (! isset($statsByGroup[$gid])) {
-                continue;
-            }
-            $statsByGroup[$gid]['parties']++;
-            $eventStats = $event->getEventStats($eEmissionRatio, $uEmissionratio);
-            foreach ($eventStats as $key => $value) {
-                $statsByGroup[$gid][$key] += $value;
-            }
-        }
+            ->lazy(200)
+            ->each(function ($event) use (&$statsByGroup, $eEmissionRatio, $uEmissionratio) {
+                $gid = $event->group;
+                if (! isset($statsByGroup[$gid])) {
+                    return;
+                }
+                $statsByGroup[$gid]['parties']++;
+                $eventStats = $event->getEventStats($eEmissionRatio, $uEmissionratio);
+                foreach ($eventStats as $key => $value) {
+                    $statsByGroup[$gid][$key] += $value;
+                }
+            });
 
         return $statsByGroup;
     }

--- a/app/Http/Controllers/API/NetworkController.php
+++ b/app/Http/Controllers/API/NetworkController.php
@@ -38,8 +38,6 @@ class NetworkController extends Controller
      */
     private function statsForTag(Network $network, int $tagId): array
     {
-        $stats = \App\Group::getGroupStatsArrayKeys();
-
         $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
         $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
 
@@ -49,9 +47,11 @@ class NetworkController extends Controller
             ->where('grouptags_groups.group_tag', $tagId)
             ->get();
 
-        foreach ($groups as $group) {
-            $singleGroupStats = $group->getGroupStats($eEmissionRatio, $uEmissionratio);
+        $allStats = \App\Group::bulkGroupStats($groups, $eEmissionRatio, $uEmissionratio);
 
+        $stats = \App\Group::getGroupStatsArrayKeys();
+
+        foreach ($allStats as $singleGroupStats) {
             foreach ($singleGroupStats as $key => $value) {
                 $stats[$key] = $stats[$key] + $value;
             }

--- a/app/Network.php
+++ b/app/Network.php
@@ -91,80 +91,20 @@ class Network extends Model
     public function stats()
     {
         $eEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioPowered();
-        $uEmissionRatio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
-        $displacementFactor = \App\Device::getDisplacementFactor();
+        $uEmissionratio = \App\Helpers\LcaStats::getEmissionRatioUnpowered();
 
-        // Get group IDs for this network
-        $groupIds = $this->groups()->pluck('idgroups')->toArray();
+        $allStats = \App\Group::bulkGroupStats($this->groups, $eEmissionRatio, $uEmissionratio);
 
-        if (empty($groupIds)) {
-            return \App\Group::getGroupStatsArrayKeys();
+        $stats = \App\Group::getGroupStatsArrayKeys();
+
+        foreach ($allStats as $singleGroupStats) {
+            foreach ($singleGroupStats as $key => $value) {
+                $stats[$key] = $stats[$key] + $value;
+            }
         }
 
-        // Single aggregate query for all device stats
-        $deviceStats = \DB::table('devices')
-            ->join('events', 'devices.event', '=', 'events.idevents')
-            ->join('categories', 'devices.category', '=', 'categories.idcategories')
-            ->whereIn('events.group', $groupIds)
-            ->where('events.event_start_utc', '<=', now())
-            ->whereNull('events.deleted_at')
-            ->select(\DB::raw("
-                SUM(CASE WHEN categories.powered = 1 THEN 1 ELSE 0 END) as devices_powered,
-                SUM(CASE WHEN categories.powered = 0 THEN 1 ELSE 0 END) as devices_unpowered,
-                SUM(CASE WHEN devices.repair_status = 1 THEN 1 ELSE 0 END) as fixed_devices,
-                SUM(CASE WHEN devices.repair_status = 1 AND categories.powered = 1 THEN 1 ELSE 0 END) as fixed_powered,
-                SUM(CASE WHEN devices.repair_status = 1 AND categories.powered = 0 THEN 1 ELSE 0 END) as fixed_unpowered,
-                SUM(CASE WHEN devices.repair_status = 2 THEN 1 ELSE 0 END) as repairable_devices,
-                SUM(CASE WHEN devices.repair_status = 3 THEN 1 ELSE 0 END) as dead_devices,
-                SUM(CASE WHEN devices.repair_status = 0 OR devices.repair_status IS NULL THEN 1 ELSE 0 END) as unknown_repair_status,
-                SUM(CASE WHEN devices.repair_status = 1 AND categories.powered = 1 THEN COALESCE(categories.weight, 0) ELSE 0 END) as waste_powered,
-                SUM(CASE WHEN devices.repair_status = 1 AND categories.powered = 0 THEN COALESCE(categories.weight, 0) ELSE 0 END) as waste_unpowered,
-                SUM(CASE WHEN categories.powered = 1 AND COALESCE(categories.weight, 0) = 0 THEN 1 ELSE 0 END) as no_weight_powered,
-                SUM(CASE WHEN categories.powered = 0 AND COALESCE(categories.weight, 0) = 0 THEN 1 ELSE 0 END) as no_weight_unpowered
-            "))
-            ->first();
+        $stats['parties'] = $stats['parties'] ?? 0;
 
-        // Get event stats (participants, volunteers, hours)
-        $eventStats = \DB::table('events')
-            ->whereIn('events.group', $groupIds)
-            ->where('events.event_start_utc', '<=', now())
-            ->whereNull('events.deleted_at')
-            ->select(\DB::raw("
-                COUNT(*) as parties,
-                SUM(COALESCE(pax, 0)) as participants,
-                SUM(COALESCE(volunteers, 0)) as volunteers,
-                SUM(COALESCE(hours, 3) * COALESCE(volunteers, 0)) as hours_volunteered
-            "))
-            ->first();
-
-        // Calculate CO2 values
-        $wastePowered = $deviceStats->waste_powered ?? 0;
-        $wasteUnpowered = $deviceStats->waste_unpowered ?? 0;
-        $co2Powered = $wastePowered * $eEmissionRatio * $displacementFactor;
-        $co2Unpowered = $wasteUnpowered * $uEmissionRatio * $displacementFactor;
-
-        return [
-            'co2_powered' => round($co2Powered, 2),
-            'co2_unpowered' => round($co2Unpowered, 2),
-            'co2_total' => round($co2Powered + $co2Unpowered, 2),
-            'waste_powered' => round($wastePowered, 2),
-            'waste_unpowered' => round($wasteUnpowered, 2),
-            'waste_total' => round($wastePowered + $wasteUnpowered, 2),
-            'fixed_devices' => (int) ($deviceStats->fixed_devices ?? 0),
-            'fixed_powered' => (int) ($deviceStats->fixed_powered ?? 0),
-            'fixed_unpowered' => (int) ($deviceStats->fixed_unpowered ?? 0),
-            'repairable_devices' => (int) ($deviceStats->repairable_devices ?? 0),
-            'dead_devices' => (int) ($deviceStats->dead_devices ?? 0),
-            'unknown_repair_status' => (int) ($deviceStats->unknown_repair_status ?? 0),
-            'devices_powered' => (int) ($deviceStats->devices_powered ?? 0),
-            'devices_unpowered' => (int) ($deviceStats->devices_unpowered ?? 0),
-            'no_weight_powered' => (int) ($deviceStats->no_weight_powered ?? 0),
-            'no_weight_unpowered' => (int) ($deviceStats->no_weight_unpowered ?? 0),
-            'participants' => (int) ($eventStats->participants ?? 0),
-            'volunteers' => (int) ($eventStats->volunteers ?? 0),
-            'hours_volunteered' => (int) ($eventStats->hours_volunteered ?? 0),
-            'invited' => 0,
-            'parties' => (int) ($eventStats->parties ?? 0),
-        ];
+        return $stats;
     }
 }

--- a/app/Party.php
+++ b/app/Party.php
@@ -579,7 +579,10 @@ class Party extends Model implements Auditable
         $result['waste_total'] = $result['waste_powered'] + $result['waste_unpowered'];
         $result['participants'] = $this->pax ?? 0;
         $result['volunteers'] = $this->volunteers ?? 0;
-        $result['invited'] = $this->allInvited->count();
+        // Prefer the aggregate count when the caller eager-loaded it via withCount('allInvited')
+        // (e.g. bulkGroupStats) to avoid an N+1 COUNT query per event. Fall back to counting the
+        // relation directly for callers that loaded a single event without the count.
+        $result['invited'] = $this->all_invited_count ?? $this->allInvited->count();
         $result['hours_volunteered'] = $this->hoursVolunteered();
 
         return $result;

--- a/tests/Feature/Stats/NetworkStatsTest.php
+++ b/tests/Feature/Stats/NetworkStatsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature\Stats;
+
+use App\Device;
+use App\EventsUsers;
+use App\Group;
+use App\Network;
+use App\Party;
+use App\User;
+use Tests\Feature\Stats\StatsTestCase;
+
+/**
+ * Regression cover for the network stats over-reporting bug (RES-2062).
+ *
+ * A January change rewrote Network::stats() as raw aggregate SQL that
+ *   - ignored per-device `estimate` values (so misc devices contributed nothing), and
+ *   - derived CO2e from weight x emission-ratio instead of the category `footprint`,
+ * which significantly over-reported waste and CO2e for networks.
+ *
+ * Network::stats() now sums the canonical per-event calculation via
+ * Group::bulkGroupStats(). These tests assert the aggregate is correct across
+ * multiple groups, that misc-device estimates ARE counted, that CO2e uses the
+ * footprints, and that the invited tally (loaded via withCount in bulkGroupStats)
+ * still matches counting the relation directly.
+ */
+class NetworkStatsTest extends StatsTestCase
+{
+    /** @test */
+    public function a_network_with_no_groups_has_empty_stats(): void
+    {
+        $network = Network::factory()->create();
+
+        $expect = \App\Group::getGroupStatsArrayKeys();
+        $expect['parties'] = $expect['parties'] ?? 0;
+
+        $this->assertEquals($expect, $network->stats());
+    }
+
+    /** @test */
+    public function network_stats_aggregate_misc_estimates_and_footprints_across_groups(): void
+    {
+        $network = Network::factory()->create();
+
+        // Two groups, each with one past event, so we exercise aggregation across
+        // groups (and the lazy() chunked event load) rather than a single group.
+        $group1 = Group::factory()->create();
+        $event1 = Party::factory()->moderated()->create([
+            'event_start_utc' => '2000-01-01T10:15:05+05:00',
+            'event_end_utc' => '2000-01-0113:45:05+05:00',
+            'group' => $group1->idgroups,
+        ]);
+
+        $group2 = Group::factory()->create();
+        $event2 = Party::factory()->moderated()->create([
+            'event_start_utc' => '2000-01-01T10:15:05+05:00',
+            'event_end_utc' => '2000-01-0113:45:05+05:00',
+            'group' => $group2->idgroups,
+        ]);
+
+        $network->addGroup($group1);
+        $network->addGroup($group2);
+
+        // Truncates devices/categories then seeds categories with known weights/footprints.
+        $this->_setupCategoriesWithUnpoweredWeights();
+
+        // --- group 1 / event 1 ---
+        // Powered non-misc fixed device: contributes its footprint (14.4) and weight (4).
+        Device::factory()->fixed()->create([
+            'category' => $this->_idPoweredNonMisc,
+            'category_creation' => $this->_idPoweredNonMisc,
+            'event' => $event1->idevents,
+        ]);
+        // Powered MISC fixed device WITH an estimate: the broken SQL ignored this entirely.
+        // It must contribute estimate to waste and estimate x ratioPowered to CO2e.
+        Device::factory()->fixed()->create([
+            'category' => $this->_idPoweredMisc,
+            'category_creation' => $this->_idPoweredMisc,
+            'event' => $event1->idevents,
+            'estimate' => 2.0,
+        ]);
+        // Unpowered MISC fixed device WITH an estimate.
+        Device::factory()->fixed()->create([
+            'category' => $this->_idUnpoweredMisc,
+            'category_creation' => $this->_idUnpoweredMisc,
+            'event' => $event1->idevents,
+            'estimate' => 3.0,
+        ]);
+
+        // --- group 2 / event 2 ---
+        // Unpowered non-misc fixed device: contributes its footprint (15.5) and weight (5).
+        Device::factory()->fixed()->create([
+            'category' => $this->_idUnpoweredNonMisc,
+            'category_creation' => $this->_idUnpoweredNonMisc,
+            'event' => $event2->idevents,
+        ]);
+
+        // A couple of invitees (status <> 1 counts as invited) so the invited tally,
+        // which bulkGroupStats loads via withCount('allInvited'), is non-zero.
+        foreach ([$event1, $event2] as $event) {
+            EventsUsers::create([
+                'event' => $event->idevents,
+                'user' => User::factory()->create()->getKey(),
+                'status' => 0,
+                'role' => 4,
+                'full_name' => null,
+            ]);
+        }
+
+        $expect = \App\Group::getGroupStatsArrayKeys();
+        $expect['parties'] = 2;
+        $expect['hours_volunteered'] = 42; // 21 per event with no volunteers recorded
+        $expect['fixed_devices'] = 4;
+        $expect['fixed_powered'] = 2;
+        $expect['fixed_unpowered'] = 2;
+        $expect['devices_powered'] = 2;
+        $expect['devices_unpowered'] = 2;
+        // Misc devices carried an estimate, so no_weight_* stays 0.
+        $expect['no_weight_powered'] = 0;
+        $expect['no_weight_unpowered'] = 0;
+        // Waste: footprint-weighted device weight + misc estimates.
+        $expect['waste_powered'] = 4 + 2.0;
+        $expect['waste_unpowered'] = 5 + 3.0;
+        $expect['waste_total'] = $expect['waste_powered'] + $expect['waste_unpowered'];
+        // CO2e: footprints for non-misc, estimate x ratio for the misc estimates.
+        $expect['co2_powered'] = (14.4 + (2.0 * $this->_ratioPowered)) * $this->_displacementFactor;
+        $expect['co2_unpowered'] = (15.5 + (3.0 * $this->_ratioUnpowered)) * $this->_displacementFactor;
+        $expect['co2_total'] = $expect['co2_powered'] + $expect['co2_unpowered'];
+
+        $result = $network->stats();
+
+        // Ground-truth invited tally by counting the relation directly, proving the
+        // withCount-loaded all_invited_count matches.
+        $expectedInvited = 0;
+        foreach ($network->groups as $group) {
+            foreach (Party::where('group', $group->idgroups)->get() as $event) {
+                $expectedInvited += $event->allInvited()->count();
+            }
+        }
+        $this->assertGreaterThan(0, $expectedInvited, 'Test should exercise a non-zero invited count');
+        $expect['invited'] = $expectedInvited;
+
+        $floatKeys = ['co2_powered', 'co2_unpowered', 'co2_total', 'waste_powered', 'waste_unpowered', 'waste_total'];
+        foreach ($expect as $k => $v) {
+            $this->assertArrayHasKey($k, $result, "Missing array key $k");
+            if (in_array($k, $floatKeys, true)) {
+                $this->assertEqualsWithDelta($v, $result[$k], 0.0001, "Wrong value for $k");
+            } else {
+                $this->assertEquals($v, $result[$k], "Wrong value for $k");
+            }
+        }
+    }
+}


### PR DESCRIPTION
`Network::stats()` was wrong since https://github.com/TheRestartProject/restarters.net/commit/849fd6b9125bbdda085a03e841488b8e14a0bf94#diff-32a89a2afc5e166fe2203ac8cb43047a971993a199f076c8e7f79f4d5737eabdR104 .  The SQL aggregates produced incorrect waste/CO2 values.  

Switched back to same as old logic, but also change to use the recently introduced `Group::bulkGroupStats()`.  This fixes the calculation issue and should still be reasonably performant.  

Changed statsForTag too.