### PR TITLE
Push a full avatar URL when a group is edited

### DIFF
--- a/app/Console/Commands/WordpressFixGroupAvatars.php
+++ b/app/Console/Commands/WordpressFixGroupAvatars.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Group;
+use HieuLe\WordpressXmlrpcClient\WordpressClient;
+use Illuminate\Console\Command;
+
+/**
+ * Backfill for groups whose WordPress group_avatar_url custom field holds a bare filename rather than a
+ * full URL.  Editing a group used to push env('UPLOADS_URL').'mid_'.$path, and UPLOADS_URL has never been
+ * defined in the Laravel app, so every group edited since the port left WordPress with an unrenderable
+ * src like "mid_1652779858....png" (or the literal string "null" for groups with no image at all).
+ */
+class WordpressFixGroupAvatars extends Command
+{
+    protected $signature = 'wordpress:group:fix-avatars
+                            {--dry-run : Report what would change without touching WordPress}
+                            {--id=* : Only check these group ids}
+                            {--limit= : Stop after this many groups have been checked}
+                            {--sleep=0 : Seconds to wait between groups, to go easy on WordPress}';
+
+    protected $description = 'Repair group_avatar_url custom fields in WordPress which hold a relative path';
+
+    /**
+     * The client is injected here rather than into the constructor.  Artisan resolves commands when it
+     * boots, which can happen well before the command runs, so a constructor dependency would be pinned to
+     * whatever was bound at boot time.
+     */
+    public function handle(WordpressClient $wpClient): int
+    {
+        if (! config('restarters.features.wordpress_integration')) {
+            $this->error('WordPress integration is disabled on this site.');
+
+            return self::FAILURE;
+        }
+
+        $dryRun = $this->option('dry-run');
+        $sleep = (float) $this->option('sleep');
+
+        $query = Group::whereNotNull('wordpress_post_id')
+            ->where('wordpress_post_id', '>', 0)
+            ->orderBy('idgroups');
+
+        if ($ids = $this->option('id')) {
+            $query->whereIn('idgroups', $ids);
+        }
+
+        if ($limit = $this->option('limit')) {
+            $query->limit((int) $limit);
+        }
+
+        $groups = $query->get();
+
+        $this->info(($dryRun ? '[dry run] ' : '').'Checking '.$groups->count().' groups with a WordPress post.');
+
+        $checked = $fixed = $skipped = $failed = 0;
+
+        foreach ($groups as $group) {
+            $checked++;
+
+            try {
+                $post = $wpClient->getPost($group->wordpress_post_id);
+            } catch (\Exception $e) {
+                $failed++;
+                $this->warn(sprintf(
+                    'Group %d (post %s): could not read post - %s',
+                    $group->idgroups,
+                    $group->wordpress_post_id,
+                    $e->getMessage()
+                ));
+
+                continue;
+            }
+
+            $field = $this->findCustomField($post, 'group_avatar_url');
+            $current = $field['value'] ?? null;
+
+            if ($this->isUsable($current)) {
+                $skipped++;
+
+                continue;
+            }
+
+            $wanted = $group->groupImagePath();
+
+            $this->line(sprintf(
+                'Group %d (post %s) "%s": %s -> %s',
+                $group->idgroups,
+                $group->wordpress_post_id,
+                $group->name,
+                $current === null ? '(no field)' : var_export($current, true),
+                $wanted
+            ));
+
+            if ($dryRun) {
+                $fixed++;
+
+                continue;
+            }
+
+            // Send only the avatar field, so we don't disturb anything else on the post.  The field's own
+            // id has to go with it, otherwise WordPress adds a second group_avatar_url rather than
+            // replacing the existing one.
+            $replacement = ['key' => 'group_avatar_url', 'value' => $wanted];
+
+            if (isset($field['id'])) {
+                $replacement['id'] = $field['id'];
+            }
+
+            try {
+                $wpClient->editPost($group->wordpress_post_id, ['custom_fields' => [$replacement]]);
+                $fixed++;
+            } catch (\Exception $e) {
+                $failed++;
+                $this->warn(sprintf(
+                    'Group %d (post %s): could not update post - %s',
+                    $group->idgroups,
+                    $group->wordpress_post_id,
+                    $e->getMessage()
+                ));
+            }
+
+            if ($sleep > 0) {
+                usleep((int) ($sleep * 1000000));
+            }
+        }
+
+        $this->info(sprintf(
+            '%s: %d checked, %d %s, %d already correct, %d failed.',
+            $dryRun ? 'Dry run' : 'Done',
+            $checked,
+            $fixed,
+            $dryRun ? 'would be fixed' : 'fixed',
+            $skipped,
+            $failed
+        ));
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function findCustomField($post, string $key): ?array
+    {
+        if (! is_array($post) || ! isset($post['custom_fields']) || ! is_array($post['custom_fields'])) {
+            return null;
+        }
+
+        foreach ($post['custom_fields'] as $field) {
+            if (isset($field['key']) && $field['key'] === $key) {
+                return $field;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * WordPress can only render the avatar if it's an absolute URL.  Anything else - a bare "mid_x.png",
+     * an empty string, or the literal string "null" that we used to send for groups with no image - needs
+     * replacing.
+     */
+    private function isUsable($value): bool
+    {
+        return is_string($value) && preg_match('#^https?://#i', $value) === 1;
+    }
+}

--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -963,21 +963,11 @@ class GroupController extends Controller
         }
 
         if (isset($_FILES) && !empty($_FILES)) {
-            // Update the group image.
+            // Update the group image.  We don't pass a URL through in the event data - the listeners which
+            // push to WordPress read the image back off the group via groupImagePath().
             $file = new \FixometerFile();
-            $group_avatar = $file->upload('image', 'image', $idGroup, env('TBL_GROUPS'), false, true, true);
-            $group_avatar = env('UPLOADS_URL').'mid_'.$group_avatar;
-        } else {
-            // Get the existing image to pass in data to the notification in case it needs it.
-            $existing_image = Fixometer::hasImage($idGroup, 'groups', true);
-            if (! empty($existing_image)) {
-                $group_avatar = env('UPLOADS_URL').'mid_'.$existing_image[0]->path;
-            } else {
-                $group_avatar = 'null';
-            }
+            $file->upload('image', 'image', $idGroup, env('TBL_GROUPS'), false, true, true);
         }
-
-        $data['group_avatar'] = $group_avatar;
 
         $group->update($data);
 

--- a/app/Listeners/EditWordpressPostForGroup.php
+++ b/app/Listeners/EditWordpressPostForGroup.php
@@ -28,7 +28,6 @@ class EditWordpressPostForGroup extends BaseEvent
     public function handle(EditGroup $event): void
     {
         $id = $event->group->idgroups;
-        $data = $event->data;
 
         $group = Group::find($id);
 
@@ -45,20 +44,23 @@ class EditWordpressPostForGroup extends BaseEvent
 
         try {
             if (is_numeric($group->wordpress_post_id)) {
+                // Read everything off the group, which the caller has already saved, rather than off the
+                // event payload.  That keeps this in step with CreateWordpressPostForGroup - notably the
+                // avatar, which the payload only ever held as a bare filename.
                 $custom_fields = [
                     ['key' => 'group_city', 'value' => $group->area],
                     ['key' => 'group_country', 'value' => Fixometer::getCountryFromCountryCode($group->country_code)],
-                    ['key' => 'group_website', 'value' => $data['website']],
+                    ['key' => 'group_website', 'value' => $group->website],
                     ['key' => 'group_hash', 'value' => $id],
-                    ['key' => 'group_avatar_url', 'value' => $data['group_avatar']],
-                    ['key' => 'group_latitude', 'value' => $data['latitude']],
-                    ['key' => 'group_longitude', 'value' => $data['longitude']],
+                    ['key' => 'group_avatar_url', 'value' => $group->groupImagePath()],
+                    ['key' => 'group_latitude', 'value' => $group->latitude],
+                    ['key' => 'group_longitude', 'value' => $group->longitude],
                 ];
 
                 $content = [
                     'post_type' => 'group',
-                    'post_title' => $data['name'],
-                    'post_content' => $data['free_text'],
+                    'post_title' => $group->name,
+                    'post_content' => $group->free_text,
                     'custom_fields' => $custom_fields,
                 ];
 
@@ -79,7 +81,7 @@ class EditWordpressPostForGroup extends BaseEvent
                     $content['custom_fields'] = $custom_fields;
                     $this->wpClient->editPost($group->wordpress_post_id, $content);
                 } else {
-                    $wpid = $this->wpClient->newPost($data['name'], $data['free_text'], $content);
+                    $wpid = $this->wpClient->newPost($group->name, $group->free_text, $content);
                     $group->wordpress_post_id = $wpid;
                     $group->save();
                 }

--- a/tests/Feature/Groups/WordpressFixGroupAvatarsTest.php
+++ b/tests/Feature/Groups/WordpressFixGroupAvatarsTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Group;
+use DB;
+use HieuLe\WordpressXmlrpcClient\WordpressClient;
+use Mockery;
+use Tests\TestCase;
+
+class WordpressFixGroupAvatarsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['restarters.features.wordpress_integration' => true]);
+    }
+
+    /** @test */
+    public function relative_avatar_paths_are_replaced_with_the_full_url(): void
+    {
+        $path = '1652779858f105814c6992b17930bf453ab9783610a5c8fb95489.png';
+        $group = $this->groupWithPost(100, $path);
+
+        $edited = null;
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) use (&$edited) {
+            $mock->shouldReceive('getPost')->with(100)->andReturn([
+                'custom_fields' => [
+                    ['id' => '7', 'key' => 'group_city', 'value' => 'Portsmouth'],
+                    ['id' => '11', 'key' => 'group_avatar_url', 'value' => 'mid_1652779858f105814c6992b17930bf453ab9783610a5c8fb95489.png'],
+                ],
+            ]);
+            $mock->shouldReceive('editPost')->once()->andReturnUsing(function ($postId, $content) use (&$edited) {
+                $edited = [$postId, $content];
+
+                return true;
+            });
+        }));
+
+        $this->artisan('wordpress:group:fix-avatars')->assertSuccessful();
+
+        $this->assertNotNull($edited);
+        [$postId, $content] = $edited;
+        $this->assertEquals(100, $postId);
+
+        // Only the avatar field should be touched, and it must carry the existing field id so that
+        // WordPress replaces the value rather than adding a second field.
+        $this->assertEquals([
+            'custom_fields' => [
+                ['key' => 'group_avatar_url', 'value' => asset('/uploads/mid_'.$path), 'id' => '11'],
+            ],
+        ], $content);
+    }
+
+    /** @test */
+    public function the_literal_string_null_is_replaced_too(): void
+    {
+        $this->groupWithPost(101, null);
+
+        $edited = null;
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) use (&$edited) {
+            $mock->shouldReceive('getPost')->with(101)->andReturn([
+                'custom_fields' => [
+                    ['id' => '11', 'key' => 'group_avatar_url', 'value' => 'null'],
+                ],
+            ]);
+            $mock->shouldReceive('editPost')->once()->andReturnUsing(function ($postId, $content) use (&$edited) {
+                $edited = $content;
+
+                return true;
+            });
+        }));
+
+        $this->artisan('wordpress:group:fix-avatars')->assertSuccessful();
+
+        $this->assertNotNull($edited);
+        $this->assertStringStartsWith('http', $edited['custom_fields'][0]['value']);
+    }
+
+    /** @test */
+    public function groups_which_are_already_correct_are_left_alone(): void
+    {
+        $path = '1740242182255d38b64da3e4f70b8a1c13030c3a3f4ab44dbf11313.jpg';
+        $this->groupWithPost(102, $path);
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) use ($path) {
+            $mock->shouldReceive('getPost')->with(102)->andReturn([
+                'custom_fields' => [
+                    ['id' => '11', 'key' => 'group_avatar_url', 'value' => 'https://restarters.net/uploads/mid_'.$path],
+                ],
+            ]);
+            $mock->shouldReceive('editPost')->never();
+        }));
+
+        $this->artisan('wordpress:group:fix-avatars')->assertSuccessful();
+    }
+
+    /** @test */
+    public function a_dry_run_changes_nothing(): void
+    {
+        $this->groupWithPost(103, 'foo.png');
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) {
+            $mock->shouldReceive('getPost')->with(103)->andReturn([
+                'custom_fields' => [
+                    ['id' => '11', 'key' => 'group_avatar_url', 'value' => 'mid_foo.png'],
+                ],
+            ]);
+            $mock->shouldReceive('editPost')->never();
+        }));
+
+        $this->artisan('wordpress:group:fix-avatars --dry-run')->assertSuccessful();
+    }
+
+    /** @test */
+    public function a_group_whose_post_has_gone_is_reported_but_does_not_stop_the_run(): void
+    {
+        $this->groupWithPost(104, 'foo.png');
+        $this->groupWithPost(105, 'bar.png');
+
+        $edited = [];
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) use (&$edited) {
+            $mock->shouldReceive('getPost')->with(104)->andThrow(new \Exception('Invalid post ID.'));
+            $mock->shouldReceive('getPost')->with(105)->andReturn([
+                'custom_fields' => [
+                    ['id' => '11', 'key' => 'group_avatar_url', 'value' => 'mid_bar.png'],
+                ],
+            ]);
+            $mock->shouldReceive('editPost')->once()->andReturnUsing(function ($postId, $content) use (&$edited) {
+                $edited[] = $postId;
+
+                return true;
+            });
+        }));
+
+        // The failure is reported in the exit code, but the second group is still repaired.
+        $this->artisan('wordpress:group:fix-avatars')->assertFailed();
+        $this->assertEquals([105], $edited);
+    }
+
+    /** @test */
+    public function it_refuses_to_run_when_wordpress_integration_is_disabled(): void
+    {
+        config(['restarters.features.wordpress_integration' => false]);
+
+        $this->groupWithPost(106, 'foo.png');
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) {
+            $mock->shouldReceive('getPost')->never();
+            $mock->shouldReceive('editPost')->never();
+        }));
+
+        $this->artisan('wordpress:group:fix-avatars')
+            ->expectsOutputToContain('disabled')
+            ->assertFailed();
+    }
+
+    private function groupWithPost(int $wordpressPostId, ?string $imagePath): Group
+    {
+        $group = Group::factory()->create([
+            'wordpress_post_id' => $wordpressPostId,
+            'approved' => true,
+        ]);
+
+        if ($imagePath !== null) {
+            $imageId = DB::table('images')->insertGetId(['path' => $imagePath]);
+
+            DB::table('xref')->insert([
+                'object' => $imageId,
+                'object_type' => 5,
+                'reference' => $group->idgroups,
+                'reference_type' => env('TBL_GROUPS'),
+            ]);
+        }
+
+        return $group;
+    }
+}

