### PR TITLE
fix(backup): stop the Google Drive API request storm from db-backup.sh

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -73,6 +73,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gettext-base \
     redis-server \
     procps \
+    util-linux \
     default-mysql-client \
     rclone \
     libpng-dev libjpeg62-turbo-dev libfreetype6-dev libzip-dev libicu-dev libxml2-dev \
@@ -136,7 +137,8 @@ COPY docker/restart-yesterday.sh /usr/local/bin/restart-yesterday.sh
 RUN chmod +x /usr/local/bin/db-backup.sh /usr/local/bin/restart-yesterday.sh
 
 # Set up cron: Laravel scheduler + queue watchdog + hourly DB backup + daily yesterday restart (5am UTC)
-RUN printf '* * * * * cd /var/www && php artisan schedule:run >> /dev/null 2>&1\n* * * * * /usr/local/bin/queue-watchdog.sh\n0 * * * * /usr/local/bin/db-backup.sh\n0 5 * * * /usr/local/bin/restart-yesterday.sh\n' | crontab -
+# flock -n guards the backup so a slow run can never overlap with the next hourly invocation.
+RUN printf '* * * * * cd /var/www && php artisan schedule:run >> /dev/null 2>&1\n* * * * * /usr/local/bin/queue-watchdog.sh\n0 * * * * flock -n /tmp/db-backup.lock /usr/local/bin/db-backup.sh\n0 5 * * * /usr/local/bin/restart-yesterday.sh\n' | crontab -
 
 # Set working directory
 WORKDIR /var/www

--- a/docker/db-backup.sh
+++ b/docker/db-backup.sh
@@ -81,6 +81,12 @@ rm -f "$BACKUP_FILE"
 # 168 hourly backups (7 days), so the list+delete pass only needs to run daily; doing
 # it every hour just wastes Drive API calls. Between prunes the count drifts up to ~192
 # (8 days), which is harmless.
+#
+# IMPORTANT: deletion requires the backup service account to have **Content Manager**
+# (not just Contributor) on the Shared Drive. With only Contributor it can upload and
+# list but every delete is rejected (403 insufficientFilePermissions / 404), so backups
+# accumulate without bound and the hourly retry of rejected deletes becomes a Drive API
+# request storm. Grant Content Manager on the Shared Drive for this to actually prune.
 if [ "$(date -u +%H)" = "03" ]; then
     # Keep only the last 168 hourly backups on Google Drive.
     # List all backups newest-first and delete everything past the 168th.

--- a/docker/db-backup.sh
+++ b/docker/db-backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Daily MySQL backup to Google Drive
-# Cron runs this daily at 2am UTC; logs to /var/log/db-backup.log
+# Hourly MySQL backup to Google Drive
+# Cron runs this hourly (see Dockerfile.fly); logs to /var/log/db-backup.log
 
 LOG=/var/log/db-backup.log
 
@@ -55,9 +55,16 @@ fi
 
 # Upload to Google Drive using rclone
 # --drive-root-folder-id targets the folder by its Drive ID (not by name path)
+# Rate-limit / retry caps (--tpslimit, --drive-pacer-min-sleep, --retries,
+# --low-level-retries) ensure a transient Drive error can never become a request
+# storm. --drive-chunk-size 64M cuts the number of upload requests ~8x vs the 8M
+# default. --drive-use-trash=false deletes permanently (also frees Shared Drive quota).
 if ! rclone copy "$BACKUP_FILE" "gdrive:" \
     --drive-root-folder-id="$GDRIVE_BACKUP_FOLDER_ID" \
     --drive-team-drive="$RCLONE_CONFIG_GDRIVE_TEAM_DRIVE" \
+    --tpslimit=2 --drive-pacer-min-sleep=200ms \
+    --retries=2 --low-level-retries=3 \
+    --drive-chunk-size=64M --drive-use-trash=false \
     --log-file="$LOG" \
     --log-level=INFO 2>>"$LOG"; then
     echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): ERROR - rclone upload failed" >> "$LOG"
@@ -70,19 +77,28 @@ echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Uploaded $BACKUP_NAME to Google Drive
 # Clean up local backup file
 rm -f "$BACKUP_FILE"
 
