### PR TITLE
Migrate user/all admin page to Vue + /api/v2/users (Group 2.1)

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -35,6 +35,17 @@ class Handler extends ExceptionHandler
                     422);
             }
 
+            // AuthenticationException / AuthorizationException don't implement
+            // getStatusCode(), so without these the generic branch below rendered
+            // them as 500 instead of the correct 401/403 for JSON API requests.
+            if ($exception instanceof \Illuminate\Auth\AuthenticationException) {
+                return response()->json(['message' => $exception->getMessage()], 401);
+            }
+
+            if ($exception instanceof \Illuminate\Auth\Access\AuthorizationException) {
+                return response()->json(['message' => $exception->getMessage()], 403);
+            }
+
             return response()->json(
                 ['message' => $exception->getMessage()],
                 method_exists($exception, 'getStatusCode') ? $exception->getStatusCode() : 500);

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -2,12 +2,16 @@
 
 namespace App\Http\Controllers\API;
 
-use Illuminate\Http\JsonResponse;
+use App\Helpers\Fixometer;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\UserAdmin;
+use App\Role;
 use App\User;
 use Auth;
-use Illuminate\Http\Request;
 use Cache;
+use DB;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class UserController extends Controller
 {
@@ -131,5 +135,96 @@ class UserController extends Controller
                                     'restarters' => $restartersNotifications,
                                     'discourse' => $discourseNotifications
                                 ], 200);
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v2/users",
+     *      operationId="listUsersv2",
+     *      tags={"Users"},
+     *      summary="List users with optional filtering and sorting",
+     *      description="Administrator only. Paginated.",
+     *      security={{"apiToken":{}}},
+     *      @OA\Parameter(name="name", in="query", required=false, @OA\Schema(type="string")),
+     *      @OA\Parameter(name="email", in="query", required=false, @OA\Schema(type="string")),
+     *      @OA\Parameter(name="location", in="query", required=false, @OA\Schema(type="string")),
+     *      @OA\Parameter(name="country", in="query", required=false, @OA\Schema(type="string")),
+     *      @OA\Parameter(name="role", in="query", required=false, @OA\Schema(type="integer")),
+     *      @OA\Parameter(name="sort", in="query", required=false, @OA\Schema(type="string", enum={"name","email","role","location","country","created_at","updated_at"})),
+     *      @OA\Parameter(name="sortdir", in="query", required=false, @OA\Schema(type="string", enum={"asc","desc"})),
+     *      @OA\Parameter(name="page", in="query", required=false, @OA\Schema(type="integer")),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Successful operation",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/UserAdmin")),
+     *              @OA\Property(property="meta", type="object")
+     *          )
+     *      ),
+     *      @OA\Response(response=401, description="Unauthenticated"),
+     *      @OA\Response(response=403, description="Forbidden")
+     * )
+     */
+    public function listUsersv2(Request $request): JsonResponse
+    {
+        if (!Fixometer::hasRole(Auth::user(), 'Administrator')) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $query = User::query()
+            ->leftJoin('roles', 'roles.idroles', '=', 'users.role')
+            ->select('users.*', 'roles.role as role_name')
+            ->withCount('groups');
+
+        if ($name = $request->input('name')) {
+            $query->where('users.name', 'like', '%' . $name . '%');
+        }
+        if ($email = $request->input('email')) {
+            $query->where('users.email', 'like', '%' . $email . '%');
+        }
+        if ($location = $request->input('location')) {
+            $query->where('users.location', 'like', '%' . $location . '%');
+        }
+        if ($country = $request->input('country')) {
+            $query->where('users.country_code', '=', $country);
+        }
+        if (($role = $request->input('role')) !== null && $role !== '') {
+            $query->where('users.role', '=', (int) $role);
+        }
+
+        $sortMap = [
+            'name' => 'users.name',
+            'email' => 'users.email',
+            'role' => 'users.role',
+            'location' => 'users.location',
+            'country' => 'users.country_code',
+            'created_at' => 'users.created_at',
+            'updated_at' => 'users.updated_at',
+        ];
+        $sort = $request->input('sort');
+        if ($sort && isset($sortMap[$sort])) {
+            $dir = strtolower($request->input('sortdir', 'asc'));
+            if (!in_array($dir, ['asc', 'desc'], true)) {
+                $dir = 'asc';
+            }
+            $query->orderBy($sortMap[$sort], $dir);
+        } else {
+            $query->orderBy('users.id', 'asc');
+        }
+
+        $perPage = (int) (env('PAGINATE') ?: 30);
+        $paginator = $query->paginate($perPage);
+
+        return response()->json([
+            'data' => UserAdmin::collection($paginator->getCollection())->toArray($request),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page' => $paginator->lastPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'from' => $paginator->firstItem(),
+                'to' => $paginator->lastItem(),
+            ],
+        ]);
     }
 }

