### PR TITLE
fix: stop createEvent picking a past date for a future event

### DIFF
--- a/tests/Integration/utils.js
+++ b/tests/Integration/utils.js
@@ -168,13 +168,30 @@ exports.createEvent = async function(page, baseURL, idgroups, past) {
   log('Setting event date', { past })
   await page.click('#event_date button')
 
+  // The click below lands on the first day of the calendar's final week row,
+  // which is near the end of whichever month is on display.  In the current
+  // month that date is in the past for the last few days of every month, which
+  // quietly created a finished event when we asked for a future one, so shift a
+  // month in the direction we want rather than relying on today's position.
   if (past) {
     log('Setting past date - going back a month')
-    // Go back a month
     await page.locator('[aria-label="Previous month"]').click()
+  } else {
+    log('Setting future date - going forward a month')
+    await page.locator('[aria-label="Next month"]').click()
   }
 
   await page.click('#event_date .b-calendar-grid > .b-calendar-grid-body > .row:last-child .btn:last-child')
+
+  // A mis-picked date changes which actions the event offers, which surfaces as
+  // a puzzling timeout much later in whichever test used this helper.  Fail here
+  // instead, saying what went wrong.
+  const chosenDate = await page.locator('input[name="event_date"]').inputValue()
+  const todayDate = await page.evaluate(() => new Date().toISOString().slice(0, 10))
+  if (past ? chosenDate >= todayDate : chosenDate <= todayDate) {
+    throw new Error(`createEvent(past=${past}) picked ${chosenDate}, but today is ${todayDate}`)
+  }
+  log('Event date set', { chosenDate, todayDate, past })
 
   log('Setting event times')
   await page.click('#event_time input[name="start"]')


### PR DESCRIPTION
`develop` has been red since 31 August, and it is a dormant fixture bug rather than a code regression.

## Cause

`createEvent` picks a date with:

```js
await page.click('#event_date .b-calendar-grid > ... .row:last-child .btn:last-child')
```

`page.click` is not strict, so it takes the **first** of the seven matches in the final week row, not the last. That day sits near the end of the displayed month — so for the last few days of every month it is on or before today, and `createEvent(past=false)` silently produced a *finished* event.

`EventActions` renders a different branch when an event is finished (Request review / Share event stats / Download event data) with no **Invite volunteers** item at all, so the test timed out waiting for a dropdown item that was never going to appear. The CI failure screenshot shows exactly that: an event dated **30 Aug 2026** on a run dated **31 Aug 2026**, dropdown open on the finished branch.

Green on 15 Jul, red on 31 Aug, with no relevant code change in between — the only two commits between those runs were the WordPress group avatar fix and its merge.

## Fix

Shift a month in the direction we want, mirroring what the `past` branch already did, then assert the date we actually landed on. Without that assertion a mis-picked date surfaces as a confusing timeout much later in whichever test used the helper.

## Verification

Against the local site with the browser clock faked (both the grid and the assertion are client-side):

| Date | Old click picks | Patched helper |
|---|---|---|
| 2026-08-31 | 2026-08-30 — past | OK |
| 2026-12-29 | 2026-12-27 — past | OK |
| 2026-09-02 | 2026-09-27 — future | test passes |

`Invite volunteers modal opens from Event Actions dropdown` passes locally with the change.

This should also clear the same test's noise on #835.