-# Keep only the last 7 daily backups on Google Drive
-# List all backups in reverse chronological order and delete older ones
-BACKUPS=$(rclone lsf "gdrive:" --drive-root-folder-id="$GDRIVE_BACKUP_FOLDER_ID" --drive-team-drive="$RCLONE_CONFIG_GDRIVE_TEAM_DRIVE" --format=p 2>/dev/null | grep 'db-backup-.*\.sql\.gz' | sort -r)
-BACKUP_COUNT=$(echo "$BACKUPS" | grep -c 'db-backup')
+# Prune old backups once per day, at 03:00 UTC, rather than every hour. Retention is
+# 168 hourly backups (7 days), so the list+delete pass only needs to run daily; doing
+# it every hour just wastes Drive API calls. Between prunes the count drifts up to ~192
+# (8 days), which is harmless.
+if [ "$(date -u +%H)" = "03" ]; then
+    # Keep only the last 168 hourly backups on Google Drive.
+    # List all backups newest-first and delete everything past the 168th.
+    BACKUPS=$(rclone lsf "gdrive:" --drive-root-folder-id="$GDRIVE_BACKUP_FOLDER_ID" --drive-team-drive="$RCLONE_CONFIG_GDRIVE_TEAM_DRIVE" --tpslimit=2 --drive-pacer-min-sleep=200ms --retries=2 --low-level-retries=3 --format=p 2>/dev/null | grep 'db-backup-.*\.sql\.gz' | sort -r)
+    BACKUP_COUNT=$(echo "$BACKUPS" | grep -c 'db-backup')
 
-if [ "$BACKUP_COUNT" -gt 168 ]; then
-    BACKUPS_TO_DELETE=$(echo "$BACKUPS" | tail -n +169)
-    while IFS= read -r backup; do
-        if [ -n "$backup" ]; then
-            echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Deleting old backup: $backup" >> "$LOG"
-            rclone delete "gdrive:$backup" --drive-root-folder-id="$GDRIVE_BACKUP_FOLDER_ID" --drive-team-drive="$RCLONE_CONFIG_GDRIVE_TEAM_DRIVE" 2>>"$LOG" || true
-        fi
-    done <<< "$BACKUPS_TO_DELETE"
+    if [ "$BACKUP_COUNT" -gt 168 ]; then
+        BACKUPS_TO_DELETE=$(echo "$BACKUPS" | tail -n +169)
+        while IFS= read -r backup; do
+            if [ -n "$backup" ]; then
+                echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Deleting old backup: $backup" >> "$LOG"
+                # `rclone deletefile` removes a single named file. (`rclone delete` treats its
+                # argument as a directory to enumerate, so for a file path it deletes nothing
+                # while still issuing API calls — the bug that let backups accumulate forever.)
+                rclone deletefile "gdrive:$backup" --drive-root-folder-id="$GDRIVE_BACKUP_FOLDER_ID" --drive-team-drive="$RCLONE_CONFIG_GDRIVE_TEAM_DRIVE" --tpslimit=2 --drive-pacer-min-sleep=200ms --retries=2 --low-level-retries=3 --drive-use-trash=false 2>>"$LOG" || true
+            fi
+        done <<< "$BACKUPS_TO_DELETE"
+    fi
 fi
 
 echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Database backup completed successfully" >> "$LOG"

--- a/docker/db-backup.sh
+++ b/docker/db-backup.sh
@@ -57,14 +57,13 @@ fi
 # --drive-root-folder-id targets the folder by its Drive ID (not by name path)
 # Rate-limit / retry caps (--tpslimit, --drive-pacer-min-sleep, --retries,
 # --low-level-retries) ensure a transient Drive error can never become a request
-# storm. --drive-chunk-size 64M cuts the number of upload requests ~8x vs the 8M
-# default. --drive-use-trash=false deletes permanently (also frees Shared Drive quota).
+# storm. --drive-chunk-size 64M cuts the number of upload requests ~8x vs the 8M default.
 if ! rclone copy "$BACKUP_FILE" "gdrive:" \
     --drive-root-folder-id="$GDRIVE_BACKUP_FOLDER_ID" \
     --drive-team-drive="$RCLONE_CONFIG_GDRIVE_TEAM_DRIVE" \
     --tpslimit=2 --drive-pacer-min-sleep=200ms \
     --retries=2 --low-level-retries=3 \
