### PR TITLE
security: fix user IDOR/account-takeover and audit-log stored XSS (F001/F002/F004-F007)

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -149,9 +149,7 @@ class UserController extends Controller
         }
 
         $id = $request->input('id', Auth::id());
-        if ($id != Auth::id() && ! Auth::user()->hasRole('Administrator')) {
-            abort(403);
-        }
+        $this->authorize('update', User::findOrFail($id));
 
         User::find($id)->update([
         'email'    => $request->input('email'),
@@ -187,11 +185,8 @@ class UserController extends Controller
     public function postProfilePasswordEdit(Request $request): RedirectResponse
     {
         $id = $request->input('id', Auth::id());
-        if ($id != Auth::id() && ! Auth::user()->hasRole('Administrator')) {
-            abort(403);
-        }
-
-        $user = User::find($id);
+        $user = User::findOrFail($id);
+        $this->authorize('update', $user);
 
         if ($request->input('new-password') !== $request->input('new-password-repeat')) {
             return redirect()->back()->with('error', __('profile.password_new_mismatch'));
@@ -252,7 +247,8 @@ class UserController extends Controller
         }
 
         $newLanguage = $request->input('user_language');
-        $user = User::find($userId);
+        $user = User::findOrFail($userId);
+        $this->authorize('update', $user);
         $user->language = $newLanguage;
         $user->save();
 
@@ -277,7 +273,9 @@ class UserController extends Controller
             $id = Auth::id();
         }
 
-        $user = User::find($id);
+        $user = User::findOrFail($id);
+        $this->authorize('delete', $user);
+
         $old_user_name = $user->name;
         $user_id = $user->id;
 
@@ -300,7 +298,8 @@ class UserController extends Controller
             $id = Auth::id();
         }
 
-        $user = User::find($id);
+        $user = User::findOrFail($id);
+        $this->authorize('update', $user);
 
         if ($request->input('invites') !== null) :
             $user->invites = 1; else :
@@ -320,7 +319,8 @@ class UserController extends Controller
             $id = Auth::id();
         }
 
-        $user = User::find($id);
+        $user = User::findOrFail($id);
+        $this->authorize('update', $user);
 
         $skills = $request->input('tags');
         $user->skillsold()->sync($skills);
