### PR TITLE
i18n: translation keys for stat-widget labels

### DIFF
--- a/lang/en/groups.php
+++ b/lang/en/groups.php
@@ -73,6 +73,7 @@ return [
   'volunteers' => 'Volunteers',
   'invite_to_group' => 'Invite to group',
   'participants' => 'participants',
+  'parties_thrown' => 'parties thrown',
   'hours_volunteered' => 'hours volunteered',
   'years_volunteered' => 'years volunteered',
   'waste_prevented' => 'Waste prevented',

--- a/lang/fr-BE/groups.php
+++ b/lang/fr-BE/groups.php
@@ -80,6 +80,7 @@ return [
   'share_group_stats' => 'Partager les statistiques du Repair Café',
   'total_devices' => 'Total des éléments qui ont été pris en charge',
   'participants' => 'participants',
+  'parties_thrown' => 'événements organisés',
   'hours_volunteered' => 'heures de bénévolat',
   'years_volunteered' => 'années de bénévolat',
   'waste_prevented' => 'Déchets évités',

--- a/lang/fr/groups.php
+++ b/lang/fr/groups.php
@@ -80,6 +80,7 @@ return [
   'share_group_stats' => 'Partager les statistiques du Repair Café',
   'total_devices' => 'Total des éléments qui ont été pris en charge',
   'participants' => 'participants',
+  'parties_thrown' => 'événements organisés',
   'hours_volunteered' => 'heures de bénévolat',
   'years_volunteered' => 'années de bénévolat',
   'waste_prevented' => 'Déchets évités',

--- a/resources/views/admin/stats.blade.php
+++ b/resources/views/admin/stats.blade.php
@@ -44,7 +44,7 @@
             </div>
 
             <div class="col-md-12">
-                <h2><span class="title-text">Most Repaired Devices</span></h2>
+                <h2><span class="title-text">@lang('groups.most_repaired_devices')</span></h2>
 
                 <div class="row">
                     <div class="col-xs-4 col-sm-4 col-md-4"><div class="topper  text-center"><?php echo $top[0]['name'] . ' [' . $top[0]['counter'] . ']'; ?></div></div>

--- a/resources/views/group/stats.blade.php
+++ b/resources/views/group/stats.blade.php
@@ -4,22 +4,22 @@
 
   <div id="group-main-stats">
       <div class="col">
-          <h5>participants</h5>
+          <h5>@lang('groups.participants')</h5>
           <span class="largetext"><?php echo $participants; ?></span>
       </div>
 
       <div class="col">
-          <h5>hours volunteered</h5>
+          <h5>@lang('groups.hours_volunteered')</h5>
           <span class="largetext"><?php echo $hours_volunteered; ?></span>
       </div>
 
       <div class="col">
-          <h5>parties thrown</h5>
+          <h5>@lang('groups.parties_thrown')</h5>
           <span class="largetext"><?php echo $parties; ?></span>
       </div>
 
       <div class="col">
-          <h5>waste prevented</h5>
+          <h5>@lang('groups.waste_prevented')</h5>
           <span class="largetext">
               {{ number_format(round($waste_total), 0) }} kg
           </span>
@@ -38,7 +38,7 @@
   <div id="group-main-stats">
       <div class="group-stats-row first-row">
            <div class="col">
-                  <h5>waste prevented</h5>
+                  <h5>@lang('groups.waste_prevented')</h5>
                   <span class="largetext">
                       <?php echo $waste_total; ?> kg
                   </span>
@@ -52,17 +52,17 @@
       </div>
       <div class="group-stats-row second-row">
           <div class="col">
-                  <h5>participants</h5>
+                  <h5>@lang('groups.participants')</h5>
                   <span class="largetext"><?php echo $pax; ?></span>
               </div>
 
               <div class="col">
-                  <h5>hours volunteered</h5>
+                  <h5>@lang('groups.hours_volunteered')</h5>
                   <span class="largetext"><?php echo $hours; ?></span>
               </div>
 
               <div class="col">
-                  <h5>parties thrown</h5>
+                  <h5>@lang('groups.parties_thrown')</h5>
                   <span class="largetext"><?php echo $parties; ?></span>
               </div>
       </div>
@@ -73,12 +73,12 @@
 
   <div id="group-main-stats" class="mini">
       <div class="col">
-          <h5>parties thrown</h5>
+          <h5>@lang('groups.parties_thrown')</h5>
           <span class="largetext"><?php echo $parties; ?></span>
       </div>
 
       <div class="col">
-          <h5>waste prevented</h5>
+          <h5>@lang('groups.waste_prevented')</h5>
           <span class="largetext">
               <?php echo $waste_total; ?> kg
           </span>

--- a/resources/views/party/stats.blade.php
+++ b/resources/views/party/stats.blade.php
@@ -5,7 +5,7 @@
     <div class="stat1">
         <span>
                 <img style="height:40px" class="" alt="Volunteers" src="{{ asset('/icons/icon_pax.png') }}">
-                <span class="subtext">participants</span>
+                <span class="subtext">@lang('groups.participants')</span>
         </span>
         <?php echo $party['participants']; ?>
     </div>


### PR DESCRIPTION
## Summary
The group / party / admin **stat widgets** (server-rendered iframes embedded on external sites — deliberately kept as Blade for embed performance, not migrated to Vue) had hardcoded English labels. This localises the clear standalone labels via translation keys:

- **group/stats**: `participants`, `hours_volunteered`, **`parties_thrown` (new)**, `waste_prevented` — across the `row` / `double-row` / `mini` formats.
- **party/stats**: `participants`.
- **admin/stats**: "Most Repaired Devices" → existing `groups.most_repaired_devices`.

Only one new key (`groups.parties_thrown`) was added, to **en + fr + fr-BE only** per the project's fr/fr-BE translation policy (`fr`/`fr-BE`: "événements organisés"). Everything else reuses existing keys.

## Deliberately left as-is
The CO₂/waste value lines (which mix `<sub>` formatting with units) and the interpolated impact-sentences in `admin/stats` (e.g. "X participants aided by Y hours … worked on Z devices", "Equal to driving …") are **not** touched — they need placeholder-based (`:count`) restructuring to translate correctly, which is a larger careful pass out of scope here.

## Test plan
- [x] `php artisan translations:check` exits 0
- [x] `GroupStatsTest` + `PartyStatsTest` green (5 tests, 399 assertions) — the widgets still render
- [ ] CircleCI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)