--- a/app/Http/Resources/UserAdmin.php
+++ b/app/Http/Resources/UserAdmin.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Helpers\Fixometer;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @OA\Schema(
+ *     title="UserAdmin",
+ *     schema="UserAdmin",
+ *     description="A user row for the admin user list",
+ *     @OA\Property(property="id", type="integer", format="int64", example=42),
+ *     @OA\Property(property="name", type="string", example="Jane Doe"),
+ *     @OA\Property(property="email", type="string", example="jane@example.com"),
+ *     @OA\Property(property="role", type="integer", example=3),
+ *     @OA\Property(property="role_name", type="string", example="Host"),
+ *     @OA\Property(property="location", type="string", nullable=true, example="London"),
+ *     @OA\Property(property="country", type="string", nullable=true, example="GB"),
+ *     @OA\Property(property="country_name", type="string", nullable=true, example="United Kingdom"),
+ *     @OA\Property(property="groups_count", type="integer", example=2),
+ *     @OA\Property(property="created_at", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="last_login_at", type="string", format="date-time", nullable=true)
+ * )
+ */
+class UserAdmin extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        $lastLogin = method_exists($this->resource, 'lastLogin') ? $this->resource->lastLogin() : null;
+
+        return [
+            'id' => (int) $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'role' => (int) $this->role,
+            'role_name' => $this->role_name ?? (string) $this->getRoleName(),
+            'location' => $this->location,
+            'country' => $this->country_code,
+            'country_name' => $this->country_code ? Fixometer::getCountryFromCountryCode($this->country_code) : null,
+            'groups_count' => (int) ($this->groups_count ?? $this->groups()->count()),
+            'created_at' => optional($this->created_at)?->toIso8601String(),
+            'last_login_at' => optional($lastLogin)?->toIso8601String(),
+        ];
+    }
+
+    private function getRoleName(): string
+    {
+        $roleNames = [
+            \App\Role::ROOT => 'Root',
+            \App\Role::ADMINISTRATOR => 'Administrator',
+            \App\Role::NETWORK_COORDINATOR => 'NetworkCoordinator',
+            \App\Role::HOST => 'Host',
+            \App\Role::RESTARTER => 'Restarter',
+        ];
+
+        return $roleNames[$this->role] ?? '';
+    }
+}

--- a/lang/en/users.php
+++ b/lang/en/users.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'title' => 'Users',
+    'reveal_filters' => 'Reveal filters',
+    'create_new' => 'Create new user',
+    'name' => 'Name',
+    'email' => 'Email address',
+    'role' => 'Role',
+    'role_any' => 'Any role',
+    'location' => 'Location',
+    'country' => 'Country',
+    'groups' => 'Groups',
+    'joined' => 'Joined',
+    'last_login' => 'Last login',
+    'placeholder_name' => 'Search by name',
+    'placeholder_email' => 'Search by email address',
+    'placeholder_location' => 'E.g. Paris, London, Brussels',
+    'search' => 'Search all users',
+    'empty' => 'No users match the current filters.',
+    'never' => 'Never',
+    'showing' => 'Showing :from to :to of :total results',
+];

--- a/lang/fr-BE/users.php
+++ b/lang/fr-BE/users.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'title' => 'Utilisateurs',
+    'reveal_filters' => 'Afficher les filtres',
+    'create_new' => 'Créer un nouvel utilisateur',
+    'name' => 'Nom',
+    'email' => 'Adresse e-mail',
+    'role' => 'Rôle',
+    'role_any' => 'Tous les rôles',
+    'location' => 'Ville',
+    'country' => 'Pays',
+    'groups' => 'Groupes',
+    'joined' => 'Inscrit',
+    'last_login' => 'Dernière connexion',
+    'placeholder_name' => 'Rechercher par nom',
+    'placeholder_email' => 'Rechercher par adresse e-mail',
+    'placeholder_location' => 'Par ex. Paris, Londres, Bruxelles',
+    'search' => 'Rechercher tous les utilisateurs',
+    'empty' => 'Aucun utilisateur ne correspond aux filtres actuels.',
+    'never' => 'Jamais',
+    'showing' => 'Affichage de :from à :to sur :total résultats',
+];

--- a/lang/fr/users.php
+++ b/lang/fr/users.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'title' => 'Utilisateurs',
+    'reveal_filters' => 'Afficher les filtres',
+    'create_new' => 'Créer un nouvel utilisateur',
+    'name' => 'Nom',
+    'email' => 'Adresse e-mail',
+    'role' => 'Rôle',
+    'role_any' => 'Tous les rôles',
+    'location' => 'Ville',
+    'country' => 'Pays',
+    'groups' => 'Groupes',
+    'joined' => 'Inscrit',
+    'last_login' => 'Dernière connexion',
+    'placeholder_name' => 'Rechercher par nom',
+    'placeholder_email' => 'Rechercher par adresse e-mail',
+    'placeholder_location' => 'Par ex. Paris, Londres, Bruxelles',
+    'search' => 'Rechercher tous les utilisateurs',
+    'empty' => 'Aucun utilisateur ne correspond aux filtres actuels.',
+    'never' => 'Jamais',
+    'showing' => 'Affichage de :from à :to sur :total résultats',
+];

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -42,6 +42,7 @@ import EventsRequiringModeration from './components/EventsRequiringModeration.vu
 import EventPage from './components/EventPage.vue'
 import FixometerPage from './components/FixometerPage.vue'
 import GroupsPage from './components/GroupsPage.vue'
+import UsersPage from './components/UsersPage.vue'
 import GroupPage from './components/GroupPage.vue'
 import GroupAddEditPage from './components/GroupAddEditPage.vue'
 import GroupEventsPage from './components/GroupEventsPage.vue'