--- a/tests/Feature/Groups/WordpressGroupPushTest.php
+++ b/tests/Feature/Groups/WordpressGroupPushTest.php
@@ -86,4 +86,154 @@ class WordpressGroupPushTest extends TestCase
         event(new EditGroup($group, $groupData));
         $this->artisan("queue:work --stop-when-empty");
     }
+
+    /** @test */
+    public function group_avatar_pushed_as_absolute_url_when_edited(): void
+    {
+        $edited = null;
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) use (&$edited) {
+            $mock->shouldReceive('getPost')->andReturn([]);
+            $mock->shouldReceive('editPost')->once()->andReturnUsing(function ($postId, $content) use (&$edited) {
+                $edited = $content;
+
+                return true;
+            });
+        }));
+
+        $network = Network::factory()->create([
+            'name' => 'Restart',
+            'events_push_to_wordpress' => true,
+        ]);
+        $group = Group::factory()->create([
+            'wordpress_post_id' => 100,
+            'approved' => true,
+        ]);
+        $network->addGroup($group);
+
+        $path = '1740242182255d38b64da3e4f70b8a1c13030c3a3f4ab44dbf11313.jpg';
+        $this->giveGroupAnImage($group, $path);
+
+        $groupData = Group::factory()->raw();
+        // The API used to put a bare filename in here, because UPLOADS_URL has never been defined.
+        $groupData['group_avatar'] = 'mid_'.$path;
+
+        event(new EditGroup($group, $groupData));
+        $this->artisan('queue:work --stop-when-empty');
+
+        $this->assertNotNull($edited);
+        $avatar = $this->customField($edited, 'group_avatar_url');
+        $this->assertEquals(asset('/uploads/mid_'.$path), $avatar);
+    }
+
+    /** @test */
+    public function group_with_no_image_still_pushes_an_absolute_url_when_edited(): void
+    {
+        $edited = null;
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) use (&$edited) {
+            $mock->shouldReceive('getPost')->andReturn([]);
+            $mock->shouldReceive('editPost')->once()->andReturnUsing(function ($postId, $content) use (&$edited) {
+                $edited = $content;
+
+                return true;
+            });
+        }));
+
+        $network = Network::factory()->create([
+            'name' => 'Restart',
+            'events_push_to_wordpress' => true,
+        ]);
+        $group = Group::factory()->create([
+            'wordpress_post_id' => 100,
+            'approved' => true,
+        ]);
+        $network->addGroup($group);
+
+        $groupData = Group::factory()->raw();
+        // This is what the API sent for a group with no image at all.
+        $groupData['group_avatar'] = 'null';
+
+        event(new EditGroup($group, $groupData));
+        $this->artisan('queue:work --stop-when-empty');
+
+        $this->assertNotNull($edited);
+        $avatar = $this->customField($edited, 'group_avatar_url');
+        $this->assertEquals($group->fresh()->groupImagePath(), $avatar);
+        $this->assertStringStartsWith('http', $avatar);
+    }
+
+    /** @test */
+    public function created_and_edited_groups_push_the_same_avatar_url(): void
+    {
+        $created = null;
+        $edited = null;
+
+        $this->instance(WordpressClient::class, Mockery::mock(WordpressClient::class, function ($mock) use (&$created, &$edited) {
+            $mock->shouldReceive('getPost')->andReturn([]);
+            $mock->shouldReceive('newPost')->once()->andReturnUsing(function ($title, $body, $content) use (&$created) {
+                $created = $content;
+
+                return 100;
+            });
+            $mock->shouldReceive('editPost')->once()->andReturnUsing(function ($postId, $content) use (&$edited) {
+                $edited = $content;
+
+                return true;
+            });
+        }));
+
+        $this->instance(CreateDiscourseGroupForGroup::class, Mockery::mock(CreateDiscourseGroupForGroup::class, function ($mock) {
+            $mock->shouldReceive('handle');
+        }));
+
+        $network = Network::factory()->create([
+            'name' => 'Restart',
+            'events_push_to_wordpress' => true,
+        ]);
+        $group = Group::factory()->create();
+        $network->addGroup($group);
+
+        $path = '1740242182255d38b64da3e4f70b8a1c13030c3a3f4ab44dbf11313.jpg';
+        $this->giveGroupAnImage($group, $path);
+
+        $groupData = Group::factory()->raw();
+        $groupData['group_avatar'] = 'mid_'.$path;
+
+        event(new ApproveGroup($group, $groupData));
+        $this->artisan('queue:work --stop-when-empty');
+
+        event(new EditGroup($group->fresh(), $groupData));
+        $this->artisan('queue:work --stop-when-empty');
+
+        $this->assertNotNull($created);
+        $this->assertNotNull($edited);
+        $this->assertEquals(
+            $this->customField($created, 'group_avatar_url'),
+            $this->customField($edited, 'group_avatar_url')
+        );
+    }
+
+    private function giveGroupAnImage(Group $group, string $path): void
+    {
+        $imageId = DB::table('images')->insertGetId(['path' => $path]);
+
+        DB::table('xref')->insert([
+            'object' => $imageId,
+            'object_type' => 5,
+            'reference' => $group->idgroups,
+            'reference_type' => env('TBL_GROUPS'),
+        ]);
+    }
+
+    private function customField(array $content, string $key)
+    {
+        foreach ($content['custom_fields'] as $field) {
+            if ($field['key'] === $key) {
+                return $field['value'];
+            }
+        }
+
+        $this->fail("No $key custom field was pushed to WordPress");
+    }
 }


