### PR TITLE
Migrate events/cantcreate page to Vue + i18n (Group 5.2)

### DIFF
--- a/lang/en/cantcreate.php
+++ b/lang/en/cantcreate.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'heading' => 'Adding events',
+    'intro' => 'You need to be a host of a group in order to create a new event listing.',
+    'image_alt' => 'Materials for promoting upcoming Restart events',
+    'not_host_q' => 'Not a host?',
+    'not_host_body' => 'You can view already listed events for any groups that you\'re following, and other events near you, on the <a href="/group">Events</a> page.',
+    'missing_event' => '(If an event is missing, please encourage the group host to list it!)',
+    'want_to_add_group_q' => 'Want to add a group that you host?',
+    'want_to_add_group_body' => 'Check whether it\'s already listed on the <a href="/group">Groups</a> page - and if not, please create it!',
+    'start_new_group_q' => 'Want to start a new group?',
+    'start_new_group_body' => 'Find out more here: <a href="https://talk.restarters.net/t/how-to-power-up-community-repair-with-restarters-net/1228/2">How to power up community repair with Restarters.net</a>.',
+];

--- a/lang/fr-BE/cantcreate.php
+++ b/lang/fr-BE/cantcreate.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'heading' => 'Ajouter des événements',
+    'intro' => 'Vous devez être hôte d\'un groupe pour pouvoir créer une nouvelle annonce d\'événement.',
+    'image_alt' => 'Matériel pour promouvoir les prochains événements Restart',
+    'not_host_q' => 'Vous n\'êtes pas hôte ?',
+    'not_host_body' => 'Vous pouvez consulter les événements déjà annoncés par les groupes que vous suivez, ainsi que d\'autres événements près de chez vous, sur la page <a href="/group">Événements</a>.',
+    'missing_event' => '(Si un événement est manquant, encouragez l\'hôte du groupe à l\'annoncer !)',
+    'want_to_add_group_q' => 'Vous voulez ajouter un groupe dont vous êtes hôte ?',
+    'want_to_add_group_body' => 'Vérifiez s\'il est déjà répertorié sur la page <a href="/group">Groupes</a> — sinon, créez-le !',
+    'start_new_group_q' => 'Vous voulez démarrer un nouveau groupe ?',
+    'start_new_group_body' => 'Pour en savoir plus : <a href="https://talk.restarters.net/t/how-to-power-up-community-repair-with-restarters-net/1228/2">Comment dynamiser la réparation communautaire avec Restarters.net</a>.',
+];

--- a/lang/fr/cantcreate.php
+++ b/lang/fr/cantcreate.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'heading' => 'Ajouter des événements',
+    'intro' => 'Vous devez être hôte d\'un groupe pour pouvoir créer une nouvelle annonce d\'événement.',
+    'image_alt' => 'Matériel pour promouvoir les prochains événements Restart',
+    'not_host_q' => 'Vous n\'êtes pas hôte ?',
+    'not_host_body' => 'Vous pouvez consulter les événements déjà annoncés par les groupes que vous suivez, ainsi que d\'autres événements près de chez vous, sur la page <a href="/group">Événements</a>.',
+    'missing_event' => '(Si un événement est manquant, encouragez l\'hôte du groupe à l\'annoncer !)',
+    'want_to_add_group_q' => 'Vous voulez ajouter un groupe dont vous êtes hôte ?',
+    'want_to_add_group_body' => 'Vérifiez s\'il est déjà répertorié sur la page <a href="/group">Groupes</a> — sinon, créez-le !',
+    'start_new_group_q' => 'Vous voulez démarrer un nouveau groupe ?',
+    'start_new_group_body' => 'Pour en savoir plus : <a href="https://talk.restarters.net/t/how-to-power-up-community-repair-with-restarters-net/1228/2">Comment dynamiser la réparation communautaire avec Restarters.net</a>.',
+];

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -40,6 +40,7 @@ import EventAddEditPage from './components/EventAddEditPage.vue'
 import EventAddEdit from './components/EventAddEdit.vue'
 import EventsRequiringModeration from './components/EventsRequiringModeration.vue'
 import EventPage from './components/EventPage.vue'
+import CantCreateEventPage from './components/CantCreateEventPage.vue'
 import FixometerPage from './components/FixometerPage.vue'
 import GroupsPage from './components/GroupsPage.vue'
 import GroupPage from './components/GroupPage.vue'
