### PR TITLE
Group view: fetch group + permission flags from /api/v2/groups/{id} (Group 4.1)

### DIFF
--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -383,7 +383,59 @@ class GroupController extends Controller
      */
     public static function getGroupv2(Request $request, $idgroups) {
         $group = Group::findOrFail($idgroups);
-        return \App\Http\Resources\Group::make($group);
+
+        // This endpoint is not behind auth:api, so the request may be anonymous.  Try session auth first (the
+        // group view page is loaded via a normal browser session), then fall back to API token auth.  If there is
+        // no authenticated user at all, every permission flag is false.
+        $user = Auth::user();
+        if (! $user) {
+            $user = auth('api')->user();
+        }
+
+        $permissions = self::groupPermissionsFor($user, $group);
+
+        return \App\Http\Resources\Group::make($group)->additional([
+            'data' => [
+                'permissions' => $permissions,
+            ],
+        ]);
+    }
+
+    /**
+     * Compute the UI show/hide permission flags for a given (possibly null) user against a group.
+     *
+     * These flags are for UI purposes only - the actual edit/delete/archive endpoints enforce their own
+     * authorization independently.  Mirrors the logic previously computed server-side in group/view.blade.php.
+     */
+    private static function groupPermissionsFor(?User $user, Group $group): array
+    {
+        if (! $user) {
+            return [
+                'can_edit' => false,
+                'can_demote' => false,
+                'can_see_delete' => false,
+                'can_perform_delete' => false,
+                'can_perform_archive' => false,
+            ];
+        }
+
+        $isAdministrator = Fixometer::hasRole($user, 'Administrator');
+        $isCoordinatorForGroup = $user->isCoordinatorForGroup($group);
+        $isHostOfGroup = Fixometer::userHasEditGroupPermission($group->idgroups, $user->id);
+
+        $canEdit = $isAdministrator || $isCoordinatorForGroup || $isHostOfGroup;
+        $canDemote = $isAdministrator || $isCoordinatorForGroup;
+        $canSeeDelete = $isAdministrator;
+        $canPerformDelete = $canSeeDelete && $group->canDelete();
+        $canPerformArchive = $isAdministrator || $isCoordinatorForGroup;
+
+        return [
+            'can_edit' => $canEdit,
+            'can_demote' => $canDemote,
+            'can_see_delete' => $canSeeDelete,
+            'can_perform_delete' => $canPerformDelete,
+            'can_perform_archive' => $canPerformArchive,
+        ];
     }
 
     /**

--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -260,6 +260,42 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *          title="archived_at",
  *          description="If present, this group has been archived and is no longer active.",
  *          format="date-time",
+ *     ),
+ *     @OA\Property(
+ *          property="permissions",
+ *          title="permissions",
+ *          description="UI show/hide permission flags for the currently authenticated user (only present on the single-group endpoint).  These are for UI purposes only - the edit/delete/archive endpoints enforce their own authorization independently.  When there is no authenticated user, every flag is false.",
+ *          format="object",
+ *          @OA\Property(
+ *              property="can_edit",
+ *              title="can_edit",
+ *              description="Whether the user can see group editing controls (administrator, network coordinator for the group, or host of the group).",
+ *              type="boolean",
+ *          ),
+ *          @OA\Property(
+ *              property="can_demote",
+ *              title="can_demote",
+ *              description="Whether the user can demote/manage volunteer roles (administrator or network coordinator for the group).",
+ *              type="boolean",
+ *          ),
+ *          @OA\Property(
+ *              property="can_see_delete",
+ *              title="can_see_delete",
+ *              description="Whether the user can see the delete-group control (administrator only).",
+ *              type="boolean",
+ *          ),
+ *          @OA\Property(
+ *              property="can_perform_delete",
+ *              title="can_perform_delete",
+ *              description="Whether the group can actually be deleted by this user (can_see_delete and the group has no events with devices).",
+ *              type="boolean",
+ *          ),
+ *          @OA\Property(
+ *              property="can_perform_archive",
+ *              title="can_perform_archive",
+ *              description="Whether the user can archive the group (administrator or network coordinator for the group).",
+ *              type="boolean",
+ *          ),
  *     )
  * )
 */

