### PR TITLE
RES-1863: draggable map for group location fine-tuning

### DIFF
--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -1103,6 +1103,8 @@ class GroupController extends Controller
                                    'location' => ['required', 'max:255'],
                                    'description' => ['required'],
                                    'website' => ['nullable', 'url', 'max:255'],
+                                   'lat' => ['nullable', 'numeric', 'between:-90,90', 'required_with:lng'],
+                                   'lng' => ['nullable', 'numeric', 'between:-180,180', 'required_with:lat'],
                                ]);
         } else {
             $request->validate([
@@ -1110,6 +1112,8 @@ class GroupController extends Controller
                                    'location' => ['max:255'],
                                    'website' => ['nullable', 'url', 'max:255'],
                                    'archived_at' => ['nullable', 'date'],
+                                   'lat' => ['nullable', 'numeric', 'between:-90,90', 'required_with:lng'],
+                                   'lng' => ['nullable', 'numeric', 'between:-180,180', 'required_with:lat'],
                                ]);
         }
 
@@ -1133,6 +1137,12 @@ class GroupController extends Controller
             throw ValidationException::withMessages(['location ' => __('partials.validate_timezone')]);
         }
 
+        // The add/edit page shows a draggable map, so the client can send explicit
+        // coordinates that take precedence over geocoding the location text.
+        $clientLat = $request->input('lat');
+        $clientLng = $request->input('lng');
+        $hasClientCoords = $clientLat !== null && $clientLng !== null;
+
         if (!empty($location)) {
             // Skip geocoding when the location string hasn't changed — avoids unnecessary API calls
             // and prevents failures when editing other fields (e.g. group icon) in environments
@@ -1148,16 +1158,25 @@ class GroupController extends Controller
                 $geocoded = $geocoder->geocode($location);
 
                 if (empty($geocoded)) {
-                    throw ValidationException::withMessages(['location ' => __('groups.geocode_failed')]);
+                    // With an explicit pin we can still place the group; without
+                    // one, an ungeocodable location is fatal as before.
+                    if (!$hasClientCoords) {
+                        throw ValidationException::withMessages(['location ' => __('groups.geocode_failed')]);
+                    }
+                } else {
+                    $latitude = $geocoded['latitude'];
+                    $longitude = $geocoded['longitude'];
+
+                    // Note that the country returned by the geocoder is already in English, which is what we need for the
+                    // value in the database.
+                    $country_code = $geocoded['country_code'] ?? null;
                 }
-
-                $latitude = $geocoded['latitude'];
-                $longitude = $geocoded['longitude'];
-
-                // Note that the country returned by the geocoder is already in English, which is what we need for the
-                // value in the database.
-                $country_code = $geocoded['country_code'] ?? null;
             }
