### PR TITLE
test: make geocoding deterministic (location-aware mock + DI) and block Maps in E2E

### DIFF
--- a/app/Console/Commands/CheckGroupLocations.php
+++ b/app/Console/Commands/CheckGroupLocations.php
@@ -37,7 +37,7 @@ class CheckGroupLocations extends Command
     public function handle(): void
     {
         $groups = Group::where('approved', true)->get();
-        $geocoder = new \App\Helpers\Geocoder();
+        $geocoder = app(\App\Helpers\Geocoder::class);
 
         foreach ($groups as $group) {
             if (! $group->location) {

--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -730,7 +730,7 @@ class EventController extends Controller
         }
 
         if (!empty($location)) {
-            $geocoder = new \App\Helpers\Geocoder();
+            $geocoder = app(\App\Helpers\Geocoder::class);
             $geocoded = $geocoder->geocode($location);
 
             if (empty($geocoded)) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -861,7 +861,7 @@ class UserController extends Controller
 
     public function postRegister(Request $request, $hash = null): RedirectResponse
     {
-        $geocoder = new \App\Helpers\Geocoder();
+        $geocoder = app(\App\Helpers\Geocoder::class);
 
         if (Auth::check()) { //Existing users don't need all the same rules
             $rules = [

--- a/tests/Integration/fixtures.js
+++ b/tests/Integration/fixtures.js
@@ -21,8 +21,16 @@ const test = base.extend({
             'X-Playwright-Test': 'true'
           }
         });
+      } else if (/maps\.googleapis\.com|maps\.gstatic\.com|maps\.google\.|\.ggpht\.com|khms\d/i.test(url)) {
+        // Google Maps JS and tiles never finish loading in the headless Docker
+        // environment, so the page 'load' event never fires and any navigation that
+        // waits for it (the default for page.goto) hangs until the per-test timeout —
+        // which silently eats >10 min and trips CircleCI's no-output timeout. The app
+        // already tolerates the map not rendering, so abort these requests; 'load' then
+        // fires and navigations complete. No test asserts on the map.
+        await route.abort();
       } else {
-        // For CDN and external resources, don't add the header
+        // For other CDN and external resources, don't add the header
         await route.continue();
       }
     });

--- a/tests/Support/GeocoderMock.php
+++ b/tests/Support/GeocoderMock.php
@@ -5,18 +5,21 @@ namespace Tests\Support;
 use App\Helpers\Geocoder;
 
 /**
- * Deterministic Geocoder for the test suite.
+ * Deterministic, location-aware Geocoder for the test suite.
  *
- * The real Geocoder makes a live HTTP call to the Google Maps Geocoding API. That
- * API is rate-limited and intermittently errors, so any test that geocodes a
- * location (event/group creation, "nearby" calculations) was at the mercy of the
- * network — most visibly BasicTest::testUpcomingEvents, which flaked with
- * "Undefined array key 'nearby'" whenever a live geocode failed and the event lost
- * its coordinates.
+ * The real Geocoder makes a live HTTP call to the Google Maps Geocoding API, which is
+ * rate-limited and non-deterministic. Tests that geocode a location were at the mercy
+ * of Google's responses — e.g. APIv2GroupTest::testLocales flipped between Belgium and
+ * the United Kingdom, and the "bad location" tests only passed while Google happened to
+ * reject the gibberish string.
  *
- * This fake is bound globally in Tests\TestCase::setUp() so no test ever hits the
- * live API. Tests that specifically exercise the geocode-failure path bind their
- * own failing mock in their setUp(), which overrides this binding.
+ * This fake is bound globally in Tests\TestCase::setUp() so no test hits the live API.
+ * It recognises the specific places the suite uses and returns fixed results for them;
+ * anything it does not recognise (gibberish like "zzzz", "ZZZZ", or the
+ * ForceGeocodeFailure sentinel) returns null — a geocode failure — which is exactly
+ * what the bad-location / invalid-location tests assert.
+ *
+ * Tests that need a different result bind their own mock in setUp(), overriding this.
  */
 class GeocoderMock extends Geocoder
 {
@@ -26,21 +29,31 @@ class GeocoderMock extends Geocoder
 
     public function geocode($location)
     {
-        // Preserve the real Geocoder's sentinel so failure-path tests still work.
-        if ($location === 'ForceGeocodeFailure') {
-            return null;
+        // Match on CITY names only, never on an appended country. The profile editor
+        // geocodes "<townCity>, <country>" (e.g. "ZZZZ, United Kingdom"), so matching a
+        // country name would wrongly turn gibberish towns into a valid location.
+        $loc = strtolower((string) $location);
+
+        // Belgian cities used in tests ("Brussels, Belgium", "Ghent, Belgium").
+        if (str_contains($loc, 'brussels') || str_contains($loc, 'ghent')) {
+            return ['latitude' => 50.8503, 'longitude' => 4.3517, 'country_code' => 'BE'];
         }
 
-        // Central London. The bulk of the test fixtures (createGroup() and
-        // PartyFactory both default to London) resolve here, and several
-        // distance-based "nearby" assertions compare against hard-coded London
-        // coordinates, so pinning every fixture to a single real London point
-        // keeps that logic deterministic and matches what the live API returned
-        // for these locations.
-        return [
-            'latitude' => 51.5073509,
-            'longitude' => -0.1277583,
-            'country_code' => 'GB',
-        ];
+        // Lancaster, UK (group / network creation tests) — kept distinct from London so
+        // any distance-based logic stays correct.
+        if (str_contains($loc, 'lancaster')) {
+            return ['latitude' => 54.0466, 'longitude' => -2.7988, 'country_code' => 'GB'];
+        }
+
+        // London — the bulk of the fixtures (createGroup() default, the PartyFactory
+        // default address "… London SW9 7QD", "London", "London, UK", "London, United Kingdom").
+        if (str_contains($loc, 'london')) {
+            return ['latitude' => 51.5073509, 'longitude' => -0.1277583, 'country_code' => 'GB'];
+        }
+
+        // Anything else — gibberish ("zzzz", "ZZZZ, United Kingdom"), the ForceGeocodeFailure
+        // sentinel, an unknown place — is a geocode failure (null), matching the real API for
+        // un-geocodable input.
+        return null;
     }
 }


### PR DESCRIPTION
Follow-up to #882. The fixed-"London" stub merged in #882 returns London for **every** location, which deterministically breaks the location-specific tests on develop:

- `APIv2GroupTest::testLocales` — "Brussels, Belgium" → London → asserts Belgium, gets United Kingdom
- `GroupCreateTest::testCreateBadLocation` / `GroupEditTest::invalid_location` — gibberish → London → expected ValidationException never thrown
- `EditProfileTest::test_location_update` — "ZZZZ" → London `51.5073509` → expected null

## Fix
- **Location-aware `GeocoderMock`**: London/Lancaster→GB, Brussels/Ghent→BE, and anything unrecognised (gibberish, `ForceGeocodeFailure`)→null (geocode failure). Matches every location string the suite uses; matches on city, never the appended country (so "ZZZZ, United Kingdom" correctly fails).
- **Route geocoding through DI**: `EventController`, `UserController::postRegister`, `CheckGroupLocations` did `new Geocoder()`, bypassing the bound mock and hitting live Google (which hung the suite). Now `app(Geocoder::class)`; production resolves the same singleton.
- **Block Google Maps in Playwright fixtures**: Maps JS/tiles never finish loading in headless Docker, so the page `load` event never fires and navigations hang past CircleCI's 10-min no-output timeout. Abort Maps requests so `load` fires.

Full PHPUnit suite green locally (516 tests, 0 failures) and CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)