--- a/resources/js/components/GroupPage.vue
+++ b/resources/js/components/GroupPage.vue
@@ -48,6 +48,9 @@
 
     <GroupDevicesBreakdown :idgroups="idgroups" :cluster-stats="clusterStats" />
   </div>
+  <div v-else class="vue-placeholder vue-placeholder-large">
+    <div class="vue-placeholder-content">{{ __('partials.loading') }}...</div>
+  </div>
 </template>
 <script>
 import GroupHeading from './GroupHeading.vue'
@@ -60,6 +63,7 @@ import GroupDevicesMostRepaired from './GroupDevicesMostRepaired.vue'
 import GroupDevicesBreakdown from './GroupDevicesBreakdown.vue'
 import AlertBanner from './AlertBanner.vue'
 import auth from '../mixins/auth'
+import axios from 'axios'
 
 export default {
   components: {
@@ -79,38 +83,9 @@ export default {
       type: Number,
       required: true
     },
-    initialGroup: {
-      type: Object,
-      required: true
-    },
     events: {
       type: Array,
       required: true
-    },
-    canedit: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    candemote: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    canSeeDelete: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    canPerformDelete: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    canPerformArchive: {
-      type: Boolean,
-      required: false,
-      default: false
     },
     ingroup: {
       type: Boolean,
@@ -163,21 +138,58 @@ export default {
         name: this.group.name,
         link: '/group/view/' + this.group.id
       })
+    },
+    permissions() {
+      return (this.group && this.group.permissions) || {}
+    },
+    canedit() {
+      return this.permissions.can_edit || false
+    },
+    candemote() {
+      return this.permissions.can_demote || false
+    },
+    canSeeDelete() {
+      return this.permissions.can_see_delete || false
+    },
+    canPerformDelete() {
+      return this.permissions.can_perform_delete || false
+    },
+    canPerformArchive() {
+      return this.permissions.can_perform_archive || false
     }
   },