+        }
+
+        if ($hasClientCoords) {
+            $latitude = (float) $clientLat;
+            $longitude = (float) $clientLng;
         }
 
         return [

--- a/lang/en/partials.php
+++ b/lang/en/partials.php
@@ -84,6 +84,7 @@ return [
   'notification_greeting' => 'Hello!',
   'confirm' => 'Confirm',
   'validate_timezone' => 'Please select a valid timezone.',
+  'dragmap' => 'Map marker not quite right?  Feel free to drag around to fix it.',
   'share_this' => 'Share this',
   'download' => 'Download',
   'share_modal_title' => 'Shareable Statistics',

--- a/lang/fr-BE/partials.php
+++ b/lang/fr-BE/partials.php
@@ -87,6 +87,7 @@ return [
   'notification_greeting' => 'Bonjour !',
   'notification_footer' => 'Si vous souhaitez ne plus recevoir ces courriels, veuillez consulter <a href=":url">vos préférences</a> sur votre compte.',
   'validate_timezone' => 'Veuillez sélectionner un fuseau horaire valide.',
+  'dragmap' => 'Marqueur de carte pas tout à fait exact ? N\'hésitez pas à le faire glisser pour le corriger.',
   'share_this' => 'Partager ceci',
   'download' => 'Télécharger',
   'share_modal_title' => 'Statistiques à partager',

--- a/lang/fr/partials.php
+++ b/lang/fr/partials.php
@@ -87,6 +87,7 @@ return [
   'notification_greeting' => 'Bonjour !',
   'notification_footer' => 'Si vous souhaitez ne plus recevoir ces courriels, veuillez consulter <a href=":url">vos préférences</a> sur votre compte.',
   'validate_timezone' => 'Veuillez sélectionner un fuseau horaire valide.',
+  'dragmap' => 'Marqueur de carte pas tout à fait exact ? N\'hésitez pas à le faire glisser pour le corriger.',
   'share_this' => 'Partager ceci',
   'download' => 'Télécharger',
   'share_modal_title' => 'Statistiques à partager',

--- a/resources/js/components/GroupAddEdit.vue
+++ b/resources/js/components/GroupAddEdit.vue
@@ -59,11 +59,10 @@
           ref="location"
       />
       <GroupLocationMap
-          :lat="lat"
-          :lng="lng"
+          :lat.sync="lat"
+          :lng.sync="lng"
           class="group-locationmap"
           ref="locationmap"
-          :id="lat + ',' + lng"
           v-if="lat || lng"
       />
       <GroupTimeZone
@@ -483,7 +482,11 @@ export default {
               timezone: this.timezone,
               phone: this.phone,
               image: this.image,
-              network_data: JSON.stringify(this.networkData)
+              network_data: JSON.stringify(this.networkData),
+              // Strings, not numbers: the store skips falsy values when
+              // building FormData, which would drop a 0 coordinate.
+              lat: this.lat !== null ? String(this.lat) : null,
+              lng: this.lng !== null ? String(this.lng) : null,
             }
             const id = await this.$store.dispatch('groups/create', payload)
 
@@ -516,6 +519,8 @@ export default {
                 tags: JSON.stringify((this.tagList || []).map(n => n.id)),
                 network_data: JSON.stringify(this.networkData),
                 archived_at: this.archived_at,
+                lat: this.lat !== null ? String(this.lat) : null,
+                lng: this.lng !== null ? String(this.lng) : null,
               }
 
               console.log('Edit', JSON.stringify(payload))

--- a/resources/js/components/GroupLocationMap.test.js
+++ b/resources/js/components/GroupLocationMap.test.js
@@ -1,0 +1,75 @@
+import Vue from 'vue'
+import { BootstrapVue } from 'bootstrap-vue'
+Vue.use(BootstrapVue)
+
+import { mount } from '@vue/test-utils'
+import LangMixin from 'resources/js/mixins/lang.js'
+import GroupLocationMap from './GroupLocationMap.vue'
+
+const LMapStub = {
+  name: 'l-map',
+  template: '<div class="lmap-stub"><slot /></div>'
+}
+
+const LMarkerStub = {
+  name: 'l-marker',
+  props: ['latLng'],
+  template: '<div class="lmarker-stub" />'
+}
+
+function mountMap (props = {}) {
+  return mount(GroupLocationMap, {
+    mixins: [LangMixin],
+    propsData: { lat: 51.5, lng: -0.12, ...props },
+    stubs: {
+      'l-map': LMapStub,
+      'l-tile-layer': true,
+      'l-marker': LMarkerStub
+    }
+  })
+}
+
+test('shows the drag hint', () => {
+  const wrapper = mountMap()
+  expect(wrapper.text()).toContain('partials.dragmap')
+})
+
+test('dragging the map emits updated lat/lng', async () => {
+  const wrapper = mountMap()
+
+  wrapper.findComponent(LMapStub).vm.$emit('update:center', { lat: 52.1, lng: 1.3 })
+  await wrapper.vm.$nextTick()
+
+  expect(wrapper.emitted('update:lat').pop()).toEqual([52.1])
+  expect(wrapper.emitted('update:lng').pop()).toEqual([1.3])
+})
+
+test('marker follows a dragged center', async () => {
+  const wrapper = mountMap()
+
+  wrapper.findComponent(LMapStub).vm.$emit('update:center', { lat: 48.85, lng: 2.35 })
+  await wrapper.vm.$nextTick()
+
+  expect(wrapper.findComponent(LMarkerStub).props('latLng')).toEqual([48.85, 2.35])
+})
+
+test('an external lat/lng change (new geocode) recentres the map', async () => {
+  const wrapper = mountMap()
+
+  await wrapper.setProps({ lat: 40.7, lng: -74.0 })
+
+  expect(wrapper.findComponent(LMarkerStub).props('latLng')).toEqual([40.7, -74.0])
+})
+
+test('prop echo of a drag does not re-emit', async () => {
+  const wrapper = mountMap()
+
+  wrapper.findComponent(LMapStub).vm.$emit('update:center', { lat: 52.1, lng: 1.3 })
+  await wrapper.vm.$nextTick()
+  const emitsAfterDrag = wrapper.emitted('update:lat').length
+
+  // Parent syncs the emitted values straight back down.
+  await wrapper.setProps({ lat: 52.1, lng: 1.3 })
+
+  expect(wrapper.emitted('update:lat').length).toBe(emitsAfterDrag)
+})

--- a/resources/js/components/GroupLocationMap.vue
+++ b/resources/js/components/GroupLocationMap.vue
@@ -1,17 +1,27 @@
 <template>
-  <l-map
-      class="map"
-      ref="group-map"
-      :zoom="11"
-      :center="[lat, lng]"
-      :style="'width: 100%; height: 200px'"
-  >
-    <l-tile-layer :url="tiles" :attribution="attribution" />
-    <l-marker :lat-lng="[lat, lng]" :interactive="false" />
-  </l-map>
+  <div>
+    <div class="mb-1">
+      {{ __('partials.dragmap') }}
+    </div>
+    <l-map
+        class="map"
+        ref="group-map"
+        :zoom="11"
+        :center="center"
+        :style="'width: 100%; height: 200px'"
+        @update:center="centerUpdated"
+    >
+      <l-tile-layer :url="tiles" :attribution="attribution" />
+      <l-marker :lat-lng="center" :interactive="false" />
+    </l-map>
+  </div>
 </template>
 <script>
 import map from '../mixins/map'
+
+// Below this difference two coordinates are "the same place" — stops the
+// parent syncing our own drag emission back down and re-centring the map.
+const EPSILON = 1e-7
 
 export default {
   mixins: [ map ],
@@ -27,26 +37,36 @@ export default {
       default: null
     },
   },
+  data () {
+    return {
+      center: [this.lat, this.lng]
+    }
+  },
   watch: {
-    lat(newLat) {
-      this.updateMapCenter()
+    lat() {
+      this.recentre()
     },
-    lng(newLng) {
-      this.updateMapCenter()
+    lng() {
+      this.recentre()
     }
   },
   methods: {
-    updateMapCenter() {
-      if (this.lat !== null && this.lng !== null && this.$refs['group-map'] && this.$refs['group-map'].mapObject) {
-        this.$refs['group-map'].mapObject.setView([this.lat, this.lng], this.$refs['group-map'].mapObject.getZoom())
+    centerUpdated(newCenter) {
+      // Fired by Leaflet when a drag finishes. The marker is pinned to the
+      // centre, so tell the parent where the pin now is.
+      this.center = [newCenter.lat, newCenter.lng]
+      this.$emit('update:lat', newCenter.lat)
+      this.$emit('update:lng', newCenter.lng)
+    },
+    recentre() {
+      // A genuinely new position (e.g. a fresh geocode from the location
+      // field) moves the map; the echo of our own drag does not.
+      if (this.lat !== null && this.lng !== null &&
+          (Math.abs(this.lat - this.center[0]) > EPSILON ||
+           Math.abs(this.lng - this.center[1]) > EPSILON)) {
+        this.center = [this.lat, this.lng]
       }
     }
-  },
-  mounted() {
-    // Ensure map is centered correctly on initial mount
-    this.$nextTick(() => {
-      this.updateMapCenter()
-    })
   }
 }
 </script>

--- a/tests/Feature/Groups/GroupLatLngOverrideTest.php
+++ b/tests/Feature/Groups/GroupLatLngOverrideTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature\Groups;
+
+use App\Group;
+use App\Helpers\Geocoder;
+use App\Network;
+use App\User;
+use Tests\TestCase;
+
+/**
+ * The group add/edit page shows a draggable map so users can fine-tune the
+ * pin after geocoding. When the client supplies an explicit lat/lng, the API
+ * must store those coordinates rather than overwriting them with the
+ * server-side geocode of the location text.
+ */
+class GroupLatLngOverrideTest extends TestCase
+{
+    private function apiUser(): User
+    {
+        $user = User::factory()->administrator()->create(['api_token' => '1234']);
+        $network = Network::factory()->create(['shortname' => 'network']);
+        $user->repair_network = $network->id;
+        $user->save();
+
+        return $user;
+    }
+
+    /** @test */
+    public function create_uses_client_lat_lng_when_supplied(): void
+    {
+        $this->apiUser();
+
+        // Deliberately different from the geocoder's London (51.5073, -0.1277)
+        // so we can tell whose coordinates won.
+        $response = $this->post('/api/v2/groups?api_token=1234', [
+            'name' => 'Dragged Group',
+            'location' => 'London',
+            'description' => 'Some text.',
+            'timezone' => 'Europe/London',
+            'lat' => 51.5197,
+            'lng' => -0.1409,
+        ]);
+
+        $response->assertSuccessful();
+        $group = Group::findOrFail(json_decode($response->getContent(), true)['id']);
+
+        $this->assertEqualsWithDelta(51.5197, $group->latitude, 0.00001);
+        $this->assertEqualsWithDelta(-0.1409, $group->longitude, 0.00001);
+        // Country still comes from geocoding the location text.
+        $this->assertEquals('GB', $group->country_code);
+    }
+
+    /** @test */
+    public function create_without_lat_lng_still_geocodes(): void
+    {
+        $this->apiUser();
+
+        $response = $this->post('/api/v2/groups?api_token=1234', [
+            'name' => 'Geocoded Group',
+            'location' => 'London',
+            'description' => 'Some text.',
+            'timezone' => 'Europe/London',
+        ]);
+
+        $response->assertSuccessful();
+        $group = Group::findOrFail(json_decode($response->getContent(), true)['id']);
+
+        $this->assertEqualsWithDelta(51.5073509, $group->latitude, 0.00001);
+        $this->assertEqualsWithDelta(-0.1277583, $group->longitude, 0.00001);
+    }
+
+    /** @test */
+    public function create_with_lat_lng_survives_geocode_failure(): void
+    {
+        $this->apiUser();
+
+        // The location text doesn't geocode, but the user has placed the pin
+        // themselves — that shouldn't block creation.
+        $response = $this->post('/api/v2/groups?api_token=1234', [
+            'name' => 'Pin Only Group',
+            'location' => 'ForceGeocodeFailure',
+            'description' => 'Some text.',
+            'timezone' => 'Europe/London',
+            'lat' => 48.8566,
+            'lng' => 2.3522,
+        ]);
+
+        $response->assertSuccessful();
+        $group = Group::findOrFail(json_decode($response->getContent(), true)['id']);
+
+        $this->assertEqualsWithDelta(48.8566, $group->latitude, 0.00001);
+        $this->assertEqualsWithDelta(2.3522, $group->longitude, 0.00001);
+        $this->assertNull($group->country_code);
+    }
+
+    /** @test */
+    public function create_rejects_out_of_range_lat_lng(): void
+    {
+        $this->apiUser();
+
+        $this->expectException(\Illuminate\Validation\ValidationException::class);
+
+        $this->post('/api/v2/groups?api_token=1234', [
+            'name' => 'Bad Coords Group',
+            'location' => 'London',
+            'description' => 'Some text.',
+            'timezone' => 'Europe/London',
+            'lat' => 123.0,
+            'lng' => -190.0,
+        ]);
+    }
+
+    /** @test */
+    public function edit_uses_client_lat_lng_when_supplied(): void
+    {
+        $this->apiUser();
+
+        $group = Group::factory()->create([
+            'location' => 'London',
+            'latitude' => 51.5073509,
+            'longitude' => -0.1277583,
+            'country_code' => 'GB',
+        ]);
+
+        // Location text unchanged, pin dragged.
+        $response = $this->patch('/api/v2/groups/' . $group->idgroups . '?api_token=1234', [
+            'name' => $group->name,
+            'location' => 'London',
+            'description' => 'Some text.',
+            'timezone' => 'Europe/London',
+            'lat' => 51.5540,
+            'lng' => -0.1744,
+        ]);
+
+        $response->assertSuccessful();
+        $group->refresh();
+
+        $this->assertEqualsWithDelta(51.5540, $group->latitude, 0.00001);
+        $this->assertEqualsWithDelta(-0.1744, $group->longitude, 0.00001);
+        // Unchanged location text keeps the existing country.
+        $this->assertEquals('GB', $group->country_code);
+    }
+
+    /** @test */
+    public function edit_without_lat_lng_keeps_existing_behaviour(): void
+    {
+        $this->apiUser();
+
+        $group = Group::factory()->create([
+            'location' => 'London',
+            'latitude' => 10.0,
+            'longitude' => 20.0,
+            'country_code' => 'GB',
+        ]);
+
+        // Unchanged location, no coords: keeps existing coords (no re-geocode).
+        $response = $this->patch('/api/v2/groups/' . $group->idgroups . '?api_token=1234', [
+            'name' => $group->name,
+            'location' => 'London',
+            'description' => 'Some text.',
+            'timezone' => 'Europe/London',
+        ]);
+
+        $response->assertSuccessful();
+        $group->refresh();
+
+        $this->assertEqualsWithDelta(10.0, $group->latitude, 0.00001);
+        $this->assertEqualsWithDelta(20.0, $group->longitude, 0.00001);
+    }
+}


### PR DESCRIPTION
Re-implements #637 (RES-1863, draggable map for group create/edit) from scratch on the current codebase. The old branch was 1,240 commits behind and conflicted with the build system; it also bundled the Mapbox geocoder switch, which belongs to RES-1858 (#644) and is deliberately not included here.

Since #637 was written, `develop` gained a static `GroupLocationMap` preview and Google Places autocomplete, so this PR is much smaller than the original:

- **`GroupLocationMap` becomes draggable**: the marker is pinned to the map centre; dragging emits `update:lat`/`update:lng`. A fresh geocode from the location field still recentres the map, with an epsilon guard so the parent echoing a drag back down doesn't fight the user. A `partials.dragmap` hint invites the fine-tune.
- **`GroupAddEdit`** syncs the dragged coordinates and includes `lat`/`lng` in the create/edit payloads (string-cast — the store's FormData builder drops falsy values, which would eat a 0 coordinate). The `:id`-based remount hack is removed; it would have destroyed the map on every drag.
- **API v2 `POST /groups` and `PATCH /groups/{id}`** accept optional `lat`/`lng` (validated numeric, in range, both-or-neither), which take precedence over the server-side geocode of the location text. Country still comes from geocoding, or from the existing record when the location text is unchanged. With an explicit pin, an ungeocodable location string is no longer fatal — the pin wins and the country is left null.

## Testing

- New `GroupLatLngOverrideTest` (6 tests): client coordinates win on create and edit; geocode fallback unchanged without them; out-of-range rejected; ungeocodable-location-with-pin succeeds; unchanged-location edit keeps existing coords.
- New `GroupLocationMap.test.js` (5 tests): drag emits updates, marker follows, external geocode recentres, echo-guard, hint text.
- Full Groups suite green (88 tests / 974 assertions); full Jest suite green (30 tests); translations check green (key added to en/fr/fr-BE only, per repo convention).