@@ -400,6 +401,7 @@ function initializeJQuery() {
             'eventaddedit': EventAddEdit,
             'eventsrequiringmoderation': EventsRequiringModeration,
             'eventpage': EventPage,
+            'cantcreateeventpage': CantCreateEventPage,
             'fixometerpage': FixometerPage,
             'groupspage': GroupsPage,
             'grouppage': GroupPage,

--- a/resources/js/components/CantCreateEventPage.vue
+++ b/resources/js/components/CantCreateEventPage.vue
@@ -1,0 +1,44 @@
+<template>
+  <section class="events events-page">
+    <div class="container-fluid">
+      <div class="row justify-content-center">
+        <div class="col-lg-12">
+          <header>
+            <h2>{{ __('cantcreate.heading') }}</h2>
+          </header>
+
+          <p>{{ __('cantcreate.intro') }}</p>
+
+          <img
+              class="d-none d-md-block img-fluid img-thumbnail mb-4"
+              src="/images/dashboard/dashboard__getting-started-in-community-repair-1.png"
+              :alt="__('cantcreate.image_alt')"
+          >
+
+          <p>
+            <strong>{{ __('cantcreate.not_host_q') }}</strong>
+            <span v-html="__('cantcreate.not_host_body')" />
+            <br>
+            <em>{{ __('cantcreate.missing_event') }}</em>
+          </p>
+
+          <p>
+            <strong>{{ __('cantcreate.want_to_add_group_q') }}</strong>
+            <span v-html="__('cantcreate.want_to_add_group_body')" />
+          </p>
+
+          <p>
+            <strong>{{ __('cantcreate.start_new_group_q') }}</strong>
+            <span v-html="__('cantcreate.start_new_group_body')" />
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'CantCreateEventPage',
+}
+</script>

--- a/resources/js/components/CantCreateEventPage.vue
+++ b/resources/js/components/CantCreateEventPage.vue
@@ -11,7 +11,7 @@
 
           <img
               class="d-none d-md-block img-fluid img-thumbnail mb-4"
-              src="/images/dashboard/dashboard__getting-started-in-community-repair-1.png"
+              :src="'/images/dashboard/dashboard__getting-started-in-community-repair-1.png'"
               :alt="__('cantcreate.image_alt')"
           >
 

--- a/resources/views/events/cantcreate.blade.php
+++ b/resources/views/events/cantcreate.blade.php
@@ -1,32 +1,9 @@
 @extends('layouts.app')
 @section('content')
-<section class="events events-page">
-
-    <div class="container-fluid">
-
-    <div class="row justify-content-center">
-      <div class="col-lg-12">
-
-          <header>
-              <h2>Adding events</h2>
-          </header>
-
-          <p>You need to be a host of a group in order to create a new event listing.</p>
-
-          <img class="d-none d-md-block img-fluid img-thumbnail mb-4" src="/images/dashboard/dashboard__getting-started-in-community-repair-1.png" alt="Materials for promoting upcoming Restart events">
-
-          <p><strong>Not a host?</strong> You can view already listed events for any groups that you're following, and other events near you, on the <a href="/group">Events</a> page.
-              <br>(If an event is missing, please encourage the group host to list it!)
-          </p>
-
-          <p><strong>Want to add a group that you host?</strong>  Check whether it's already listed on the <a href="/group">Groups</a> page - and if not, please create it!</p>
-
-          <p><strong>Want to start a new group?</strong> Find out more here: <a href="https://talk.restarters.net/t/how-to-power-up-community-repair-with-restarters-net/1228/2">How to power up community repair with Restarters.net</a>.
-          </p>
-      </div>
-    </div>
-
-    </div>
-
-</section>
+  <div class="vue-placeholder vue-placeholder-large">
+    <div class="vue-placeholder-content">@lang('partials.loading')...</div>
+  </div>
+  <div class="vue">
+    <CantCreateEventPage />
+  </div>
 @endsection

--- a/tests/Feature/Events/CantCreateEventPageTest.php
+++ b/tests/Feature/Events/CantCreateEventPageTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature\Events;
+
+use App\Role;
+use App\User;
+use Tests\TestCase;
+
+class CantCreateEventPageTest extends TestCase
+{
+    public function testRestarterSeesVueCantCreatePage(): void
+    {
+        $user = User::factory()->restarter()->create();
+        $this->actingAs($user);
+
+        $response = $this->get('/party/create');
+        $response->assertSuccessful();
+        $response->assertSee('<CantCreateEventPage', false);
+    }
+}

--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -36,7 +36,10 @@ class CreateEventTest extends TestCase
         $this->actingAs($host);
 
         $response = $this->get('/party/create');
-        $response->assertSee('You need to be a host of a group in order to create a new event listing');
+        // The "can't create" page is now the CantCreateEventPage Vue component;
+        // its copy (cantcreate.intro) is rendered client-side, so assert the
+        // component mounts rather than the translated text (see CantCreateEventPageTest).
+        $response->assertSee('<CantCreateEventPage', false);
     }
 
     /**


### PR DESCRIPTION
## Summary
- plans/active/blade-to-vue-migration.md Group 5.2
- Presentational page (no API) when a restarter or group-less host hits /party/create
- Moves hard-coded English into lang/{en,fr,fr-BE}/cantcreate.php
- Renders via a small Vue component

## Test plan
- [ ] PHPUnit: tests/Feature/Events/CantCreateEventPageTest passes on CI