-  mounted () {
-    // Data is passed from the blade template to us via props.  We put it in the store for all components to use,
-    // and so that as/when it changes then reactivity updates all the views.
+  async mounted () {
+    // Fetch the group - including this user's UI permission flags - from the API, rather than relying on
+    // server-hydrated Blade props.  We put it in the store for all components to use, and so that as/when it
+    // changes then reactivity updates all the views.  While the fetch is in flight, `group` in the store is
+    // undefined and the template shows a loading placeholder.
     //
-    // Further down the line this may change so that the data is obtained via an AJAX call and perhaps SSR.
-    // TODO LATER We add some properties to the group before adding it to the store.  These should move into
-    // computed properties once we have good access to the session on the client.
-    this.initialGroup.idgroups = this.idgroups
-    this.initialGroup.canedit = this.canedit
-    this.initialGroup.candemote = this.candemote
-    this.initialGroup.ingroup = this.ingroup
+    // We fetch directly here (rather than via the groups/fetch action) so that we can add the old-style field
+    // aliases some sibling components still expect (see below) before the group ever lands in the store, and
+    // so we commit it exactly once - the shared groups/fetch action is also used by components which want the
+    // raw API shape as-is (e.g. GroupAddEdit.vue), so we don't want to change what it commits.
+    try {
+      const ret = await axios.get('/api/v2/groups/' + this.idgroups)
+      const group = ret.data.data
 
-    this.$store.dispatch('groups/set', this.initialGroup)
+      // A handful of sibling components (GroupVolunteers, GroupEvents, ...) read canedit/candemote/ingroup off
+      // the stored group object itself via the `group` mixin, rather than as props - and some still expect
+      // old-style (Eloquent) field names.  Add compatibility aliases rather than changing those components
+      // (out of scope here) - mirrors the newToOld() shim already used elsewhere in the groups store.
+      group.idgroups = this.idgroups
+      group.canedit = group.permissions ? group.permissions.can_edit : false
+      group.candemote = group.permissions ? group.permissions.can_demote : false
+      group.ingroup = this.ingroup
+      group.free_text = group.description
+
+      if (group.image) {
+        group.group_image = { image: { path: group.image } }
+      }
+
+      this.$store.dispatch('groups/set', group)
+    } catch (e) {
+      console.error('Group fetch failed', e)
+    }
 
     this.events.forEach(e => {
       this.$store.dispatch('events/setStats', {

--- a/resources/views/group/view.blade.php
+++ b/resources/views/group/view.blade.php
@@ -42,11 +42,9 @@
               $group_image->image->path;
           }
 
-          $can_edit_group = App\Helpers\Fixometer::hasRole($user, 'Administrator') || $isCoordinatorForGroup || $is_host_of_group;
-          $can_demote = App\Helpers\Fixometer::hasRole($user, 'Administrator') || $isCoordinatorForGroup;
-          $can_see_delete = App\Helpers\Fixometer::hasRole($user, 'Administrator');
-          $can_perform_delete = $can_see_delete && $group->canDelete();
-          $can_perform_archive = App\Helpers\Fixometer::hasRole($user, 'Administrator') || $isCoordinatorForGroup;
+          // The per-user UI permission flags (can_edit, can_demote, can_see_delete, can_perform_delete,
+          // can_perform_archive) are no longer computed here.  GroupPage.vue fetches them, along with the rest
+          // of the group data, from GET /api/v2/groups/{id} (see API\GroupController::getGroupv2()).
 
           $showCalendar = Auth::check() && (($group && $group->isVolunteer()) || App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator'));
 
@@ -143,17 +141,11 @@
           <GroupPage
               csrf="{{ csrf_token() }}"
               :idgroups="{{ $group->idgroups }}"
-              :initial-group="{{ $group }}"
               :group-stats="{{ json_encode($group_stats, JSON_INVALID_UTF8_IGNORE) }}"
               :device-stats="{{ json_encode($device_stats, JSON_INVALID_UTF8_IGNORE) }}"
               :cluster-stats="{{ json_encode($cluster_stats, JSON_INVALID_UTF8_IGNORE) }}"
               :top-devices="{{ json_encode($top, JSON_INVALID_UTF8_IGNORE) }}"
               :events="{{ json_encode($expanded_events, JSON_INVALID_UTF8_IGNORE) }}"
-              :canedit="{{ $can_edit_group ? 'true' : 'false' }}"
-              :candemote="{{ $can_demote ? 'true' : 'false' }}"
-              :can-see-delete="{{ $can_see_delete ? 'true' : 'false' }}"
-              :can-perform-delete="{{ $can_perform_delete ? 'true' : 'false' }}"
-              :can-perform-archive="{{ $can_perform_archive ? 'true' : 'false' }}"
               calendar-copy-url="{{ $showCalendar ? url("/calendar/group/{$group->idgroups}") : '' }}"
               calendar-edit-url="{{ $showCalendar ? url("/profile/edit/{$user->id}#list-calendar-links") : '' }}"
               :ingroup="{{ $in_group ? 'true' : 'false' }}"

--- a/tests/Feature/Groups/APIv2GroupPermissionsTest.php
+++ b/tests/Feature/Groups/APIv2GroupPermissionsTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Tests\Feature\Groups;
+
+use App\Group;
+use App\Network;
+use App\Role;
+use App\User;
+use Auth;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class APIv2GroupPermissionsTest extends TestCase
+{
+    /**
+     * Create a group as an administrator (so we control ownership independently of the users under test).
+     */
+    private function createGroupAsAdmin(): int
+    {
+        $admin = User::factory()->administrator()->create([
+            'api_token' => 'admintok-' . Str::random(20),
+        ]);
+        $this->actingAs($admin);
+
+        return $this->createGroup(
+            'Permissions Test Group ' . Str::random(8),
+            'https://therestartproject.org',
+            'London',
+            'Some text.',
+            true,
+            true,
+            'info@test.com'
+        );
+    }
+
+    private function assertFlags($idgroups, $token, $expected): void
+    {
+        // Laravel's TokenGuard caches the resolved user on the guard instance for the lifetime of the test
+        // method (HTTP calls in tests don't reboot the container). Since several tests here issue requests as
+        // different users identified purely by api_token, we must forget guards before each such request so
+        // the token is actually re-resolved rather than returning a previous request's cached user.
+        $this->app['auth']->forgetGuards();
+
+        $response = $token
+            ? $this->get("/api/v2/groups/$idgroups?api_token=$token")
+            : $this->get("/api/v2/groups/$idgroups");
+
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true);
+
+        $this->assertArrayHasKey('permissions', $json['data'], 'Response should contain a permissions object: ' . $response->getContent());
+
+        $permissions = $json['data']['permissions'];
+
+        foreach ($expected as $key => $value) {
+            $this->assertEquals($value, $permissions[$key], "Flag '$key' mismatch. Full permissions: " . json_encode($permissions));
+        }
+    }
+
+    public function testAnonymousUserSeesNoPermissions(): void
+    {
+        $idgroups = $this->createGroupAsAdmin();
+
+        // createGroupAsAdmin() left us logged in via actingAs(). Log out so the request is genuinely anonymous.
+        Auth::logout();
+
+        $this->assertFlags($idgroups, null, [
+            'can_edit' => false,
+            'can_demote' => false,
+            'can_see_delete' => false,
+            'can_perform_delete' => false,
+            'can_perform_archive' => false,
+        ]);
+    }
+
+    public function testNonMemberRestarterSeesNoPermissions(): void
+    {
+        $idgroups = $this->createGroupAsAdmin();
+        Auth::logout();
+
+        $restarter = User::factory()->restarter()->create([
+            'api_token' => 'restarter-tok-' . Str::random(20),
+        ]);
+
+        $this->assertFlags($idgroups, $restarter->api_token, [
+            'can_edit' => false,
+            'can_demote' => false,
+            'can_see_delete' => false,
+            'can_perform_delete' => false,
+            'can_perform_archive' => false,
+        ]);
+    }
+
+    public function testHostOfGroupCanEditButNotDeleteOrArchive(): void
+    {
+        // createGroup() makes the acting user a host of the group automatically.
+        $host = User::factory()->host()->create([
+            'api_token' => 'host-tok-' . Str::random(20),
+        ]);
+        $this->actingAs($host);
+
+        $idgroups = $this->createGroup(
+            'Host Owned Group ' . Str::random(8),
+            'https://therestartproject.org',
+            'London',
+            'Some text.',
+            true,
+            true,
+            'info@test.com'
+        );
+
+        $this->assertFlags($idgroups, $host->api_token, [
+            'can_edit' => true,
+            'can_demote' => false,
+            'can_see_delete' => false,
+            'can_perform_delete' => false,
+            'can_perform_archive' => false,
+        ]);
+    }
+
+    public function testNetworkCoordinatorForGroupCanEditDemoteAndArchive(): void
+    {
+        $idgroups = $this->createGroupAsAdmin();
+        $group = Group::find($idgroups);
+        Auth::logout();
+
+        $network = Network::factory()->create([
+            'shortname' => 'permtestnetwork' . Str::random(6),
+        ]);
+        $network->addGroup($group);
+
+        $coordinator = User::factory()->networkCoordinator()->create([
+            'api_token' => 'coord-tok-' . Str::random(20),
+        ]);
+        $network->addCoordinator($coordinator);
+
+        $this->assertFlags($idgroups, $coordinator->api_token, [
+            'can_edit' => true,
+            'can_demote' => true,
+            'can_see_delete' => false,
+            'can_perform_delete' => false,
+            'can_perform_archive' => true,
+        ]);
+    }
+
+    public function testCoordinatorForUnrelatedNetworkSeesNoPermissions(): void
+    {
+        $idgroups = $this->createGroupAsAdmin();
+        Auth::logout();
+
+        // A coordinator of some OTHER network (not attached to this group) should see no elevated permissions.
+        $otherNetwork = Network::factory()->create([
+            'shortname' => 'othernetwork' . Str::random(6),
+        ]);
+        $coordinator = User::factory()->networkCoordinator()->create([
+            'api_token' => 'othercoord-tok-' . Str::random(20),
+        ]);
+        $otherNetwork->addCoordinator($coordinator);
+
+        $this->assertFlags($idgroups, $coordinator->api_token, [
+            'can_edit' => false,
+            'can_demote' => false,
+            'can_see_delete' => false,
+            'can_perform_delete' => false,
+            'can_perform_archive' => false,
+        ]);
+    }
+
+    public function testAdministratorSeesAllPermissionsAndCanDeleteFollowsGroupCanDelete(): void
+    {
+        $idgroups = $this->createGroupAsAdmin();
+        Auth::logout();
+
+        $admin = User::factory()->administrator()->create([
+            'api_token' => 'admin2-tok-' . Str::random(20),
+        ]);
+
+        // Fresh group with no events/devices - canDelete() should be true.
+        $this->assertFlags($idgroups, $admin->api_token, [
+            'can_edit' => true,
+            'can_demote' => true,
+            'can_see_delete' => true,
+            'can_perform_delete' => true,
+            'can_perform_archive' => true,
+        ]);
+    }
+
+    public function testAdministratorCannotDeleteGroupWithDeviceEvent(): void
+    {
+        $idgroups = $this->createGroupAsAdmin();
+
+        $admin = User::factory()->administrator()->create([
+            'api_token' => 'admin3-tok-' . Str::random(20),
+        ]);
+        $this->actingAs($admin);
+
+        $event = \App\Party::factory()->moderated()->create([
+            'event_start_utc' => '2000-01-01T10:15:05+05:00',
+            'event_end_utc' => '2000-01-01T13:45:05+05:00',
+            'group' => $idgroups,
+        ]);
+
+        $this->createDevice($event->idevents,
+            'misc', null, 1.5, 0, '',
+            \App\Device::REPAIR_STATUS_FIXED_STR, null, null, 111);
+
+        $this->assertFlags($idgroups, $admin->api_token, [
+            'can_edit' => true,
+            'can_demote' => true,
+            'can_see_delete' => true,
+            'can_perform_delete' => false,
+            'can_perform_archive' => true,
+        ]);
+    }
+
+    public function testSessionAuthenticatedUserAlsoGetsPermissions(): void
+    {
+        // Confirm the endpoint also resolves permissions for web-session (actingAs) users, not just api_token,
+        // since the group view page is loaded via a normal browser session.
+        $idgroups = $this->createGroupAsAdmin();
+
+        $admin = User::factory()->administrator()->create([
+            'api_token' => 'admin4-tok-' . Str::random(20),
+        ]);
+        $this->actingAs($admin);
+
+        $response = $this->get("/api/v2/groups/$idgroups");
+        $response->assertSuccessful();
+        $json = json_decode($response->getContent(), true);
+        $this->assertTrue($json['data']['permissions']['can_edit']);
+        $this->assertTrue($json['data']['permissions']['can_see_delete']);
+    }
+}

--- a/tests/Feature/Groups/GroupViewTest.php
+++ b/tests/Feature/Groups/GroupViewTest.php
@@ -33,16 +33,17 @@ class GroupViewTest extends TestCase
             'event' => $event->idevents,
         ]);
 
-        // View with id.
+        // View with id.  The page itself no longer carries the per-user UI permission flags (canedit,
+        // can-see-delete, can-perform-delete, ...) as Blade props - GroupPage.vue fetches those, along with the
+        // rest of the group data, from GET /api/v2/groups/{id}. See APIv2GroupPermissionsTest for thorough
+        // coverage of that flag matrix; here we just check the page still renders the group/event data it is
+        // still responsible for passing down.
         $response = $this->get("/group/view/$id");
 
         $props = $this->assertVueProperties($response, [
             [],
             [
                 ':idgroups' => $id,
-                ':canedit' => 'true',
-                ':can-see-delete' => 'true',
-                ':can-perform-delete' => 'false',
                 ':top-devices' => json_encode([
                     [
                         'counter' => 1,
@@ -52,6 +53,14 @@ class GroupViewTest extends TestCase
             ],
         ]);
         $this->assertEquals(1, count(json_decode($props[1][':events'], TRUE)));
+
+        // The API endpoint the page fetches from should report full permissions for this administrator.
+        $apiResponse = $this->get("/api/v2/groups/$id");
+        $apiResponse->assertSuccessful();
+        $permissions = json_decode($apiResponse->getContent(), true)['data']['permissions'];
+        $this->assertTrue($permissions['can_edit']);
+        $this->assertTrue($permissions['can_see_delete']);
+        $this->assertFalse($permissions['can_perform_delete']);
     }
 
     public function testInvalidGroup(): void
@@ -66,6 +75,16 @@ class GroupViewTest extends TestCase
         $this->loginAsTestUser(Role::RESTARTER);
         $this->expectException(NotFoundHttpException::class);
         $this->get('/group/view/1');
+    }
+
+    private function assertGroupPermissions($id, $canSeeDelete, $canPerformDelete): void
+    {
+        // The page's Blade props no longer carry these flags - GroupPage.vue fetches them from this endpoint.
+        $response = $this->get("/api/v2/groups/$id");
+        $response->assertSuccessful();
+        $permissions = json_decode($response->getContent(), true)['data']['permissions'];
+        $this->assertEquals($canSeeDelete, $permissions['can_see_delete']);
+        $this->assertEquals($canPerformDelete, $permissions['can_perform_delete']);
     }
 
     public function testCanDelete(): void
@@ -87,10 +106,9 @@ class GroupViewTest extends TestCase
             [],
             [
                 ':idgroups' => $id,
-                ':can-see-delete' => 'true',
-                ':can-perform-delete' => 'true',
             ],
         ]);
+        $this->assertGroupPermissions($id, true, true);
 
         $iddevices = $this->createDevice($event->idevents,
             'misc', null, 1.5, 0, '',
@@ -101,10 +119,9 @@ class GroupViewTest extends TestCase
             [],
             [
                 ':idgroups' => $id,
-                ':can-see-delete' => 'true',
-                ':can-perform-delete' => 'false',
             ],
         ]);
+        $this->assertGroupPermissions($id, true, false);
 
         # Check the device shows in the API.
         $rsp2 = $this->get('/api/devices/1/10?sortBy=iddevices&sortDesc=asc&powered=false');
@@ -122,10 +139,9 @@ class GroupViewTest extends TestCase
                 [],
                 [
                     ':idgroups' => $id,
-                    ':can-see-delete' => 'false',
-                    ':can-perform-delete' => 'false',
                 ],
             ]);