@@ -402,6 +403,7 @@ function initializeJQuery() {
             'eventpage': EventPage,
             'fixometerpage': FixometerPage,
             'groupspage': GroupsPage,
+            'userspage': UsersPage,
             'grouppage': GroupPage,
             'groupaddeditpage': GroupAddEditPage,
             'groupeventspage': GroupEventsPage,

--- a/resources/js/components/UsersPage.vue
+++ b/resources/js/components/UsersPage.vue
@@ -186,7 +186,7 @@ export default {
         { key: 'country_name', label: this.__('users.country'), sortable: true, sortKey: 'country', class: 'd-none d-sm-table-cell' },
         { key: 'groups_count', label: this.__('users.groups'), class: 'd-none d-sm-table-cell' },
         { key: 'created_at', label: this.__('users.joined'), sortable: true, class: 'd-none d-sm-table-cell' },
-        { key: 'last_login_at', label: this.__('users.last_login'), class: 'd-none d-sm-table-cell' },
+        { key: 'last_login_at', label: this.__('users.last_login'), sortable: true, sortKey: 'updated_at', class: 'd-none d-sm-table-cell' },
       ]
     },
   },

--- a/resources/js/components/UsersPage.vue
+++ b/resources/js/components/UsersPage.vue
@@ -1,0 +1,245 @@
+<template>
+  <section>
+    <div class="container">
+      <div class="row mb-30">
+        <div class="col-12">
+          <div class="d-flex align-items-center">
+            <h1 class="mb-0 mr-30">{{ __('users.title') }}</h1>
+            <div class="button-group-filters ml-auto">
+              <b-btn
+                v-b-toggle.collapseFilter
+                variant="secondary"
+                class="d-md-none d-lg-none d-xl-none"
+              >
+                {{ __('users.reveal_filters') }}
+              </b-btn>
+              <b-btn variant="primary" href="#" data-toggle="modal" data-target="#add">
+                {{ __('users.create_new') }}
+              </b-btn>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-md-4 col-lg-3">
+          <b-collapse id="collapseFilter" visible class="d-md-block d-lg-block d-xl-block">
+            <aside class="panel p-3">
+              <b-form @submit.prevent="applyFilters">
+                <b-form-group :label="__('users.name')" label-for="filter-name">
+                  <b-form-input
+                      id="filter-name"
+                      v-model="filters.name"
+                      :placeholder="__('users.placeholder_name')"
+                      data-testid="users-filter-name"
+                  />
+                </b-form-group>
+
+                <b-form-group :label="__('users.email')" label-for="filter-email">
+                  <b-form-input
+                      id="filter-email"
+                      v-model="filters.email"
+                      :placeholder="__('users.placeholder_email')"
+                      data-testid="users-filter-email"
+                  />
+                </b-form-group>
+
+                <b-form-group :label="__('users.location')" label-for="filter-location">
+                  <b-form-input
+                      id="filter-location"
+                      v-model="filters.location"
+                      :placeholder="__('users.placeholder_location')"
+                      data-testid="users-filter-location"
+                  />
+                </b-form-group>
+
+                <b-form-group :label="__('users.country')" label-for="filter-country">
+                  <b-form-select
+                      id="filter-country"
+                      v-model="filters.country"
+                      :options="countryOptions"
+                      data-testid="users-filter-country"
+                  />
+                </b-form-group>
+
+                <b-form-group :label="__('users.role')" label-for="filter-role">
+                  <b-form-select
+                      id="filter-role"
+                      v-model="filters.role"
+                      :options="roleOptions"
+                      data-testid="users-filter-role"
+                  />
+                </b-form-group>
+
+                <b-btn type="submit" variant="secondary" block data-testid="users-filter-submit">
+                  {{ __('users.search') }}
+                </b-btn>
+              </b-form>
+            </aside>
+          </b-collapse>
+        </div>
+
+        <div class="col-md-8 col-lg-9">
+          <div class="table-responsive panel">
+            <b-table
+                :items="users"
+                :fields="tableFields"
+                :busy="loading"
+                striped
+                hover
+                sort-icon-left
+                :sort-by.sync="sortBy"
+                :sort-desc.sync="sortDesc"
+                :no-local-sorting="true"
+                @sort-changed="onSortChanged"
+                show-empty
+                :empty-text="__('users.empty')"
+                data-testid="users-table"
+            >
+              <template #cell(name)="row">
+                <a v-if="canEdit" :href="`/user/edit/${row.item.id}`">{{ row.item.name }}</a>
+                <span v-else>{{ row.item.name }}</span>
+              </template>
+              <template #cell(role_name)="row">{{ row.item.role_name }}</template>
+              <template #cell(created_at)="row">
+                <span :title="row.item.created_at">{{ humanise(row.item.created_at) }}</span>
+              </template>
+              <template #cell(last_login_at)="row">
+                <span :title="row.item.last_login_at">{{ humanise(row.item.last_login_at) }}</span>
+              </template>
+            </b-table>
+
+            <div class="d-flex justify-content-center">
+              <b-pagination
+                  v-if="meta.total > meta.per_page"
+                  v-model="page"
+                  :total-rows="meta.total"
+                  :per-page="meta.per_page"
+                  align="center"
+                  data-testid="users-pagination"
+                  @change="onPageChange"
+              />
+            </div>
+
+            <div v-if="meta.total > 0" class="d-flex justify-content-center">
+              {{ __('users.showing', { from: meta.from, to: meta.to, total: meta.total }) }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+import axios from 'axios'
+
+export default {
+  props: {
+    countries: {
+      type: Array,
+      required: true,
+    },
+    roles: {
+      type: Array,
+      required: true,
+    },
+    canEdit: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      filters: {
+        name: '',
+        email: '',
+        location: '',
+        country: '',
+        role: '',
+      },
+      page: 1,
+      sortBy: '',
+      sortDesc: false,
+      users: [],
+      meta: { current_page: 1, total: 0, per_page: 30, from: 0, to: 0 },
+      loading: false,
+    }
+  },
+  computed: {
+    countryOptions() {
+      return [{ value: '', text: '' }].concat(
+          this.countries.map(c => ({ value: c.code, text: c.name }))
+      )
+    },
+    roleOptions() {
+      return [{ value: '', text: this.__('users.role_any') }].concat(
+          this.roles.map(r => ({ value: r.id, text: r.name }))
+      )
+    },
+    tableFields() {
+      return [
+        { key: 'name', label: this.__('users.name'), sortable: true },
+        { key: 'email', label: this.__('users.email'), sortable: true, class: 'd-none d-sm-table-cell' },
+        { key: 'role_name', label: this.__('users.role'), sortable: true },
+        { key: 'location', label: this.__('users.location'), sortable: true, class: 'd-none d-sm-table-cell' },
+        { key: 'country_name', label: this.__('users.country'), sortable: true, sortKey: 'country', class: 'd-none d-sm-table-cell' },
+        { key: 'groups_count', label: this.__('users.groups'), class: 'd-none d-sm-table-cell' },
+        { key: 'created_at', label: this.__('users.joined'), sortable: true, class: 'd-none d-sm-table-cell' },
+        { key: 'last_login_at', label: this.__('users.last_login'), class: 'd-none d-sm-table-cell' },
+      ]
+    },
+  },
+  mounted() {
+    this.fetch()
+  },
+  methods: {
+    async fetch() {
+      this.loading = true
+      try {
+        const params = { page: this.page }
+        if (this.filters.name) params.name = this.filters.name
+        if (this.filters.email) params.email = this.filters.email
+        if (this.filters.location) params.location = this.filters.location
+        if (this.filters.country) params.country = this.filters.country
+        if (this.filters.role) params.role = this.filters.role
+        if (this.sortBy) {
+          const field = this.tableFields.find(f => f.key === this.sortBy)
+          params.sort = (field && field.sortKey) || this.sortBy
+          params.sortdir = this.sortDesc ? 'desc' : 'asc'
+        }
+        const { data } = await axios.get('/api/v2/users', { params })
+        this.users = data.data
+        this.meta = data.meta
+      } catch (e) {
+        console.error('Failed to load users', e)
+      } finally {
+        this.loading = false
+      }
+    },
+    applyFilters() {
+      this.page = 1
+      this.fetch()
+    },
+    onPageChange(newPage) {
+      this.page = newPage
+      this.fetch()
+    },
+    onSortChanged(ctx) {
+      this.sortBy = ctx.sortBy
+      this.sortDesc = ctx.sortDesc
+      this.page = 1
+      this.fetch()
+    },
+    humanise(iso) {
+      if (!iso) return this.__('users.never')
+      try {
+        const d = new Date(iso)
+        return d.toLocaleDateString()
+      } catch (e) {
+        return iso
+      }
+    },
+  },
+}
+</script>

