### PR TITLE
ci: stop restarters-dev nightly to save cost

### DIFF
--- a/.github/workflows/stop-dev-nightly.yml
+++ b/.github/workflows/stop-dev-nightly.yml
@@ -1,0 +1,45 @@
+name: Stop restarters-dev nightly
+
+# Stops the restarters-dev Fly machine(s) every night to avoid paying for the
+# dev/staging box while it sits idle overnight.
+#
+# How it stays cheap but stays usable:
+#   * fly.dev.toml has auto_stop_machines = "off", so Fly never auto-stops the
+#     box during the day AND never auto-restarts a machine we stop here
+#     (min_machines_running is only enforced when auto_stop is enabled, so it is
+#     inert for us — verified: a manual `fly machine stop` stays stopped).
+#   * fly.dev.toml has auto_start_machines = true, so the machine boots again
+#     automatically the first time anyone makes a request in the morning.
+#
+# Net effect: off overnight (no CPU billing), back on demand. A stopped machine
+# still keeps its volume, so no data is lost.
+#
+# NOTE ON TIME: GitHub Actions cron is UTC and does NOT follow BST/DST.
+#   0 2 * * *  ==  02:00 UTC  ==  03:00 London in summer (BST) / 02:00 in winter.
+# Adjust the cron if you want exactly 02:00 London year-round.
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # 02:00 UTC daily
+  workflow_dispatch: {}   # allow manual runs from the Actions tab
+
+jobs:
+  stop-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Stop all restarters-dev machines
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          ids=$(flyctl machine list -a restarters-dev --json | jq -r '.[].id')
+          if [ -z "$ids" ]; then
+            echo "No machines found for restarters-dev — nothing to stop."
+            exit 0
+          fi
+          for id in $ids; do
+            echo "Stopping machine $id"
+            flyctl machine stop "$id" -a restarters-dev
+          done
+          echo "Done. Machines will auto-start on the next request."

--- a/.github/workflows/stop-dev-nightly.yml
+++ b/.github/workflows/stop-dev-nightly.yml
@@ -27,7 +27,9 @@ jobs:
   stop-dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      # Pinned to a full commit SHA (supply-chain hardening; SonarCloud S7637).
+      # ed8efb3 = superfly/flyctl-actions master as of 2026-07-03.
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
       - name: Stop all restarters-dev machines
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Adds a scheduled GitHub Actions workflow that **stops the `restarters-dev` Fly machine(s) every night at 02:00 UTC** so we don't pay for the dev/staging box while it's idle overnight.

## Why it's safe / how it works
- `fly.dev.toml` has `auto_stop_machines = "off"` → Fly won't auto-stop the box during the day, and won't auto-restart a machine we stop here (`min_machines_running` is only enforced when autostop is enabled, so it's inert — **verified**: a manual `fly machine stop` stayed stopped).
- `fly.dev.toml` has `auto_start_machines = true` → the machine boots again automatically the first time anyone hits it in the morning (**verified**: a request cold-started it back to `started`).
- Stopped machines keep their volume, so **no data is lost**.

Net effect: **off overnight (no CPU billing), back on demand.**

Reuses the existing `FLY_API_TOKEN` repo secret. Also runnable on demand via **workflow_dispatch** (Actions tab → Run workflow).

## Note on time zone
GitHub Actions cron is **UTC** and doesn't follow BST/DST:
`0 2 * * *` = 02:00 UTC = 03:00 London in summer (BST) / 02:00 in winter. Nudge the cron if you want exactly 02:00 London year-round.

> Scheduled workflows only fire once this is on the default branch (`develop`), so it starts running the night after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)