+            $this->assertGroupPermissions($id, false, false);
         }
 
         // Test stats API.

--- a/tests/Feature/Groups/InviteGroupTest.php
+++ b/tests/Feature/Groups/InviteGroupTest.php
@@ -73,14 +73,18 @@ class InviteGroupTest extends TestCase
         // Small delay to ensure any database commits or cache invalidations are complete
         usleep(100000); // 100ms
 
-        $props = $this->assertVueProperties($response2, [
+        $this->assertVueProperties($response2, [
             [],
             [
                 ':idgroups' => $group->idgroups,
             ],
         ]);
 
-        $initialGroup = json_decode($props[1][':initial-group'], true);
+        // Check the group membership counts directly on the model (these are no longer exposed to the Blade
+        // view/Vue props - GroupPage.vue now gets group data, including confirmed hosts/restarters counts, from
+        // GET /api/v2/groups/{id} - but the underlying counting logic being tested here (an invited-but-not-yet-
+        // accepted restarter shouldn't count as confirmed) is independent of how it's surfaced to the page).
+        $freshGroup = Group::find($group->idgroups);
 
         // Debug info for CI failures - collect group membership state
         $groupMembers = DB::table('users_groups')
@@ -91,18 +95,25 @@ class InviteGroupTest extends TestCase
             })
             ->implode('; ');
         $debugInfo = sprintf(
-            "Group ID: %d, Host ID: %d, User ID: %d, Members: [%s], Initial group data: %s",
+            "Group ID: %d, Host ID: %d, User ID: %d, Members: [%s]",
             $group->idgroups,
             $host->id,
             $user->id,
-            $groupMembers,
-            json_encode($initialGroup)
+            $groupMembers
         );
 