--- a/resources/views/user/all.blade.php
+++ b/resources/views/user/all.blade.php
@@ -1,239 +1,44 @@
 @extends('layouts.app')
 @section('content')
-<section>
-  <div class="container">
 
-      @if (\Session::has('success'))
-          <div class="alert alert-success">
-              {!! \Session::get('success') !!}
-          </div>
-      @endif
-
-      @if (\Session::has('danger'))
-          <div class="alert alert-danger">
-              {!! \Session::get('danger') !!}
-          </div>
-      @endif
-
-
-      <div class="row mb-30">
-          <div class="col-12 col-md-12">
-              <div class="d-flex align-items-center">
-                  <h1 class="mb-0 mr-30">
-                      Users
-                  </h1>
-          <div class="button-group-filters ml-auto">
-            <button class="ml-auto reveal-filters btn btn-secondary d-md-none d-lg-none d-xl-none" type="button" data-toggle="collapse" data-target="#collapseFilter" aria-expanded="false" aria-controls="collapseFilter">Reveal filters</button>
-            <a href="#" data-toggle="modal" data-target="#add" class="btn btn-primary ml-auto">Create new user</a>
-          </div>
-        </div>
+  @if (\Session::has('success'))
+    <div class="container">
+      <div class="alert alert-success">
+        {!! \Session::get('success') !!}
       </div>
     </div>
+  @endif
 
