### PR TITLE
chore: remove unused component registrations and slot-scope variables

### DIFF
--- a/resources/js/components/ConfirmModal.vue
+++ b/resources/js/components/ConfirmModal.vue
@@ -11,7 +11,7 @@
         <span v-html="translatedPleaseConfirm" />
       </p>
     </template>
-    <template slot="modal-footer" slot-scope="{ ok, cancel }">
+    <template slot="modal-footer" slot-scope="{ cancel }">
       <!-- eslint-disable-next-line -->
       <b-button variant="white" @click="cancel" v-html="translatedCancel" />
       <!-- eslint-disable-next-line -->

--- a/resources/js/components/EventAddVolunteerModal.vue
+++ b/resources/js/components/EventAddVolunteerModal.vue
@@ -23,7 +23,7 @@
         <small class="after-offset">{{ translatedMessageVolunteerEmailAddress }}</small>
       </div>
     </template>
-    <template slot="modal-footer" slot-scope="{ ok, cancel }">
+    <template slot="modal-footer">
       <!-- eslint-disable-next-line -->
       <b-button variant="primary" @click="submit" v-html="translatedVolunteerAttended" :disabled="disabled" />
     </template>

--- a/resources/js/components/EventDescription.vue
+++ b/resources/js/components/EventDescription.vue
@@ -14,12 +14,11 @@
 <script>
 import map from '../mixins/map'
 import event from '../mixins/event'