### PR DESCRIPTION
## The bug

Group avatars are broken on therestartproject.org for any group that has been **edited** since the Laravel port.

- https://therestartproject.org/groups/portsmouth-repair-cafe/ → `<img src="mid_16527798588f105814c6992b17930bf453ab9783610a5c8fb95489.png">`
- https://therestartproject.org/groups/saras-fix/ → `<img src="https://restarters.net/uploads/mid_1740242182255d38b64da3e4f70b8a1c13030c3a3f4ab44dbf11313.jpg">`

## Root cause

The create and edit paths built `group_avatar_url` two different ways.

`CreateWordpressPostForGroup` uses the model:

```php
['key' => 'group_avatar_url', 'value' => $group->groupImagePath()],   // asset('/uploads/mid_'.$path) → absolute
```

`EditWordpressPostForGroup` used the event payload, which `API\GroupController::updateGroup` built like this:

```php
$group_avatar = env('UPLOADS_URL').'mid_'.$group_avatar;
```

**`UPLOADS_URL` has never existed in the Laravel app.** It was a PHP constant in the pre-Laravel Fixometer
(`f0dac97`) and was not carried over — it is not in `.env`, `.env.example`, `config/`, or any of the fly
configs. So `env('UPLOADS_URL')` returns `null` and the pushed value collapses to a bare `mid_….png`, with no
host and not even the `/uploads/` directory. WordPress renders that verbatim, so the image 404s.