-    --drive-chunk-size=64M --drive-use-trash=false \
+    --drive-chunk-size=64M \
     --log-file="$LOG" \
     --log-level=INFO 2>>"$LOG"; then
     echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): ERROR - rclone upload failed" >> "$LOG"
@@ -99,9 +98,11 @@ if [ "$(date -u +%H)" = "03" ]; then
             if [ -n "$backup" ]; then
                 echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC'): Deleting old backup: $backup" >> "$LOG"
                 # `rclone deletefile` removes a single named file. (`rclone delete` treats its
-                # argument as a directory to enumerate, so for a file path it deletes nothing
-                # while still issuing API calls — the bug that let backups accumulate forever.)
-                rclone deletefile "gdrive:$backup" --drive-root-folder-id="$GDRIVE_BACKUP_FOLDER_ID" --drive-team-drive="$RCLONE_CONFIG_GDRIVE_TEAM_DRIVE" --tpslimit=2 --drive-pacer-min-sleep=200ms --retries=2 --low-level-retries=3 --drive-use-trash=false 2>>"$LOG" || true
+                # argument as a directory to enumerate, so for a file path it deletes nothing.)
+                # Deletes go to the Shared Drive trash (auto-emptied after 30 days). Do NOT add
+                # --drive-use-trash=false: permanent delete returns 404 for this service account
+                # on the Shared Drive; the trash path is what actually works.
+                rclone deletefile "gdrive:$backup" --drive-root-folder-id="$GDRIVE_BACKUP_FOLDER_ID" --drive-team-drive="$RCLONE_CONFIG_GDRIVE_TEAM_DRIVE" --tpslimit=2 --drive-pacer-min-sleep=200ms --retries=2 --low-level-retries=3 2>>"$LOG" || true
             fi
         done <<< "$BACKUPS_TO_DELETE"
     fi


### PR DESCRIPTION
## Problem

The Google Drive API for the project was taking a **steadily increasing** request volume (1.7M requests / 14 days, ~27% errors). The only Drive consumer is the hourly `docker/db-backup.sh` cron job, whose retention prune never worked, so backups accumulated (825 files vs the intended 168) and **every** hourly run re-attempted to delete all ~650 excess files — with retries — producing the storm.

## True root cause (confirmed live on production)

The deletes were being **rejected**, not silently skipped — two distinct issues, both found by testing on the live machine:

1. **Permissions.** The backup service account only had **Contributor** on the Shared Drive, so every delete returned `403 insufficientFilePermissions`. Re-attempting 650+ rejected deletes hourly (×3 retries) is the storm and the ~27% errors. → Fixed by granting the SA **Content Manager**.
2. **Permanent delete 404s.** Even as Content Manager, `--drive-use-trash=false` returns `404` for this SA on the Shared Drive. Deletion only works via the **default trash** path (Shared Drive trash auto-empties after 30 days).

Secondary bug: `rclone delete` is the wrong command for a single file (it treats its arg as a directory); the correct command is `rclone deletefile`.

## Code changes (this PR)

- **`rclone deletefile`** instead of `rclone delete` (correct single-file deletion), via the **trash** path (no `--drive-use-trash=false`).
- **Prune once/day (03:00 UTC)** instead of every hour.
- **Request-amplification caps on every rclone call:** `--tpslimit 2 --drive-pacer-min-sleep 200ms --retries 2 --low-level-retries 3`; on upload `--drive-chunk-size 64M`.
- **`flock -n /tmp/db-backup.lock`** on the cron entry so a slow run can never overlap the next hourly invocation (added `util-linux` so `flock` is guaranteed present).
- Comments documenting the **Content Manager** requirement and the trash-vs-permanent behaviour; fixed the stale `# Daily … 2am` header.

## Already applied + verified live on production (ahead of this deploy)

- SA granted **Content Manager**; **backlog purged 825 → 168** (newest 7 days kept; older sent to Shared Drive trash, 0 errors).
- Corrected script pushed to the running machine; crontab `flock` guard added.
- **End-to-end verified:** a manual run dumped + uploaded a 99.9 MiB backup successfully, with the `--tpslimit 2` limiter confirmed active.

> ⚠️ The live-machine edits are on the running container only and are **lost on the next deploy/restart** — merge + deploy this PR (via the production branch) to make the fix permanent.

`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