-        $this->assertEquals(1, $initialGroup['all_hosts_count'], "all_hosts_count mismatch. Debug: $debugInfo");
-        $this->assertEquals(1, $initialGroup['all_confirmed_hosts_count'], "all_confirmed_hosts_count mismatch. Debug: $debugInfo");
-        $this->assertEquals(1, $initialGroup['all_restarters_count'], "all_restarters_count mismatch. Debug: $debugInfo");
-        $this->assertEquals(0, $initialGroup['all_confirmed_restarters_count'], "all_confirmed_restarters_count mismatch. Debug: $debugInfo");
+        $this->assertEquals(1, $freshGroup->all_hosts_count, "all_hosts_count mismatch. Debug: $debugInfo");
+        $this->assertEquals(1, $freshGroup->all_confirmed_hosts_count, "all_confirmed_hosts_count mismatch. Debug: $debugInfo");
+        $this->assertEquals(1, $freshGroup->all_restarters_count, "all_restarters_count mismatch. Debug: $debugInfo");
+        $this->assertEquals(0, $freshGroup->all_confirmed_restarters_count, "all_confirmed_restarters_count mismatch. Debug: $debugInfo");
+
+        // The API endpoint GroupPage.vue fetches from should also reflect the confirmed counts (unconfirmed
+        // members are not exposed there, matching what the page displays to end users).
+        $apiResponse = $this->get("/api/v2/groups/{$group->idgroups}");
+        $apiResponse->assertSuccessful();
+        $apiGroup = json_decode($apiResponse->getContent(), true)['data'];
+        $this->assertEquals(1, $apiGroup['hosts'], "API hosts mismatch. Debug: $debugInfo");
+        $this->assertEquals(0, $apiGroup['restarters'], "API restarters mismatch. Debug: $debugInfo");
 
         // Now accept the invite.
         preg_match('/href="(\/group\/accept-invite.*?)"/', $response2->getContent(), $matches);