Approving a group wrote a good URL; the next edit overwrote it with a broken one. That's exactly the
difference between the two pages above.

(The `else` branch had the same problem, and sent the literal string `'null'` for a group with no image.)

## The fix

`EditWordpressPostForGroup` now reads its payload off the group — which `updateGroup` has already saved —
instead of off the event array, so it can't drift from `CreateWordpressPostForGroup` again. That also removes
a latent `Undefined array key` crash: the listener indexed `$data['website']`, `$data['latitude']` etc.
directly, so any caller firing `EditGroup` with a partial array would have failed the queued job.

The dead `UPLOADS_URL` URL-building in `API\GroupController::updateGroup` is gone; the image upload itself
(the only part with a side effect) stays.

## Backfill

`php artisan wordpress:group:fix-avatars`

Walks groups with a `wordpress_post_id`, reads the post's `group_avatar_url`, and rewrites any value that
isn't an absolute URL to `$group->groupImagePath()`. It sends only that one custom field, carrying the
field's existing WordPress id so the value is replaced rather than duplicated.

```
--dry-run    report without touching WordPress
--id=        restrict to specific group ids (repeatable)
--limit=     stop after N groups
--sleep=     seconds between groups
```

The client is injected into `handle()` rather than the constructor. Artisan resolves commands when it boots,
which can be long before the command runs — with a constructor dependency the command kept whatever was bound
at boot time, and a test binding a mock afterwards got ignored and made a real XML-RPC call out to
`therestartproject.test`. That only showed up when another test had already booted Artisan (via
`processQueuedNotifications()` in `TestCase::setUp`), so the test passed alone and failed in suite order.