-    @if(isset($response))
-      @php( App\Helpers\Fixometer::printResponse($response) )
-    @endif
-
-    <div class="row justify-content-center">
-      <div class="col-md-4 col-lg-3">
-        <aside class="collapse d-md-block d-lg-block d-xl-block fixed-overlay" id="collapseFilter">
-        <form class="" action="/user/all/search" method="get">
-          <div class="form-row d-sm-none">
-            <div class="form-group col mobile-search-bar">
-              <button type="button" class="d--lg-none d-xl-none d-md-none mobile-search-bar__close" data-toggle="collapse" data-target="#collapseFilter" aria-expanded="false" aria-controls="collapseFilter"><svg width="21" height="21" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;"><title>Close</title><g><path d="M11.25,10.387l-10.387,-10.387l-0.863,0.863l10.387,10.387l0.863,-0.863Z"/><path d="M0.863,11.25l10.387,-10.387l-0.863,-0.863l-10.387,10.387l0.863,0.863Z"/></g></svg></button>
-            </div>
-          </div>
-          <div class="panel p-3">
-            <div class="form-row">
-              <div class="form-group col">
-                <label for="name">Name:</label>
-                @if (isset($name))
-                  <input type="text" class="form-control" id="inputName" name="name" placeholder="Search by name" value="{{ $name }}">
-                @else
-                  <input type="text" class="form-control" id="inputName" name="name" placeholder="Search by name">
-                @endif
-              </div>
-            </div>
-            <div class="form-row">
-              <div class="form-group col">
-                <label for="inputEmail">Email:</label>
-                @if (isset($email))
-                  <input type="text" class="form-control" id="inputEmail" name="email" placeholder="Search by email address" value="{{ $email }}">
-                @else
-                  <input type="text" class="form-control" id="inputEmail" name="email" placeholder="Search by email address">
-                @endif
-              </div>
-            </div>
-            <div class="form-row">
-              <div class="form-group col">
-                <label for="inputTownCity">Town/City:</label>
-                @if (isset($location))
-                  <input type="text" class="form-control" id="inputTownCity" name="location" placeholder="E.g. Paris, London, Brussels" value="{{ $location }}">
-                @else
-                  <input type="text" class="form-control" id="inputTownCity" name="location" placeholder="E.g. Paris, London, Brussels">
-                @endif
-              </div>
-            </div>
-            <div class="form-row">
-              <div class="form-group col">
-                <label for="inputCountry">Country:</label>
-                <select id="country" name="country" class="form-control">
-                    <option value=""></option>
-                    @foreach (App\Helpers\Fixometer::getAllCountries() as $country_code => $country_name)
-                      @if (isset($country) && $country_code == $country)
-                        <option value="{{ $country_code }}" selected>{{ $country_name }}</option>
-                      @else
-                        <option value="{{ $country_code }}">{{ $country_name }}</option>
-                      @endif
-                    @endforeach
-                </select>
-              </div>
-            </div>
-            <div class="form-row">
-              <div class="form-group col">
-                <label for="role">Role:</label>
-                <select class="form-control" id="inputRole" name="role">
-                  <option value="" selected>Choose role</option>
-                  @foreach (App\Helpers\Fixometer::allRoles() as $r)
-                    @if (isset($role) && $r->idroles == $role)
-                      <option value="{{ $r->idroles }}" selected>{{ $r->role }}</option>
-                    @else
-                      <option value="{{ $r->idroles }}">@lang($r->role)</option>
-                    @endif
-                  @endforeach
-                </select>
-              </div>
-            </div>
-            <div class="form-row">
-              <div class="form-group col">
-                <label for="permission">Permission:</label>
-                <select id="permissions" name="permissions[]" class="form-control" multiple size="6" data-live-search="true" title="Choose permissions...">
-                  @foreach (App\Helpers\Fixometer::allPermissions() as $p)
-                    @if (isset($permissions) && in_array($p->idpermissions, $permissions))
-                      <option value="{{ $p->idpermissions }}" selected>{{ $p->permission }}</option>
-                    @else
-                      <option value="{{ $p->idpermissions }}">{{ $p->permission }}</option>
-                    @endif
-                  @endforeach
-                </select>
-              </div>
-            </div>
-
-            <button type="submit" class="btn btn-secondary btn-block w-100">Search all users</button>
-          </div>
-        </form>
-        </aside>
-      </div>
-
-      <div class="col-md-8 col-lg-9">
-        <div class="table-responsive panel">
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th><a href="/user/all/search?{{ App\Helpers\Fixometer::buildSortQuery('users.name') }}">Name</a></th>
-                <th class="d-none d-sm-table-cell">Email address</th>
-                <th class=""><a href="/user/all/search?{{ App\Helpers\Fixometer::buildSortQuery('users.role') }}">Role</a></th>
-                <th class="d-none d-sm-table-cell"><a href="/user/all/search?{{ App\Helpers\Fixometer::buildSortQuery('users.location') }}">Location</a></th>
-                <th class="d-none d-sm-table-cell"><a href="/user/all/search?{{ App\Helpers\Fixometer::buildSortQuery('users.country') }}">Country</a></th>
-                <th class="d-none d-sm-table-cell">Groups</th>
-                <th class="d-none d-sm-table-cell" width="90"><a href="/user/all/search?{{ App\Helpers\Fixometer::buildSortQuery('users.created_at') }}">Joined</a></th>
-                <th class="d-none d-sm-table-cell" width="90"><a href="/user/all/search?{{ App\Helpers\Fixometer::buildSortQuery('users.updated_at') }}">Last login</a></th>
-              </tr>
-            </thead>
-            <tbody>
-              @foreach($userlist as $u)
-
-                @php( $display = true )
-
-                <?php
-                  if (isset($permissions)) {
-                    foreach($permissions as $p) {
-                      $user_permissions = array_column($u->permissions, 'idpermissions');
-                      if(!in_array($p, $user_permissions)) {
-                        $display = false;
-                        break;
-                      }
-                    }
-                  }
-                ?>
-
-                @if ($display)
-                  <tr>
-                      <td>
-
-                          @if(App\Helpers\Fixometer::hasRole($user, 'Administrator'))
-                          <a href="/user/edit/{{ $u->id }}">{{ $u->name }}</a>
-                          @else
-                          {{ $u->name }}
-                          @endif
-
-                      </td>
-                      <td class="d-none d-sm-table-cell">
-                        <span class="js-copy hover-pointer popover-usergroups"
-                        data-toggle="popover"
-                        data-trigger="hover"
-                        data-placement="top"
-                        data-html="true"
-                        data-original-email="{{ $u->email }}"
-                        data-copy="{{ $u->email }}"
-                        data-content="{{ $u->email }} </br> <b>Click/press to copy</b>">
-                          {{ Str::limit($u->email, 15) }}
-                        </span>
-                      </td>
-                      <td>
-                          @lang($u->role)
-                      </td>
-                      <td class="d-none d-sm-table-cell">
-                        @if (!empty($u->location))
-                          <?php echo $u->location; ?>
-                        @else
-                          N/A
-                        @endif
-                      </td>
-                      <td class="d-none d-sm-table-cell">{{ \App\Helpers\Fixometer::getCountryFromCountryCode($u->country_code) }}</td>
-                      <td class="d-none d-sm-table-cell text-center">
-                        @if (isset($u->groups) && $u->groups->count() > 0)
-                            <span class="popover-usergroups" data-toggle="popover" data-html="true" data-content="@include('partials.usergroups-popover')">{{ $u->groups->count() }}</span>
-                        @else
-                          0
-                        @endif
-                      </td>
-
-                      <td  class="d-none d-sm-table-cell">
-                        <span title="{{ $u->created_at }}">{{ !is_null($u->created_at) ? $u->created_at->diffForHumans(null, true) : 'Never' }}</span>
-                      </td>
-
-                      <td class="d-none d-sm-table-cell">
-                        <span title="{{ $u->lastLogin }}">{{ !is_null($u->lastLogin) ? $u->lastLogin->diffForHumans(null, true) : 'Never' }}</span>
-                      </td>
-                  </tr>
-                @endif
-              @endforeach
-            </tbody>
-          </table>
-
-          <div class="d-flex justify-content-center">
-              <nav aria-label="Pagination">
-                  @if (!empty($_GET) || isset($name))
-                      {!! $userlist->appends(Request::except('page'))->links() !!} <!-- 'selected_country' => $selected_country -->
-                  @else
-                      {!! $userlist->links() !!}
-                  @endif
-              </nav>
-          </div>
-
-          <div class="d-flex justify-content-center">
-              Showing {{ $userlist->firstItem() }} to {{ $userlist->lastItem() }} of {{ $userlist->total() }} results
-          </div>
-        </div>
-
-        <br>
-        <br>
-
+  @if (\Session::has('danger'))
+    <div class="container">
+      <div class="alert alert-danger">
+        {!! \Session::get('danger') !!}
       </div>
     </div>