@@ -338,9 +338,7 @@ class UserController extends Controller
     public function postProfilePictureEdit(Request $request): RedirectResponse
     {
         $id = $request->input('id', Auth::id());
-        if ($id != Auth::id() && ! Auth::user()->hasRole('Administrator')) {
-            abort(403);
-        }
+        $this->authorize('update', User::findOrFail($id));
 
         if (isset($_FILES) && ! empty($_FILES)) {
             $file = new FixometerFile;
@@ -731,109 +729,104 @@ class UserController extends Controller
         $user = Auth::user();
         $User = new User;
 
-        // Administrators and Hosts can edit users. Users can edit themselves.
-        if (Fixometer::hasRole($user, 'Administrator') || Fixometer::hasRole($user, 'Host') || $user->id == $id) {
-            $Roles = new Role;
-            $Roles = $Roles->findAll();
+        // Administrators can edit any user; users can edit themselves. (Hosts may NOT edit
+        // arbitrary users - that was an account-takeover vector.) Centralised in UserPolicy.
+        $editingUser = User::findOrFail($id);
+        $this->authorize('update', $editingUser);
 
-            $Groups = new Group;
-            $Groups = $Groups->findAll();
+        $Roles = new Role;
+        $Roles = $Roles->findAll();
 
-            $sent_groups = $request->input('groups', []);
+        $Groups = new Group;
+        $Groups = $Groups->findAll();
 
-            $data = $request->only([
-                'name', 'email', 'location', 'age', 'gender', 'country_code',
-                'biography', 'language', 'newsletter', 'invites',
-            ]);
+        $sent_groups = $request->input('groups', []);
 
-            $error = false;
-            // check for email in use
-            $editingUser = $User->find($id);
-            if ($editingUser->email !== $data['email'] && ! $User->checkEmail($data['email'])) {
-                $error['email'] = 'The email you entered is already in use in our database. Please use another one.';
-            }
+        $data = $request->only([
+            'name', 'email', 'location', 'age', 'gender', 'country_code',
+            'biography', 'language', 'newsletter', 'invites',
+        ]);
 
-            if ($request->filled('new-password')) {
-                if ($request->input('new-password') !== $request->input('password-confirm')) {
-                    $error['password'] = 'The passwords are not identical!';
-                } else {
-                    $data['password'] = Hash::make($request->input('new-password'));
-                }
-            }
+        $error = false;
+        // check for email in use
+        if ($editingUser->email !== $data['email'] && ! $User->checkEmail($data['email'])) {
+            $error['email'] = 'The email you entered is already in use in our database. Please use another one.';
+        }
 
-            if (! is_array($error)) {
-                $u = $User->find($id)->update($data);
-
-                $ug = new UserGroups;
-                if (isset($sent_groups)) {
-                    $ug->createUsersGroups($id, $sent_groups);
-                }
-
-                if (isset($_FILES) && ! empty($_FILES)) {
-                    $file = new FixometerFile;
-                    $file->upload('profile', 'image', $id, env('TBL_USERS'), false, true);
-                }
-
-                if (! $u) {
-                    $response['danger'] = 'Something went wrong. Please check the data and try again.';
-                    \Sentry\CaptureMessage($response['danger']);
-                } else {
-                    $response['success'] = 'User updated!';
-                    if (Fixometer::hasRole($user, 'Host')) {
-                        // Use @ for phpunit tests.
-                        @header('Location: /host?action=ue&code=200');
-                    } elseif ($user->id == $id && !Fixometer::hasRole($user, 'Administrator')) {
-                        // Regular users editing themselves should return empty response
-                        return response('');
-                    }
-                }
-
-                $userdata = User::find($id);
-
-                $usergroups = [];
-                $ugroups = $User->getUserGroups($id);
-                foreach ($ugroups as $g) {
-                    $usergroups[] = $g->group;
-                }
-
-                $userdata->groups = $usergroups;
-
-                return view('user.edit', [
-                'title' => 'Edit User',
-                'langs' => $fixometer_languages,
-                'user' => $user,
-                'header' => true,
-                'response' => $response,
-                'roles' => $Roles,
-                'groups' => $Groups,
-                'data' => $userdata,
-                ]);
+        if ($request->filled('new-password')) {
+            if ($request->input('new-password') !== $request->input('password-confirm')) {
+                $error['password'] = 'The passwords are not identical!';
             } else {
-                $userdata = User::find($id);
-
-                $usergroups = [];
-                $ugroups = $User->getUserGroups($id);
-                foreach ($ugroups as $g) {
-                    $usergroups[] = $g->group;
-                }
-
-                $userdata->groups = $usergroups;
-
-                return view('user.edit', [
-                'title' => 'Edit User',
-                'langs' => $fixometer_languages,
-                'user' => $user,
-                'header' => true,
-                'error' => $error,
-                'roles' => $Roles,
-                'groups' => $Groups,
-                'data' => $userdata,
-                ]);
+                $data['password'] = Hash::make($request->input('new-password'));
             }
         }
-        
-        // Add a default return for when user doesn't have permissions
-        abort(403, 'Unauthorized');
+
+        if (! is_array($error)) {
+            $u = $User->find($id)->update($data);
+
+            $ug = new UserGroups;
+            if (isset($sent_groups)) {
+                $ug->createUsersGroups($id, $sent_groups);
+            }
+
+            if (isset($_FILES) && ! empty($_FILES)) {
+                $file = new FixometerFile;
+                $file->upload('profile', 'image', $id, env('TBL_USERS'), false, true);
+            }
+
+            if (! $u) {
+                $response['danger'] = 'Something went wrong. Please check the data and try again.';
+                \Sentry\CaptureMessage($response['danger']);
+            } else {
+                $response['success'] = 'User updated!';
+                if ($user->id == $id && ! Fixometer::hasRole($user, 'Administrator')) {
+                    // Regular users editing themselves should return empty response
+                    return response('');
+                }
+            }
+
+            $userdata = User::find($id);
+
+            $usergroups = [];
+            $ugroups = $User->getUserGroups($id);
+            foreach ($ugroups as $g) {
+                $usergroups[] = $g->group;
+            }
+
+            $userdata->groups = $usergroups;
+
+            return view('user.edit', [
+            'title' => 'Edit User',
+            'langs' => $fixometer_languages,
+            'user' => $user,
+            'header' => true,
+            'response' => $response,
+            'roles' => $Roles,
+            'groups' => $Groups,
+            'data' => $userdata,
+            ]);
+        } else {
+            $userdata = User::find($id);
+
+            $usergroups = [];
+            $ugroups = $User->getUserGroups($id);
+            foreach ($ugroups as $g) {
+                $usergroups[] = $g->group;
+            }
+
+            $userdata->groups = $usergroups;
+
+            return view('user.edit', [
+            'title' => 'Edit User',
+            'langs' => $fixometer_languages,
+            'user' => $user,
+            'header' => true,
+            'error' => $error,
+            'roles' => $Roles,
+            'groups' => $Groups,
+            'data' => $userdata,
+            ]);
+        }
     }
 
     public function logout(): RedirectResponse

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -12,6 +12,26 @@ class UserPolicy
     use HandlesAuthorization;
 
     /**
+     * Determine whether the acting user may modify the target user's account/profile.
+     *
+     * This is the canonical "self or administrator" rule. Every endpoint that mutates a
+     * user record (profile info, password, picture, skills, language, preferences and the
+     * admin edit() form) authorises through here so the check can never be omitted piecemeal.
+     */
+    public function update(User $user, User $target): bool
+    {
+        return $user->id == $target->id || Fixometer::hasRole($user, 'Administrator');
+    }
+
+    /**
+     * Determine whether the acting user may delete (soft-delete) the target user's account.
+     */
+    public function delete(User $user, User $target): bool
+    {
+        return $user->id == $target->id || Fixometer::hasRole($user, 'Administrator');
+    }
+
+    /**
      * Determine whether one user can change the Repair Directory role of another to a specific value.
      *
      * @param  \App\User  $user

--- a/resources/views/partials/log-accordion.blade.php
+++ b/resources/views/partials/log-accordion.blade.php
@@ -20,7 +20,7 @@
                             @if(gettype($modified) == 'string')
                             <td>@lang($type.'.'.$audit->event.'.modified.'.$attribute, $modified)</td>
                             @else
-                            <td><?php echo $type.'.'.$audit->event.'.modified.'.$attribute . " " . json_encode($modified) ?></td>
+                            <td>{{ $type.'.'.$audit->event.'.modified.'.$attribute . " " . json_encode($modified) }}</td>
                             @endif
                           </tr>
                       @endforeach

--- a/tests/Feature/Groups/GroupEditTest.php
+++ b/tests/Feature/Groups/GroupEditTest.php
@@ -290,4 +290,28 @@ class GroupEditTest extends TestCase
             ],
         ]);
     }
+
+    /** @test */
+    // F005: stored XSS via audited model attributes rendered in the audit-log accordion.
+    public function audit_log_escapes_xss_payload_in_group_fields(): void
+    {
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        $group = Group::factory()->create(['website' => 'https://safe.example.com']);
+
+        // Updating an audited field records an 'updated' audit holding the new value verbatim.
+        $group->website = "<script>alert('XSSPROBE')</script>";
+        $group->save();
+
+        $response = $this->get('/group/edit/' . $group->idgroups);
+        $response->assertStatus(200);
+
+        // The injected <script> must NOT reach the admin's browser unescaped...
+        $response->assertDontSee("<script>alert('XSSPROBE')", false);
+        // ...but the value must still be displayed, HTML-escaped, in the audit log.
+        // (Blade's {{ }} uses ENT_QUOTES, so < > become &lt; &gt; and ' becomes &#039;.)
+        $response->assertSee('&lt;script&gt;alert(', false);
+        $response->assertSee('XSSPROBE', false);
+    }
 }

--- a/tests/Feature/Users/PrivilegeEscalationTest.php
+++ b/tests/Feature/Users/PrivilegeEscalationTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Feature\Users;
 
 use App\Role;
+use App\Skills;
 use App\User;
+use App\UsersSkills;
 use DB;
+use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 
 /**
@@ -181,5 +184,278 @@ class PrivilegeEscalationTest extends TestCase
         ]);
 
         $this->assertEquals('legitimate_token', $user->fresh()->api_token);
+    }
+
+    // -------------------------------------------------------------------------
+    // F001: Any user can soft-delete any other user via POST /user/soft-delete
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function restarter_cannot_soft_delete_another_user(): void
+    {
+        $this->withExceptionHandling();
+
+        $attacker = User::factory()->restarter()->create();
+        $victim   = User::factory()->restarter()->create();
+
+        $this->actingAs($attacker);
+
+        $response = $this->post('/user/soft-delete', ['id' => $victim->id]);
+
+        $response->assertStatus(403);
+        // Victim must NOT be soft-deleted.
+        $this->assertFalse(User::withTrashed()->find($victim->id)->trashed());
+    }
+
+    /** @test */
+    public function admin_can_soft_delete_another_user(): void
+    {
+        $admin  = User::factory()->administrator()->create();
+        $victim = User::factory()->restarter()->create();
+
+        $this->actingAs($admin);
+
+        $response = $this->post('/user/soft-delete', ['id' => $victim->id]);
+
+        $response->assertRedirect('user/all');
+        // Victim is soft-deleted.
+        $this->assertTrue(User::withTrashed()->find($victim->id)->trashed());
+    }
+
+    /** @test */
+    public function user_can_soft_delete_themselves(): void
+    {
+        $user = User::factory()->restarter()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->post('/user/soft-delete', ['id' => $user->id]);
+
+        $response->assertRedirect('login');
+    }
+
+    // -------------------------------------------------------------------------
+    // F002: A Host can edit/reset the password of any unrelated user via edit()
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function host_cannot_reset_unrelated_users_password_via_edit_endpoint(): void
+    {
+        $this->withExceptionHandling();
+
+        $host   = User::factory()->host()->create();
+        $victim = User::factory()->restarter()->create(['password' => bcrypt('originalPassword')]);
+
+        $this->actingAs($host);
+
+        $response = $this->post('/user/edit/' . $victim->id, [
+            'name'             => $victim->name,
+            'email'            => $victim->email,
+            'groups'           => [],
+            'new-password'     => 'hackedPassword',
+            'password-confirm' => 'hackedPassword',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertTrue(Hash::check('originalPassword', $victim->fresh()->password));
+    }
+
+    /** @test */
+    public function host_cannot_edit_unrelated_users_profile_via_edit_endpoint(): void
+    {
+        $this->withExceptionHandling();
+
+        $host   = User::factory()->host()->create();
+        $victim = User::factory()->restarter()->create(['name' => 'Original Name']);
+
+        $this->actingAs($host);
+
+        $response = $this->post('/user/edit/' . $victim->id, [
+            'name'   => 'Hacked Name',
+            'email'  => $victim->email,
+            'groups' => [],
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertEquals('Original Name', $victim->fresh()->name);
+    }
+
+    /** @test */
+    public function admin_can_reset_another_users_password_via_edit_endpoint(): void
+    {
+        $GLOBALS['_FILES'] = [];
+
+        $admin  = User::factory()->administrator()->create();
+        $target = User::factory()->restarter()->create(['password' => bcrypt('originalPassword')]);
+
+        $this->actingAs($admin);
+
+        $response = $this->post('/user/edit/' . $target->id, [
+            'name'             => $target->name,
+            'email'            => $target->email,
+            'groups'           => [],
+            'new-password'     => 'newPassword123',
+            'password-confirm' => 'newPassword123',
+        ]);
+
+        $this->assertFalse($response->isClientError());
+        $this->assertTrue(Hash::check('newPassword123', $target->fresh()->password));
+    }
+
+    /** @test */
+    public function user_can_reset_own_password_via_edit_endpoint(): void
+    {
+        $GLOBALS['_FILES'] = [];
+
+        $user = User::factory()->restarter()->create(['password' => bcrypt('originalPassword')]);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/user/edit/' . $user->id, [
+            'name'             => $user->name,
+            'email'            => $user->email,
+            'groups'           => [],
+            'new-password'     => 'newPassword123',
+            'password-confirm' => 'newPassword123',
+        ]);
+
+        $this->assertFalse($response->isClientError());
+        $this->assertTrue(Hash::check('newPassword123', $user->fresh()->password));
+    }
+
+    // -------------------------------------------------------------------------
+    // F004: Any user can overwrite any other user's skills via edit-tags
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function restarter_cannot_edit_another_users_tags(): void
+    {
+        $this->withExceptionHandling();
+
+        $attacker = User::factory()->restarter()->create();
+        $victim   = User::factory()->restarter()->create();
+
+        $this->actingAs($attacker);
+
+        $response = $this->post('/profile/edit-tags', [
+            'id'   => $victim->id,
+            'tags' => [1],
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertEmpty(UsersSkills::where('user', $victim->id)->get());
+    }
+
+    /** @test */
+    public function user_can_edit_own_tags_and_self_promote_to_host(): void
+    {
+        $user = User::factory()->restarter()->create();
+
+        // A category-1 ("organising") skill qualifies the user for the Host role by design.
+        $skill = Skills::create([
+            'skill_name'  => 'UT Host Skill',
+            'category'    => 1,
+            'description' => 'Organising',
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/profile/edit-tags', [
+            'id'   => $user->id,
+            'tags' => [$skill->id],
+        ]);
+
+        $this->assertTrue($response->isRedirection());
+        $this->assertEquals(Role::HOST, $user->fresh()->role);
+    }
+
+    // -------------------------------------------------------------------------
+    // F006: Any user can change any other user's language via edit-language
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function restarter_cannot_change_another_users_language(): void
+    {
+        $this->withExceptionHandling();
+
+        $attacker = User::factory()->restarter()->create();
+        $victim   = User::factory()->restarter()->create(['language' => 'en']);
+
+        $this->actingAs($attacker);
+
+        $response = $this->post('/profile/edit-language', [
+            'id'            => $victim->id,
+            'user_language' => 'fr',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertEquals('en', $victim->fresh()->language);
+    }
+
+    /** @test */
+    public function user_can_change_own_language(): void
+    {
+        $user = User::factory()->restarter()->create(['language' => 'en']);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/profile/edit-language', [
+            'id'            => $user->id,
+            'user_language' => 'fr',
+        ]);
+
+        $this->assertTrue($response->isRedirection());
+        $this->assertEquals('fr', $user->fresh()->language);
+    }
+
+    /** @test */
+    public function admin_can_change_another_users_language(): void
+    {
+        $admin  = User::factory()->administrator()->create();
+        $victim = User::factory()->restarter()->create(['language' => 'en']);
+
+        $this->actingAs($admin);
+
+        $response = $this->post('/profile/edit-language', [
+            'id'            => $victim->id,
+            'user_language' => 'fr',
+        ]);
+
+        $this->assertTrue($response->isRedirection());
+        $this->assertEquals('fr', $victim->fresh()->language);
+    }
+
+    // -------------------------------------------------------------------------
+    // F007: Any user can toggle any other user's invites preference
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function restarter_cannot_toggle_another_users_invites(): void
+    {
+        $this->withExceptionHandling();
+
+        $attacker = User::factory()->restarter()->create();
+        $victim   = User::factory()->restarter()->create(['invites' => 1]);
+
+        $this->actingAs($attacker);
+
+        // Omitting 'invites' attempts to set it to 0.
+        $response = $this->post('/profile/edit-preferences', ['id' => $victim->id]);
+
+        $response->assertStatus(403);
+        $this->assertEquals(1, $victim->fresh()->invites);
+    }
+
+    /** @test */
+    public function user_can_toggle_own_invites(): void
+    {
+        $user = User::factory()->restarter()->create(['invites' => 1]);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/profile/edit-preferences', ['id' => $user->id]);
+
+        $this->assertTrue($response->isRedirection());
+        $this->assertEquals(0, $user->fresh()->invites);
     }
 }

--- a/tests/Feature/Users/ProfileTest.php
+++ b/tests/Feature/Users/ProfileTest.php
@@ -60,47 +60,29 @@ class ProfileTest extends TestCase
             // Success case.
         }
 
-        // TODO These are the behaviours as coded, but they seem weird.
-        //
-        // As yourself.
+        // Let the framework render authorization failures as HTTP 403 responses.
+        $this->withExceptionHandling();
+
+        // As yourself - returns an empty response.
         $this->actingAs($user1);
-
         $response = $this->post('/user/edit/'.$user1->id, $editdata);
-
         $this->assertEquals('', $response->getContent());
 
-        // A restart acting on another restart - should be unauthorized.
+        // A restarter acting on another restarter - should be unauthorized.
         $this->actingAs($user2);
+        $this->post('/user/edit/'.$user1->id, $editdata)->assertStatus(403);
 
-        try {
-            $response = $this->post('/user/edit/'.$user1->id, $editdata);
-            $this->assertFalse(true); // Should not reach here
-        } catch (\Symfony\Component\HttpKernel\Exception\HttpException $e) {
-            $this->assertEquals(403, $e->getStatusCode());
-        }
-
-        // A host acting on a restarter - can.
+        // A host acting on an unrelated restarter - should be unauthorized (F002 account-takeover fix).
         $this->actingAs($host);
-
-        $response = $this->post('/user/edit/'.$user1->id, $editdata);
-
-        $response->assertSee('Edit User');
+        $this->post('/user/edit/'.$user1->id, $editdata)->assertStatus(403);
 
         // A network coordinator acting on a restarter - should be unauthorized.
         $this->actingAs($nc);
-
-        try {
-            $response = $this->post('/user/edit/'.$user1->id, $editdata);
-            $this->assertFalse(true); // Should not reach here
-        } catch (\Symfony\Component\HttpKernel\Exception\HttpException $e) {
-            $this->assertEquals(403, $e->getStatusCode());
-        }
+        $this->post('/user/edit/'.$user1->id, $editdata)->assertStatus(403);
 
         // An administrator acting on a restarter - can.
         $this->actingAs($admin);
-
         $response = $this->post('/user/edit/'.$user1->id, $editdata);
-
         $response->assertSee('Edit User');
     }
 
@@ -108,7 +90,8 @@ class ProfileTest extends TestCase
     {
         $GLOBALS['_FILES'] = [];
         $user1 = User::factory()->restarter()->create();
-        $host = User::factory()->host()->create();
+        // An administrator is authorised to edit the user, so reaches the password-mismatch path.
+        $admin = User::factory()->administrator()->create();
 
         $editdata = [
             'id' => $user1->id,
@@ -119,7 +102,7 @@ class ProfileTest extends TestCase
             'password-confirm' => 'test2',
         ];
 
-        $this->actingAs($host);
+        $this->actingAs($admin);
         $response = $this->post('/user/edit/'.$user1->id, $editdata);
 
         $response->assertSee('The passwords are not identical!');


### PR DESCRIPTION
## Summary

Fixes six security findings (post-`C1/C2/M1`) in the user-account endpoints and the audit log. All were confirmed present on `develop`.

| ID | Severity | Issue | Fix |
|----|----------|-------|-----|
| F001 | HIGH | `postSoftDeleteUser` soft-deletes any user by `id` (IDOR — any user can delete anyone, incl. admins) | `UserPolicy@delete` (self or admin) |
| F002 | HIGH | `edit()` lets any **Host** edit/reset-password of any user → account takeover | Remove Host bypass + dead redirect branch; `UserPolicy@update` |
| F004 | LOW | `edit-tags` overwrites any user's skills (IDOR) | `UserPolicy@update` (self-promote to Host preserved) |
| F005 | MEDIUM | Stored XSS in the audit-log accordion, executes in an **admin's** session | Blade `{{ }}` auto-escaping |
| F006 | LOW | `edit-language` changes any user's language (IDOR) | `UserPolicy@update` |
| F007 | LOW | `edit-preferences` toggles any user's `invites` (IDOR) | `UserPolicy@update` |

Authorization is **centralized in `UserPolicy`** (`update`/`delete` = "self or administrator"). The already-merged C1 self-or-admin endpoints (`edit-info` / `edit-password` / `edit-photo`) are migrated to the same policy so the check can no longer be omitted piecemeal. `postAdminEdit` keeps its existing admin-only guard (distinct rule, already correct).

### F002 — why removing the Host bypass is safe
- The UI link to `/user/edit/{id}` is rendered for **Administrators only** (`user/all.blade.php`).
- The matching GET form (`getProfileEdit`) already blocks Hosts from editing other users.
- The `@header('Location: /host?action=ue&code=200')` branch is dead (no view consumes `action=ue`).
- Notification "edit preferences" links are self-referential (`$notifiable`'s own id) and remain valid.

## Test plan — TDD (tests written first, watched fail on the vulnerable code, then made green)

- `PrivilegeEscalationTest` (new cases): cross-user delete / edit / tags / language / preferences all return **403**; a Host cannot edit or reset another user's password; **self and admin still succeed**; self-promotion to Host via a category-1 skill is preserved.
- `GroupEditTest::audit_log_escapes_xss_payload_in_group_fields`: an injected `<script>` in an audited field renders HTML-escaped, not raw.
- Updated `ProfileTest::testEdit` / `testEditBadPassword` to assert the secured behaviour (Host now 403; an admin reaches the password-mismatch path).
- Run green locally via `task docker:test:phpunit` (`PrivilegeEscalationTest`, `ProfileTest`, `GroupEditTest` XSS, `EditProfileTest`, `UserAdminTest`).

## Related

- Parallel security PR #879 (volunteer PII leak on public event pages) — **independent scope**, can merge separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCxx4qQJu1z4GWomNx7tm1