Suggested run:

```bash
php artisan wordpress:group:fix-avatars --dry-run
php artisan wordpress:group:fix-avatars --sleep=0.5
```

## Scale on live

I swept all 623 group pages in https://therestartproject.org/group-sitemap.xml. 22 are broken; the other 601
are fine.

| group id | slug | name |
|---|---|---|
| 10 | restarters-torino | Restarters Torino |
| 49 | portsmouth-repair-cafe | Repair Café Portsmouth |
| 58 | restarters-tooting | Restarters Tooting |
| 140 | repair-cafe-pavia | Repair Cafe Pavia |
| 423 | west-central-london-fixers-north-kensington | West Central London Fixers – Kensington & Chelsea |
| 483 | walton-on-thames-repair-cafe | Repair Cafe Walton-on-Thames |
| 529 | ulverston-repair-cafe | Ulverston Repair Café |
| 824 | sustainable-napier | Napier Repair Cafe |
| 969 | tower-hamlets-fixers | Tower Hamlets Repair Cafes |
| 1040 | winterbourne-repair-cafe | Winterbourne Repair Cafe |
| 1086 | bowes-bounds-repair-cafe | Bowes & Bounds Repair Café |
| 1221 | ramsgate-repair-cafe-and-town-shed | Ramsgate Repair Cafe |
| 1247 | repair-cafe-mo-annoeulin | Repair Café MO Annoeullin |
| 1269 | godmanchester-repair-cafe | Godmanchester Repair Cafe |
| 1299 | kidbrooke-repair-cafe | Kidbrooke Repair Café |
| 1305 | remake-mending-circle | Remake Mending Circle |
| 1313 | centre-for-computing-history | Centre for Computing History |
| 1383 | tamaki-zero-waste-hub-repair-cafe | Tāmaki Zero Waste Hub Repair Café |
| 1401 | tullymeadow-repair-cafe | Tullymeadow Repair Cafe |
| 1402 | newlands-and-waterlooville-repair-cafe | Newlands and Waterlooville Repair Cafe |
| 1426 | repair-cafe-titchfield | Repair Café Titchfield |
| 1447 | wimbledon-repair-cafe | Wimbledon Repair Cafe |

So a targeted run is also an option:

```bash
php artisan wordpress:group:fix-avatars --id=10 --id=49 --id=58 --id=140 --id=423 --id=483 --id=529 \
  --id=824 --id=969 --id=1040 --id=1086 --id=1221 --id=1247 --id=1269 --id=1299 --id=1305 --id=1313 \
  --id=1383 --id=1401 --id=1402 --id=1426 --id=1447
```

## Tests

`WordpressGroupPushTest` gains three cases: the avatar pushed on edit must be the absolute
`groupImagePath()`, a group with no image must still get an absolute URL rather than `'null'`, and create and
edit must push the same value. All three fail on the old listener (the first with
`Failed asserting that two strings are equal`).

`WordpressFixGroupAvatarsTest` covers the backfill: relative paths and the literal `'null'` are rewritten,
already-correct posts are left alone, `--dry-run` writes nothing, a group whose post has been deleted is
reported without aborting the run, and the command refuses when `wordpress_integration` is off.

## Not affected

The event/party push (`CreateWordpressPostForEvent`, `EditWordpressPostForEvent`) never sends an image field,
and `SyncGroups` doesn't touch `group_avatar_url`, so neither could cause or repair this.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRv64fqMT3fAveD6NFgnmR