+  @endif
+
+  <?php
+    $countries = [];
+    foreach (App\Helpers\Fixometer::getAllCountries() as $code => $name) {
+      $countries[] = ['code' => $code, 'name' => $name];
+    }
+    $roles = [];
+    foreach (App\Helpers\Fixometer::allRoles() as $r) {
+      $roles[] = ['id' => $r->idroles, 'name' => $r->role];
+    }
+    $can_edit = App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator');
+  ?>
+
+  <div class="vue-placeholder vue-placeholder-large">
+    <div class="vue-placeholder-content">@lang('partials.loading')...</div>
+  </div>
+  <div class="vue">
+    <UsersPage
+      :countries="{{ json_encode($countries, JSON_INVALID_UTF8_IGNORE) }}"
+      :roles="{{ json_encode($roles, JSON_INVALID_UTF8_IGNORE) }}"
+      :can-edit="{{ $can_edit ? 'true' : 'false' }}"
+    />
   </div>
 
-</section>
-@include('includes/modals/create-user')
+  @include('includes/modals/create-user')
 @endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,6 +93,12 @@ Route::prefix('v2')->group(function() {
             Route::patch('{id}', [API\EventController::class, 'updateEventv2']);
         });
 
+        Route::prefix('/users')->group(function() {
+            Route::middleware('auth:api')->group(function() {
+                Route::get('', [API\UserController::class, 'listUsersv2']);
+            });
+        });
+
         Route::prefix('/networks')->group(function() {
             Route::get('/', [API\NetworkController::class, 'getNetworksv2']);
             Route::get('{id}', [API\NetworkController::class, 'getNetworkv2']);

--- a/tests/Feature/Admin/Users/ViewUsersTest.php
+++ b/tests/Feature/Admin/Users/ViewUsersTest.php
@@ -3,135 +3,26 @@
 namespace Tests\Feature;
 
 use App\User;
-use Carbon\Carbon;
-use DB;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ViewUsersTest extends TestCase
 {
-    protected function setUp(): void
+    public function testAdminCanLoadUsersPage(): void
     {
-        parent::setUp();
-        DB::statement('SET foreign_key_checks=0');
-        User::truncate();
-        DB::statement('SET foreign_key_checks=1');
-
-        // Given we're logged in as an admin
         $admin = User::factory()->administrator()->create();
         $this->actingAs($admin);
-    }
 
-    /** @test */
-    public function an_admin_can_view_list_of_users(): void
-    {
-        // Given we have users in the database
-        $users = User::factory()->count(10)->create();
-
-        // When we visit the list of users
         $response = $this->get('/user/all');
-
-        // Then the users should be in the list
-        $response->assertSeeText($users[0]->name);
+        $response->assertSuccessful();
+        $response->assertSee('<UsersPage', false);
     }
 
-    /** @test */
-    public function an_admin_can_see_how_many_total_users_in_the_list(): void
+    public function testNonAdminCannotLoadUsersPage(): void
     {
-        // Given we have users in the database
-        $users = User::factory()->count(41)->create();
+        $user = User::factory()->restarter()->create();
+        $this->actingAs($user);
 
-        // When we visit the list of users
         $response = $this->get('/user/all');
-
-        // Then we should see the count of users
-        $response->assertSeeText(42);
-    }
-
-    /** @test */
-    public function admin_can_see_users_last_login_time(): void
-    {
-        // Given we have a user who has just logged in
-        $lastLogin = new \Carbon\Carbon();
-        $user = User::factory()->create([
-            'updated_at' => $lastLogin,
-        ]);
-
-        // When we visit the list of users
-        $response = $this->get('/user/all');
-
-        // Then we should see the last login date for that user
-        $response->assertSeeText($lastLogin->diffForHumans(null, true));
-    }
-
-    /** @test */
-    public function admin_can_see_users_last_login_time_on_filtered_results(): void
-    {
-        // Given we have a user who has just logged in
-        $lastLogin = new \Carbon\Carbon();
-        $user = User::factory()->create([
-            'updated_at' => $lastLogin,
-        ]);
-
-        // When we visit the list of users and filter by that user
-        $response = $this->get('/user/all/search?name='.$user->name);
-
-        // Then we should see the last login date for that user
-        $response->assertSeeText($lastLogin->diffForHumans(null, true));
-    }
-
-    /** @test */
-    public function admin_can_sort_user_list_by_last_login(): void
-    {
-        // Given we have users with various login times
-        $dateOfMostRecentLogin = new Carbon();
-        $dateOfLeastRecentLogin = new Carbon('-1 year');
-
-        $userWithMostRecentLogin = User::factory()->create([
-            'last_login_at' => $dateOfMostRecentLogin,
-        ]);
-        $otherUsers = User::factory()->count(42)->create([
-            'last_login_at' => new Carbon('-1 month'),
-        ]);
-        $userWithLeastRecentLogin = User::factory()->create([
-            'last_login_at' => $dateOfLeastRecentLogin,
-        ]);
-
-        // Try this a few times because we might be unlucky and hit a second boundary.
-        $found = false;
-
-        for ($i = 0; $i < 10; $i++) {
-            // When we visit the list of users and sort it by last login descending
-            $response = $this->get('/user/all/search?sort=last_login_at&sortdir=desc');
-            $datestr = $dateOfMostRecentLogin->diffForHumans(null, true);
-
-            if (stripos($response->getContent(), $datestr) !== false) {
-                // Then the first result is the most recent login
-                $found = true;
-                break;
-            }
-        }
-
-        $this->assertTrue($found);
-
-        // When we visit the list of users and sort it by last login descending
-        $response = $this->get('/user/all/search?sort=last_login_at&sortdir=asc');
-
-        // Then the first result is the most recent login
-        $found = false;
-
-        for ($i = 0; $i < 10; $i++) {
-            // When we visit the list of users and sort it by last login descending
-            $response = $this->get('/user/all/search?sort=last_login_at&sortdir=asc');
-            $datestr = $dateOfLeastRecentLogin->diffForHumans(null, true);
-
-            if (stripos($response->getContent(), $datestr) !== false) {
-                // Then the first result is the most recent login
-                $found = true;
-                break;
-            }
-        }
-
-        $this->assertTrue($found);
+        $response->assertRedirect('/user/forbidden');
     }
 }

--- a/tests/Feature/Users/APIv2UsersTest.php
+++ b/tests/Feature/Users/APIv2UsersTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Users;
+
+use App\Role;
+use App\User;
+use Tests\TestCase;
+
+class APIv2UsersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function testListUsersRequiresAuth(): void
+    {
+        $response = $this->getJson('/api/v2/users');
+        $response->assertStatus(401);
+    }
+
+    public function testListUsersForbiddenForNonAdmin(): void
+    {
+        $user = User::factory()->restarter()->create(['api_token' => 'r1']);
+        $this->actingAs($user);
+
+        $response = $this->getJson('/api/v2/users?api_token=r1');
+        $response->assertStatus(403);
+    }
+
+    public function testListUsersAsAdminReturnsPaginated(): void
+    {
+        $admin = User::factory()->administrator()->create(['api_token' => 'admin1']);
+        User::factory()->host()->create(['name' => 'Aaa Host']);
+        User::factory()->restarter()->create(['name' => 'Bbb Restarter']);
+        $this->actingAs($admin);
+
+        $response = $this->getJson('/api/v2/users?api_token=admin1');
+        $response->assertSuccessful();
+
+        $payload = $response->json();
+        $this->assertArrayHasKey('data', $payload);
+        $this->assertArrayHasKey('meta', $payload);
+        $this->assertArrayHasKey('current_page', $payload['meta']);
+        $this->assertArrayHasKey('total', $payload['meta']);
+        $this->assertIsArray($payload['data']);
+
+        foreach ($payload['data'] as $row) {
+            $this->assertArrayHasKey('id', $row);
+            $this->assertArrayHasKey('name', $row);
+            $this->assertArrayHasKey('email', $row);
+            $this->assertArrayHasKey('role', $row);
+            $this->assertArrayHasKey('role_name', $row);
+            $this->assertArrayHasKey('location', $row);
+            $this->assertArrayHasKey('country', $row);
+            $this->assertArrayHasKey('country_name', $row);
+            $this->assertArrayHasKey('groups_count', $row);
+            $this->assertArrayHasKey('created_at', $row);
+            $this->assertArrayHasKey('last_login_at', $row);
+        }
+    }
+
+    public function testListUsersFilterByName(): void
+    {
+        $admin = User::factory()->administrator()->create(['api_token' => 'admin1']);
+        User::factory()->host()->create(['name' => 'Alpha Person']);
+        User::factory()->host()->create(['name' => 'Bravo Person']);
+        $this->actingAs($admin);
+
+        $response = $this->getJson('/api/v2/users?api_token=admin1&name=Alpha');
+        $response->assertSuccessful();
+
+        $names = array_column($response->json('data'), 'name');
+        $this->assertContains('Alpha Person', $names);
+        $this->assertNotContains('Bravo Person', $names);
+    }
+
+    public function testListUsersFilterByEmail(): void
+    {
+        $admin = User::factory()->administrator()->create(['api_token' => 'admin1']);
+        User::factory()->host()->create(['email' => 'unique-target@example.com']);
+        User::factory()->host()->create(['email' => 'noise@example.com']);
+        $this->actingAs($admin);
+
+        $response = $this->getJson('/api/v2/users?api_token=admin1&email=unique-target');
+        $response->assertSuccessful();
+
+        $emails = array_column($response->json('data'), 'email');
+        $this->assertContains('unique-target@example.com', $emails);
+        $this->assertNotContains('noise@example.com', $emails);
+    }
+
+    public function testListUsersFilterByRole(): void
+    {
+        $admin = User::factory()->administrator()->create(['api_token' => 'admin1']);
+        $host = User::factory()->host()->create();
+        User::factory()->restarter()->create();
+        $this->actingAs($admin);
+
+        $response = $this->getJson('/api/v2/users?api_token=admin1&role=' . Role::HOST);
+        $response->assertSuccessful();
+
+        $roles = array_unique(array_column($response->json('data'), 'role'));
+        $this->assertEquals([Role::HOST], array_values($roles));
+    }
+
+    public function testListUsersSortByNameAsc(): void
+    {
+        $admin = User::factory()->administrator()->create(['api_token' => 'admin1']);
+        User::factory()->host()->create(['name' => 'Zeta Sortable']);
+        User::factory()->host()->create(['name' => 'Alpha Sortable']);
+        $this->actingAs($admin);
+
+        $response = $this->getJson('/api/v2/users?api_token=admin1&name=Sortable&sort=name&sortdir=asc');
+        $response->assertSuccessful();
+
+        $names = array_column($response->json('data'), 'name');
+        $alphaIdx = array_search('Alpha Sortable', $names);
+        $zetaIdx = array_search('Zeta Sortable', $names);
+        $this->assertNotFalse($alphaIdx);
+        $this->assertNotFalse($zetaIdx);
+        $this->assertLessThan($zetaIdx, $alphaIdx);
+    }
+}

--- a/tests/Feature/Users/UserAdminTest.php
+++ b/tests/Feature/Users/UserAdminTest.php
@@ -43,10 +43,11 @@ class UserAdminTest extends TestCase
         $response = $this->get('/user/all');
 
         if ($cansee) {
-            $response->assertSee('Create new user');
-            $response->assertSee($admin->name);
+            $response->assertSuccessful();
+            $response->assertSee('<UsersPage', false);
         } else {
-            $response->assertDontSee('Create new user');
+            // Non-admin is redirected away from the page in the new Vue flow.
+            $response->assertRedirect('/user/forbidden');
         }
     }
 

