### PR TITLE
Use a CARTO API key for map tiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,9 @@ DISCOURSE_APIKEY=1234
 REPAIRDIRECTORY_URL=http://map.restarters.test
 
 MAPBOX_TOKEN=1234
+# API key for CARTO basemap tiles (https://carto.com/basemaps/apikey/).
+# Without one the map tiles are watermarked but still render.
+CARTO_API_KEY=
 GOOGLE_ANALYTICS_TRACKING_ID=UA-12345678-1
 GOOGLE_TAG_MANAGER_ID=GTM-1ABCDEF
 GOOGLE_API_CONSOLE_KEY=1234

--- a/config/restarters.php
+++ b/config/restarters.php
@@ -18,6 +18,14 @@ return [
         'base_url' => env('REPAIRDIRECTORY_URL'),
     ],
 
+    'carto' => [
+        // CARTO's raster basemaps need an API key; without one the tiles come
+        // back watermarked. The key is served to the browser, so it isn't a
+        // secret in the usual sense, but keeping it in config means it stays
+        // out of the repo and can differ per environment.
+        'api_key' => env('CARTO_API_KEY'),
+    ],
+
     'xref_types' => [
         'networks' => 7,
     ],

--- a/fly.pr-secrets.example.env
+++ b/fly.pr-secrets.example.env
@@ -45,6 +45,9 @@ RCLONE_CONFIG_GDRIVE_SERVICE_ACCOUNT_CREDENTIALS=<single-line-service-account-js
 #   fly ssh console -a restarters -C "printenv GOOGLE_API_CONSOLE_KEY"
 MAPBOX_TOKEN=<mapbox-token>
 GOOGLE_API_CONSOLE_KEY=<google-api-console-key>
+#   fly ssh console -a restarters -C "printenv CARTO_API_KEY"
+# Map tiles are watermarked without this, but the maps still work.
+CARTO_API_KEY=<carto-basemaps-key>
 
 # Optional: uncomment to report preview errors to Sentry (tagged environment=preview).
 # SENTRY_LARAVEL_DSN=<sentry-dsn>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -24,7 +24,7 @@ L.Icon.Default.mergeOptions({
     shadowUrl: markerShadow,
 });
 