-import ExternalLink from './ExternalLink.vue'
 import CollapsibleSection from './CollapsibleSection.vue'
 import ReadMore from './ReadMore.vue'
 
 export default {
-  components: {ReadMore, CollapsibleSection, ExternalLink},
+  components: {ReadMore, CollapsibleSection},
   mixins: [ map, event ],
   props: {
     idevents: {

--- a/resources/js/components/EventDevice.vue
+++ b/resources/js/components/EventDevice.vue
@@ -95,7 +95,6 @@ import DeviceRepairStatus from './DeviceRepairStatus.vue'
 import DeviceProblem from './DeviceProblem.vue'
 import DeviceNotes from './DeviceNotes.vue'
 import DeviceQuantity from './DeviceQuantity.vue'
-import FileUploader from './FileUploader.vue'
 import DeviceImages from './DeviceImages.vue'
 import ConfirmModal from './ConfirmModal.vue'
 
@@ -103,7 +102,6 @@ export default {
   components: {
     ConfirmModal,
     DeviceImages,
-    FileUploader,
     DeviceQuantity,
     DeviceNotes,
     DeviceProblem,

--- a/resources/js/components/EventDevices.vue
+++ b/resources/js/components/EventDevices.vue
@@ -127,14 +127,12 @@
 <script>
 import event from '../mixins/event'
 import images from '../mixins/images'
-import ExternalLink from './ExternalLink.vue'
 import CollapsibleSection from './CollapsibleSection.vue'
 import EventDeviceList from './EventDeviceList.vue'
-import EventDeviceSummary from './EventDeviceSummary.vue'
 import EventDevice from './EventDevice.vue'
 
 export default {
-  components: {EventDevice, EventDeviceSummary, EventDeviceList, CollapsibleSection, ExternalLink},
+  components: {EventDevice, EventDeviceList, CollapsibleSection},
   mixins: [ event, images ],
   props: {
     idevents: {

--- a/resources/js/components/EventTimeRangePicker.vue
+++ b/resources/js/components/EventTimeRangePicker.vue
@@ -21,9 +21,7 @@
   </div>
 </template>
 <script>
-import DashboardEvent from './DashboardEvent.vue'
 export default {
-  components: {DashboardEvent},
   props: {
     start: {
       required: false,

--- a/resources/js/components/FixometerRecordsTable.vue
+++ b/resources/js/components/FixometerRecordsTable.vue
@@ -93,7 +93,6 @@
 <script>
 import { END_OF_LIFE, FIXED, REPAIRABLE } from '../constants'
 import moment from 'moment'
-import DeviceModel from './DeviceModel.vue'
 import Vue from 'vue'
 import lineClamp from 'vue-line-clamp'
 import ConfirmModal from './ConfirmModal.vue'
@@ -109,7 +108,7 @@ const bootaxios = axios
 
 export default {
   mixins: [images],
-  components: {EventDevice, ConfirmModal, DeviceModel},
+  components: {EventDevice, ConfirmModal},
   props: {
     isAdmin: {
       type: Boolean,

--- a/resources/js/components/GroupDescription.vue
+++ b/resources/js/components/GroupDescription.vue
@@ -45,14 +45,13 @@
 import map from '../mixins/map'
 import group from '../mixins/group'
 import images from '../mixins/images'
-import ExternalLink from './ExternalLink.vue'
 import CollapsibleSection from './CollapsibleSection.vue'
 import ReadMore from './ReadMore.vue'
 import GroupArchivedBadge from "./GroupArchivedBadge.vue";
 import GroupTagsBadges from "./GroupTagsBadges.vue";
 
 export default {
-  components: {GroupArchivedBadge, GroupTagsBadges, ReadMore, CollapsibleSection, ExternalLink},
+  components: {GroupArchivedBadge, GroupTagsBadges, ReadMore, CollapsibleSection},
   mixins: [ map, group, images ],
   props: {
     idgroups: {

--- a/resources/js/components/GroupEventScrollTable.vue
+++ b/resources/js/components/GroupEventScrollTable.vue
@@ -156,7 +156,6 @@
 <script>
 import moment from 'moment'
 import images from '../mixins/images'
-import InfiniteLoading from 'vue-infinite-loading'
 import GroupEventsScrollTableDateShort from './GroupEventsScrollTableDateShort.vue'
 import GroupEventsScrollTableDateLong from './GroupEventsScrollTableDateLong.vue'
 import GroupEventsScrollTableNumber from './GroupEventsScrollTableNumber.vue'
@@ -173,7 +172,6 @@ export default {
     GroupEventsScrollTableNumber,
     GroupEventsScrollTableDateLong,
     GroupEventsScrollTableDateShort,
-    InfiniteLoading
   },
   props: {
     events: {

--- a/resources/js/components/GroupVolunteers.vue
+++ b/resources/js/components/GroupVolunteers.vue
@@ -31,10 +31,9 @@
 import group from '../mixins/group'
 import GroupVolunteer from './GroupVolunteer.vue'
 import CollapsibleSection from './CollapsibleSection.vue'
-import Group from '../mixins/group'
 
 export default {
-  components: {Group, CollapsibleSection, GroupVolunteer},
+  components: {CollapsibleSection, GroupVolunteer},
   mixins: [group],
   props: {
     idgroups: {

--- a/resources/js/components/StatsShareModal.vue
+++ b/resources/js/components/StatsShareModal.vue
@@ -18,7 +18,7 @@
       </div>
       <StatsShare :count="count" :target="target" ref="stats" :painting.sync="painting" size />
     </template>
-    <template slot="modal-footer" slot-scope="{ ok, cancel }">
+    <template slot="modal-footer" slot-scope="{ cancel }">
       <!-- eslint-disable-next-line -->
       <b-button variant="white" @click="cancel" v-html="translatedClose" />
       <!-- eslint-disable-next-line -->


### PR DESCRIPTION
Clearing the eslint no-unused-components and no-unused-vars errors in
resources/js/components:

- nine components imported and registered in `components:` but never used
  in their own template - ExternalLink (three files), FileUploader,
  EventDeviceSummary, DashboardEvent, DeviceModel, InfiniteLoading and
  Group
- three b-modal footer slots that destructured `{ ok, cancel }` and then
  never read `ok`

One of the nine is worth calling out separately: in `GroupVolunteers.vue`
the `group` mixin was imported a second time as `Group` and listed in
`components:`, so a mixin was registered as a component. The mixin is
already applied properly via `mixins: [group]` on the next line, so the
registration was doing nothing - but it is a mistake rather than just an
unused reference.

I checked each removed registration for both PascalCase and kebab-case use
in its own file before dropping it. No template markup changes.
