### PR TITLE
test: bind a deterministic geocoder globally to fix flaky "nearby" tests

### DIFF
--- a/tests/Feature/Events/CreateEventTest.php
+++ b/tests/Feature/Events/CreateEventTest.php
@@ -7,7 +7,6 @@ use App\Events\UserLeftEvent;
 use App\EventsUsers;
 use App\Group;
 use App\Helpers\Fixometer;
-use App\Helpers\Geocoder;
 use App\Helpers\RepairNetworkService;
 use App\Listeners\AddUserToDiscourseThreadForEvent;
 use App\Listeners\RemoveUserFromDiscourseThreadForEvent;
@@ -26,36 +25,8 @@ use Tests\TestCase;
 use App\Notifications\EventConfirmed;
 use Illuminate\Validation\ValidationException;
 
-class GeocoderMock extends Geocoder
-{
-    public function __construct()
-    {
-    }
-
-    public function geocode($location)
-    {
-        if ($location == 'ForceGeocodeFailure') {
-            return null;
-        }
-
-        return [
-            'latitude' => '1',
-            'longitude' => '1',
-        ];
-    }
-}
-
 class CreateEventTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->app->bind(Geocoder::class, function () {
-            return new GeocoderMock();
-        });
-    }
-
     /** @test */
     public function a_host_without_a_group_cant_create_an_event(): void
     {

--- a/tests/Feature/Events/OnlineEventsTest.php
+++ b/tests/Feature/Events/OnlineEventsTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Device;
 use App\EventsUsers;
 use App\Group;
-use App\Helpers\Geocoder;
 use App\Network;
 use App\Notifications\NotifyRestartersOfNewEvent;
 use App\Party;
@@ -19,15 +18,6 @@ use Tests\TestCase;
 
 class OnlineEventsTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->app->bind(Geocoder::class, function () {
-            return new GeocoderMock();
-        });
-    }
-
     /** @test */
     public function a_host_can_create_an_online_event(): void
     {

--- a/tests/Support/GeocoderMock.php
+++ b/tests/Support/GeocoderMock.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Helpers\Geocoder;
+
+/**
+ * Deterministic Geocoder for the test suite.
+ *
+ * The real Geocoder makes a live HTTP call to the Google Maps Geocoding API. That
+ * API is rate-limited and intermittently errors, so any test that geocodes a
+ * location (event/group creation, "nearby" calculations) was at the mercy of the
+ * network — most visibly BasicTest::testUpcomingEvents, which flaked with
+ * "Undefined array key 'nearby'" whenever a live geocode failed and the event lost
+ * its coordinates.
+ *
+ * This fake is bound globally in Tests\TestCase::setUp() so no test ever hits the
+ * live API. Tests that specifically exercise the geocode-failure path bind their
+ * own failing mock in their setUp(), which overrides this binding.
+ */
+class GeocoderMock extends Geocoder
+{
+    public function __construct()
+    {
+    }
+
+    public function geocode($location)
+    {
+        // Preserve the real Geocoder's sentinel so failure-path tests still work.
+        if ($location === 'ForceGeocodeFailure') {
+            return null;
+        }
+
+        // Central London. The bulk of the test fixtures (createGroup() and
+        // PartyFactory both default to London) resolve here, and several
+        // distance-based "nearby" assertions compare against hard-coded London
+        // coordinates, so pinning every fixture to a single real London point
+        // keeps that logic deterministic and matches what the live API returned
+        // for these locations.
+        return [
+            'latitude' => 51.5073509,
+            'longitude' => -0.1277583,
+            'country_code' => 'GB',
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ use App\EventsUsers;
 use App\Group;
 use App\GroupNetwork;
 use App\GroupTags;
+use App\Helpers\Geocoder;
 use App\Images;
 use App\Network;
 use App\Party;
@@ -35,6 +36,7 @@ use Osteel\OpenApi\Testing\ValidatorBuilder;
 use Osteel\OpenApi\Testing\Exceptions\ValidationException;
 use ReflectionFunction;
 use Illuminate\Events\Dispatcher;
+use Tests\Support\GeocoderMock;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -114,6 +116,14 @@ abstract class TestCase extends BaseTestCase
 
         $this->withoutExceptionHandling();
         app('honeypot')->disable();
+
+        // Bind a deterministic geocoder so the suite never makes live calls to the
+        // Google Maps Geocoding API (rate-limited / intermittently failing, which
+        // made any geocoding test flaky). Tests that need the geocode-failure path
+        // bind their own failing mock in setUp(), overriding this.
+        $this->app->bind(Geocoder::class, function () {
+            return new GeocoderMock();
+        });
 
         // Create categories defensively - only if they don't already exist
         if (!Category::where('idcategories', 111)->exists()) {


### PR DESCRIPTION
## Problem

`Dashboard\BasicTest::testUpcomingEvents` intermittently fails with:

```
ErrorException : Undefined array key "nearby"
tests/Feature/Dashboard/BasicTest.php:194
```

It passes in isolation and on other branches — classic flake. Root cause: the test depends on a **live** call to the Google Maps Geocoding API.

`App\Helpers\Geocoder::geocode()` does a `file_get_contents()` against `maps.googleapis.com` and returns `false` on any failure. That API is rate-limited and currently runs at ~20% errors (visible on the GCP dashboard). When the live geocode for the event's location fails, the event gets no coordinates, so it's excluded by the inner-joined `Party::scopeUpcomingEventsInUserArea` distance query, falls through to the "all upcoming" branch (which never sets `nearby`), and the assertion hits a missing key.

`BasicTest` was the one relevant test **not** mocking the geocoder — its siblings (`CreateEventTest`, `OnlineEventsTest`) each defined their own `GeocoderMock`, and three more files (`AttendanceTest`, `DeleteEventTest`, `AddRemoveVolunteerTest`) silently hit the live API too.

## Change

- Add a single deterministic `Tests\Support\GeocoderMock` and **bind it globally in `TestCase::setUp()`**, so no test ever calls the live API.
- Remove the duplicated per-test `GeocoderMock` + bindings from `CreateEventTest` and `OnlineEventsTest`.
- `GroupEditGeocodeFallbackTest` keeps its own failing mock (it exercises the geocode-failure path); its `setUp()` binding overrides the global one.
- The mock preserves the real `ForceGeocodeFailure` sentinel and resolves fixtures to central London (matching what the live API returned for the London-based test fixtures), so distance-based "nearby" assertions stay deterministic.

This also stops the test suite from contributing to live Geocoding API traffic.

## Verification

Ran locally (`task docker:test:phpunit`), all green:

| Test(s) | Result |
|---|---|
| `Dashboard/Groups/Style BasicTest` (`testUpcomingEvents`, `testPageLoads`) | OK (12 tests, 278 assertions) |
| `CreateEventTest` + `OnlineEventsTest` + `GroupEditGeocodeFallbackTest` | OK (20 tests, 271 assertions) |
| `AttendanceTest` | OK (2 tests, 22 assertions) |
| `DeleteEventTest` | OK (18 tests, 294 assertions) |
| `AddRemoveVolunteerTest` | OK (8 tests, 112 assertions) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)