@@ -128,18 +139,24 @@ class InviteGroupTest extends TestCase
 
         // Check the counts have changed.
         $response4 = $this->get('/group/view/'.$group->idgroups);
-        $props = $this->assertVueProperties($response4, [
+        $this->assertVueProperties($response4, [
             [],
             [
                 ':idgroups' => $group->idgroups,
             ],
         ]);
 
-        $initialGroup = json_decode($props[1][':initial-group'], true);
-        $this->assertEquals(1, $initialGroup['all_hosts_count']);
-        $this->assertEquals(1, $initialGroup['all_confirmed_hosts_count']);
-        $this->assertEquals(1, $initialGroup['all_restarters_count']);
-        $this->assertEquals(1, $initialGroup['all_confirmed_restarters_count']);
+        $freshGroup = Group::find($group->idgroups);
+        $this->assertEquals(1, $freshGroup->all_hosts_count);
+        $this->assertEquals(1, $freshGroup->all_confirmed_hosts_count);
+        $this->assertEquals(1, $freshGroup->all_restarters_count);
+        $this->assertEquals(1, $freshGroup->all_confirmed_restarters_count);
+
+        $apiResponse = $this->get("/api/v2/groups/{$group->idgroups}");
+        $apiResponse->assertSuccessful();
+        $apiGroup = json_decode($apiResponse->getContent(), true)['data'];
+        $this->assertEquals(1, $apiGroup['hosts']);
+        $this->assertEquals(1, $apiGroup['restarters']);
 
         // Create another event.  Should now generate a notification.
         $this->actingAs($host);


### PR DESCRIPTION
## Summary
Completes **Group 4.1** of `plans/active/blade-to-vue-migration.md`. `group/view.blade.php` previously computed per-user permission flags server-side and passed them to `<GroupPage>` as props. Now `GroupPage.vue` fetches the group **and those flags** from the v2 API on mount.

- `getGroupv2` resolves the **optional** user (session, then api-token guard) and returns a `permissions` object computed by a new `groupPermissionsFor()` helper that replicates the Blade logic exactly:
  - `can_edit = admin || coordinatorForGroup || hostOfGroup`
  - `can_demote = admin || coordinatorForGroup`
  - `can_see_delete = admin`
  - `can_perform_delete = can_see_delete && group->canDelete()`
  - `can_perform_archive = admin || coordinatorForGroup`
  - **No resolved user → all flags false.** Host = `Fixometer::userHasEditGroupPermission`, coordinator = `User::isCoordinatorForGroup` — the exact calls the controller used.
- `GroupPage.vue` drops the hydrated group/permission props, fetches on mount, and derives the button flags as computed properties.
- `group/view.blade.php` stops computing/passing those props.

## Security note
These flags are **UI show/hide only** — the edit/delete/archive endpoints each enforce their own authorization independently (defense in depth). The flag logic is nonetheless replicated faithfully and covered by a full test matrix.

## Test plan
- [x] `APIv2GroupPermissionsTest` — full matrix (anonymous / non-member / host / coordinator own-vs-other-network / admin; `can_perform_delete` follows `canDelete()`): 8 tests, 112 assertions
- [x] `GroupViewTest` (8/171), `InviteGroupTest`, `APIv2GroupTest`, `Groups\BasicTest` — updated for removed props, all green (43 total)
- [x] `vite build` exit 0; `translations:check` exit 0
- [ ] CircleCI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)