-import './constants';
+import { LEAFLET_ATTRIBUTION, leafletTiles } from './constants';
 
 import Vue from 'vue'
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue'
@@ -775,8 +775,8 @@ function initAutocomplete() {
       if( latitude && longitude ){
           let map = L.map('event-map').setView([latitude, longitude], zoom);
 
-          L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png', {
-              attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>'
+          L.tileLayer(leafletTiles(), {
+              attribution: LEAFLET_ATTRIBUTION
           }).addTo(map);
 
           var icon = new L.Icon.Default();

--- a/resources/js/constants.js
+++ b/resources/js/constants.js
@@ -14,6 +14,16 @@ export const TIME_FORMAT = 'HH:MM'
 export const LEAFLET_TILES = 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png'
 export const LEAFLET_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>'
 
+// CARTO's raster basemaps require an API key; without one the tiles still load
+// but carry an "API key required" watermark. The key is injected into the page
+// by the Blade layout (see layouts/header.blade.php) rather than compiled in,
+// because the assets are built before the deployed environment's secrets exist.
+export function leafletTiles() {
+  const key = (typeof window !== 'undefined' && window.restarters && window.restarters.cartoApiKey) || ''
+
+  return key ? `${LEAFLET_TILES}?key=${encodeURIComponent(key)}` : LEAFLET_TILES
+}
+
 // These match the string definitions in Device.php
 export const FIXED = 'Fixed'
 export const REPAIRABLE = 'Repairable'

--- a/resources/js/misc/leafletTiles.test.js
+++ b/resources/js/misc/leafletTiles.test.js
@@ -1,0 +1,31 @@
+import { LEAFLET_TILES, leafletTiles } from '../constants'
+
+afterEach(() => {
+  delete window.restarters
+})
+
+test('returns the bare tile URL when no CARTO key has been injected', () => {
+  expect(leafletTiles()).toBe(LEAFLET_TILES)
+})
+
+test('returns the bare tile URL when the key is present but empty', () => {
+  window.restarters = { cartoApiKey: '' }
+
+  expect(leafletTiles()).toBe(LEAFLET_TILES)
+})
+
+test('appends the CARTO key when one has been injected', () => {
+  window.restarters = { cartoApiKey: 'cb1_test_key' }
+
+  expect(leafletTiles()).toBe(LEAFLET_TILES + '?key=cb1_test_key')
+})
+
+test('leaves the Leaflet placeholders intact so tiles still resolve', () => {
+  window.restarters = { cartoApiKey: 'cb1_test_key' }
+
+  const url = leafletTiles()
+
+  for (const placeholder of ['{s}', '{z}', '{x}', '{y}', '{r}']) {
+    expect(url).toContain(placeholder)
+  }
+})

--- a/resources/js/mixins/map.js
+++ b/resources/js/mixins/map.js
@@ -1,4 +1,4 @@
-import { DATE_FORMAT, LEAFLET_ATTRIBUTION, LEAFLET_TILES } from '../constants'
+import { DATE_FORMAT, LEAFLET_ATTRIBUTION, leafletTiles } from '../constants'
 
 export default {
   computed: {
@@ -6,7 +6,7 @@ export default {
       return LEAFLET_ATTRIBUTION
     },
     tiles() {
-      return LEAFLET_TILES
+      return leafletTiles()
     }
   }
 }

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -48,6 +48,9 @@
     <script>
         window.restarters = {};
         restarters.cookie_domain = '{{ env('SESSION_DOMAIN') }}';
+        // Passed through at runtime rather than baked into the built JS: the
+        // production key only exists as a Fly secret, long after the asset build.
+        restarters.cartoApiKey = @json(config('restarters.carto.api_key'));
         var gdprCookiesCheck = Cookies;
         var gdprCurrentCookiesSelection = gdprCookiesCheck.getJSON('gdprcookienotice');
         restarters.analyticsCookieEnabled = (typeof gdprCurrentCookiesSelection !== 'undefined' && gdprCurrentCookiesSelection['analytics']);

--- a/resources/views/layouts/header_plain.blade.php
+++ b/resources/views/layouts/header_plain.blade.php
@@ -63,6 +63,9 @@
         <script>
          window.restarters = {};
          restarters.cookie_domain = '{{ env('SESSION_DOMAIN') }}';
+         // Passed through at runtime rather than baked into the built JS: the
+         // production key only exists as a Fly secret, long after the asset build.
+         restarters.cartoApiKey = @json(config('restarters.carto.api_key'));
          var gdprCookiesCheck = Cookies;
          var gdprCurrentCookiesSelection = gdprCookiesCheck.getJSON('gdprcookienotice');
          restarters.analyticsCookieEnabled = (typeof gdprCurrentCookiesSelection !== 'undefined' && gdprCurrentCookiesSelection['analytics']);


### PR DESCRIPTION
CARTO now require an API key on their raster basemaps. Without one the tiles still load, but each is stamped **API KEY REQUIRED** — visible on every group, event and venue map on the site.

## Approach

The key is injected at runtime via `window.restarters`, next to the config already passed that way, rather than compiled into the bundle. `Dockerfile.fly` runs `npm run production` against a stub `.env` long before the deployed environment's secrets exist, so a `VITE_` variable would bake in an empty string and never see the Fly secret.

`leafletTiles()` appends the key when present and returns the bare URL when not, so an unconfigured environment degrades to the watermark rather than a broken map. The standalone `#event-map` in `app.js` had its own copy of the tile URL and now shares the helper.

The key is not secret in any meaningful sense — it is served to every visitor in the page — but keeping it in config keeps it out of the repo and lets it differ per environment.

## Secrets

Already staged as `CARTO_API_KEY` on `restarters`, `restarters-dev` and `restarters-yesterday` (staged, so it lands with this deploy — no extra restart). `FLY_PREVIEW_SECRETS` has been updated so previews get it too.

## Verification

- A tile fetched with the key returns clean; without it, watermarked. A bogus key returns a byte-identical watermarked tile, confirming the `?key=` parameter is read. Retina `@2x` works.
- 4 new unit tests for `leafletTiles()`; full Jest suite (29) passes; `npm run production` builds.
- Built bundle contains the runtime lookup and *not* the key.