--- a/tests/Integration/admin-users.test.js
+++ b/tests/Integration/admin-users.test.js
@@ -1,0 +1,27 @@
+/**
+ * Smoke-test coverage for /user/all migrated from a server-rendered blade
+ * to the UsersPage Vue SPA backed by GET /api/v2/users.
+ */
+
+const { test } = require('./fixtures')
+const { expect } = require('@playwright/test')
+const { login } = require('./utils')
+
+const ADMIN_EMAIL = 'jane@bloggs.net'
+const RESTARTER_EMAIL = 'host@test.net'
+const PASSWORD = 'passw0rd'
+
+test('Admin /user/all renders the UsersPage Vue SPA', async ({ page, baseURL }) => {
+  test.slow()
+  await login(page, baseURL, ADMIN_EMAIL, PASSWORD)
+  await page.goto(baseURL + '/user/all')
+  await expect(page.locator('[data-testid="users-table"]')).toBeVisible({ timeout: 10000 })
+  await expect(page.locator('[data-testid="users-filter-submit"]')).toBeVisible()
+})
+
+test('Non-admin is redirected away from /user/all', async ({ page, baseURL }) => {
+  test.slow()
+  await login(page, baseURL, RESTARTER_EMAIL, PASSWORD)
+  await page.goto(baseURL + '/user/all')
+  await expect(page).toHaveURL(/\/user\/forbidden$/)
+})


### PR DESCRIPTION
## Summary
- First sub-task of plans/active/blade-to-vue-migration.md Group 2 (user management)
- Introduces GET /api/v2/users with auth/admin gating, filters, sort, pagination
- OpenAPI annotations + UserAdmin resource
- PHPUnit tests for the new endpoint (auth/forbidden/shape/filters/sort)
- Vue page lands in a follow-up commit

## Test plan
- [ ] PHPUnit: tests/Feature/Users/APIv2UsersTest passes on CI
- [ ] Follow-up: Vue admin user list page consumes this endpoint
- [ ] Follow-up: Playwright smoke for /user/all