### PR TITLE
ci: verify production after deploy, and restart once if it is down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,10 +243,14 @@ jobs:
           command: |
             export FLY_API_TOKEN="FlyV1 $FLY_API_TOKEN"
 
-            # Probe from outside Fly, on the same path the Fly health check
-            # uses.  robots.txt is static, so a 200 means nginx is up and the
-            # proxy has a healthy instance to route to - it does not depend on
-            # the database being reachable.
+            # Two probes, because they answer different questions.
+            #
+            # robots.txt is static: a 200 means nginx is up and the proxy has an
+            # instance to route to.  That is also the path the Fly health check
+            # uses - which is exactly why it cannot be the only probe.  On
+            # 2026-09-03 restarters-dev served robots.txt, and reported a passing
+            # health check, while every database-backed page returned 500,
+            # because it was pointed at a database app that no longer existed.
             serving() {
               for _ in $(seq 1 "$1"); do
                 code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 \
@@ -257,11 +261,37 @@ jobs:
               return 1
             }
 
-            if serving 12; then
-              echo "Production is serving."
+            # homepage_data is public, cheap and aggregates over the database, so
+            # it answers the question that matters: does the app actually work?
+            working() {
+              for _ in $(seq 1 "$1"); do
+                body=$(curl -sS --max-time 20 https://restarters.net/api/homepage_data || true)
+                case "$body" in *'"items_fixed"'*) return 0 ;; esac
+                sleep 10
+              done
+              return 1
+            }
+
+            if working 12; then
+              echo "Production is serving and talking to the database."
               [ "$(cat /tmp/deploy-result)" = failed ] && \
                 echo "NOTE: flyctl exited non-zero but the site is up - check the deploy log above."
               exit 0
+            fi
+
+            # Up, but not working: the machine is serving and a restart will not
+            # fix a bad config or an unreachable database.  Restarting here would
+            # just cycle a healthy-looking machine and hide the real fault.
+            if serving 3; then
+              echo "=============================================="
+              echo "Production is serving but NOT working - the app"
+              echo "answers robots.txt while /api/homepage_data does"
+              echo "not.  That is a config or database fault, which"
+              echo "a restart cannot fix.  Needs a human."
+              echo "=============================================="
+              flyctl status --app restarters || true
+              flyctl logs --app restarters --no-tail 2>&1 | tail -50 || true
+              exit 1
             fi
 
             echo "=============================================="
@@ -279,7 +309,8 @@ jobs:
             for id in $(flyctl machines list --app restarters --json | jq -r '.[].id'); do
               echo "Restarting machine $id"
               flyctl machine restart "$id" --app restarters || true
-              if serving 18; then
+              # Recovered means working, not merely answering robots.txt.
+              if working 18; then
                 echo "=============================================="
                 echo "RECOVERED after restarting $id."
                 echo "The deploy could not bring this machine up healthy on"
@@ -290,7 +321,7 @@ jobs:
               fi
             done
 
-            echo "Still not serving after restarting. Production needs a human."
+            echo "Still not working after restarting. Production needs a human."
             flyctl status --app restarters || true
             flyctl logs --app restarters --no-tail 2>&1 | tail -50 || true
             exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,75 @@ jobs:
           name: Deploy to restarters (production)
           command: |
             export FLY_API_TOKEN="FlyV1 $FLY_API_TOKEN"
