### PR TITLE
Stop GeocoderTest calling Google

### DIFF
--- a/app/Helpers/Geocoder.php
+++ b/app/Helpers/Geocoder.php
@@ -14,10 +14,20 @@ class Geocoder
         return config('GOOGLE_API_CONSOLE_KEY') ?? env('GOOGLE_API_CONSOLE_KEY');
     }
 
+    /**
+     * Fetch a URL.  Separated out so that tests can exercise the parsing below
+     * without calling Google, which makes them depend on the network, the key
+     * and the quota all being healthy.
+     */
+    protected function fetch($url)
+    {
+        return file_get_contents($url);
+    }
+
     public function geocode($location)
     {
         if ($location != 'ForceGeocodeFailure') {
-            $json = file_get_contents('https://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&key='.$this->googleKey());
+            $json = $this->fetch('https://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&key='.$this->googleKey());
 
             if ($json) {
                 $res = json_decode($json);
@@ -48,7 +58,7 @@ class Geocoder
 
     public function reverseGeocode($lat, $lng)
     {
-        $json = file_get_contents("https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lng&key=".$this->googleKey());
+        $json = $this->fetch("https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lng&key=".$this->googleKey());
 
         $decoded = json_decode($json)->results[0];
 

--- a/tests/Unit/GeocoderTest.php
+++ b/tests/Unit/GeocoderTest.php
@@ -1,15 +1,76 @@
 <?php
 
-
 use Tests\TestCase;
 
 class GeocoderTest extends TestCase
 {
-    public function testGeocode(): void {
-        $geocoder = new \App\Helpers\Geocoder();
-        $ret = $geocoder->geocode('6 Canterbury Crescent, London SW9 7QD');
+    /**
+     * A trimmed response for the address below, keeping the parts geocode()
+     * reads: the location and the country component.
+     */
+    private function cannedResponse(): string
+    {
+        return json_encode([
+            'status' => 'OK',
+            'results' => [
+                [
+                    'geometry' => [
+                        'location' => ['lat' => 51.4643585, 'lng' => -0.1135401],
+                    ],
+                    'address_components' => [
+                        ['short_name' => 'SW9 7QD', 'types' => ['postal_code']],
+                        ['short_name' => 'GB', 'types' => ['country', 'political']],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function geocoderReturning($body): \App\Helpers\Geocoder
+    {
+        return new class($body) extends \App\Helpers\Geocoder {
+            private $body;
+
+            public function __construct($body)
+            {
+                parent::__construct();
+                $this->body = $body;
+            }
+
+            protected function fetch($url)
+            {
+                return $this->body;
+            }
+        };
+    }
+
+    public function testGeocode(): void
+    {
+        $ret = $this->geocoderReturning($this->cannedResponse())
+            ->geocode('6 Canterbury Crescent, London SW9 7QD');
+
         $this->assertEquals(round(51.4643585, 2), round($ret['latitude'], 2));
         $this->assertEquals(round(-0.1135401, 2), round($ret['longitude'], 2));
         $this->assertEquals('GB', $ret['country_code']);
+    }
+
+    public function testGeocodeReturnsFalseWhenNothingFound(): void
+    {
+        $empty = json_encode(['status' => 'ZERO_RESULTS', 'results' => []]);
+
+        $this->assertFalse($this->geocoderReturning($empty)->geocode('nowhere at all'));
+    }
+
+    public function testGeocodeReturnsFalseWhenTheRequestFails(): void
+    {
+        // file_get_contents returns false on a failed request.  This is the case
+        // that made the old test error with "array offset on value of type bool"
+        // whenever Google was unreachable or the key was unhappy.
+        $this->assertFalse($this->geocoderReturning(false)->geocode('6 Canterbury Crescent'));
+    }
+
+    public function testForcedFailureShortCircuits(): void
+    {
+        $this->assertFalse($this->geocoderReturning($this->cannedResponse())->geocode('ForceGeocodeFailure'));
     }
 }


### PR DESCRIPTION
`tests/Unit/GeocoderTest.php` built a `Geocoder` directly and geocoded a real address against the live Google Maps API. When that call fails — network, key, or quota — `geocode()` returns `false` and the test errors:

```
ErrorException : Trying to access array offset on value of type bool
  /var/www/tests/Unit/GeocoderTest.php:11
```

That is what failed CI on #900 (`feat/ords-repairs-export`), which has nothing to do with geocoding. PHPUnit passed on `develop`'s later run, so it comes and goes with the API — a unit test depending on a third party being reachable.

## Change

Move the HTTP call behind a `protected fetch()`, the same idea as the existing `googleKey()` seam ("We have this so that we can change the key in testing"), and have the test subclass it with a canned response. The assertions on parsed latitude, longitude and country code are unchanged, so what the test was actually checking — that a Google response is parsed correctly — is still checked.

Three paths that had no coverage are now tested: no results, a failed request (exactly the case that produced the error above), and the `ForceGeocodeFailure` short circuit.

`GeocoderMock` overrides `geocode()` outright, so tests resolving the geocoder from the container are unaffected — `GroupEditGeocodeFallbackTest` still passes.

## Verification

```
phpunit --filter GeocoderTest            OK (4 tests, 6 assertions)
phpunit GroupEditGeocodeFallbackTest     OK (2 tests, 7 assertions)
```