-            flyctl deploy --app restarters --remote-only
+            # Deliberately not failing the job here.  A rolling deploy that
+            # times out waiting for health checks leaves the machine on the new
+            # image but out of the proxy pool, which with a single machine is a
+            # total outage - and that is precisely when we must not stop and
+            # walk away.  The verify step below decides whether the site is
+            # actually serving, and that is the thing we care about.
+            if flyctl deploy --app restarters --remote-only; then
+              echo ok > /tmp/deploy-result
+            else
+              echo failed > /tmp/deploy-result
+              echo "flyctl reported failure; the verify step will check whether production is serving."
+            fi
+          no_output_timeout: 15m
+      - run:
+          name: Verify production is serving, restarting once if not
+          command: |
+            export FLY_API_TOKEN="FlyV1 $FLY_API_TOKEN"
+
+            # Probe from outside Fly, on the same path the Fly health check
+            # uses.  robots.txt is static, so a 200 means nginx is up and the
+            # proxy has a healthy instance to route to - it does not depend on
+            # the database being reachable.
+            serving() {
+              for _ in $(seq 1 "$1"); do
+                code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 \
+                       https://restarters.net/robots.txt || echo 000)
+                [ "$code" = "200" ] && return 0
+                sleep 10
+              done
+              return 1
+            }
+
+            if serving 12; then
+              echo "Production is serving."
+              [ "$(cat /tmp/deploy-result)" = failed ] && \
+                echo "NOTE: flyctl exited non-zero but the site is up - check the deploy log above."
+              exit 0
+            fi
+
+            echo "=============================================="
+            echo "Production is NOT serving after the deploy."
+            echo "=============================================="
+            flyctl status --app restarters || true
+
+            # On 2026-09-02 a deploy timed out waiting for health checks and
+            # left the machine started but critical for 43 minutes; restarting
+            # that same image brought it straight back.  Try that once per
+            # machine before giving up, re-checking after each so we stop as
+            # soon as the site returns - and never loop, because a restart that
+            # does not help means something a restart cannot fix.
+            command -v jq >/dev/null 2>&1 || sudo apt-get install -y jq
+            for id in $(flyctl machines list --app restarters --json | jq -r '.[].id'); do
+              echo "Restarting machine $id"
+              flyctl machine restart "$id" --app restarters || true
+              if serving 18; then
+                echo "=============================================="
+                echo "RECOVERED after restarting $id."
+                echo "The deploy could not bring this machine up healthy on"
+                echo "its own - worth finding out why rather than relying on"
+                echo "this path."
+                echo "=============================================="
+                exit 0
+              fi
+            done
+
+            echo "Still not serving after restarting. Production needs a human."
+            flyctl status --app restarters || true
+            flyctl logs --app restarters --no-tail 2>&1 | tail -50 || true
+            exit 1
           no_output_timeout: 15m
 
 workflows:


### PR DESCRIPTION
## What happened today

`production` was pushed at **12:02:30**. `deploy-fly-prod` built the image and started a rolling update. The machine came up at **12:08:07** without passing its health check, and flyctl gave up:

```
Updating existing machines in 'restarters' with rolling strategy
Error: failed to update machine 7813112c002178: Unrecoverable error:
timeout reached waiting for health checks to pass for machine 7813112c002178
Exited with code exit status 1
```

The job exited 1 and stopped, leaving the machine `started` but out of the proxy pool. With `min_machines_running = 1` that is a total outage — every request got `no known healthy instances found for route tcp/443`. It stayed down **43 minutes**, until the machine was restarted by hand.

Restarting **that same image** brought it straight back. Nothing was wrong with the build. The deploy had everything it needed to recover and instead walked away.

## Change

Stop treating flyctl's exit code as the verdict, and ask the question that actually matters: *is the site serving?*

- Probe `https://restarters.net/robots.txt` from outside Fly — the same static path the Fly health check uses, so the answer doesn't depend on the database being reachable.
- If it isn't serving, restart each machine **once**, re-probing after each so we stop as soon as it recovers.
- Never loop. A restart that doesn't help means something a restart cannot fix, and that needs a person — so the job fails, dumps `flyctl status` and the last 50 log lines.
- A deploy that only passed because of the restart says so loudly. This path existing is not a reason to stop asking why a machine failed to come up healthy.

## Notes

- Verified: the YAML parses and both step scripts pass `bash -n`.
- `jq` isn't used anywhere else in this config, so its presence is no longer assumed — it's installed if missing.
- This is a mitigation, not a cure. The single machine is the reason an unhealthy instance means a full outage; a second machine would make a failed rolling update a non-event. Worth considering separately.
- Needs to reach the `production` branch to take effect, so it follows the usual develop → master → production route.