### PR TITLE
feat: optional reference field on devices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,13 @@ jobs:
           command: |
             mkdir -p /tmp/test-results/playwright-client
             docker cp restarters_playwright:/tmp/test-results/. /tmp/test-results/playwright-client/ || echo "No playwright results found"
+
+            # An API 500 shows up here only as "expected 200, received 500";
+            # without Laravel's log there is no way to tell what threw.
+            mkdir -p /tmp/test-results/laravel
+            docker cp restarters:/var/www/storage/logs/. /tmp/test-results/laravel/ 2>/dev/null || echo "No Laravel logs found"
+            echo "--- last Laravel errors ---"
+            grep -hE "production\.(ERROR|CRITICAL)" /tmp/test-results/laravel/*.log 2>/dev/null | tail -20 || true
           when: always
       - store_artifacts:
           path: /tmp/test-results

--- a/app/Device.php
+++ b/app/Device.php
@@ -67,7 +67,7 @@ class Device extends Model implements Auditable
      *
      * @var array
      */
-    protected $fillable = ['event', 'category', 'category_creation', 'estimate', 'repair_status', 'spare_parts', 'parts_provider', 'brand', 'item_type', 'model', 'age', 'problem', 'notes', 'repaired_by', 'do_it_yourself', 'professional_help', 'more_time_needed', 'wiki', 'fault_type'];
+    protected $fillable = ['event', 'category', 'category_creation', 'estimate', 'repair_status', 'spare_parts', 'parts_provider', 'brand', 'item_type', 'model', 'age', 'problem', 'notes', 'reference', 'repaired_by', 'do_it_yourself', 'professional_help', 'more_time_needed', 'wiki', 'fault_type'];
 
     /**
      * The attributes that should be hidden for arrays.

--- a/app/Http/Controllers/API/DeviceController.php
+++ b/app/Http/Controllers/API/DeviceController.php
@@ -130,6 +130,10 @@ class DeviceController extends Controller {
      *                     property="barrier",
      *                     ref="#/components/schemas/Device/properties/barrier",
      *                ),
+     *                @OA\Property(
+     *                     property="reference",
+     *                     ref="#/components/schemas/Device/properties/reference",
+     *                ),
      *             )
      *         )
      *    ),
@@ -188,7 +192,8 @@ class DeviceController extends Controller {
             $professional_help,
             $more_time_needed,
             $do_it_yourself,
-            $barrier
+            $barrier,
+            $reference
         ) = $this->validateDeviceParams($request,true);
 
         // We may have uploaded photos before creation, and we have a draft id which allows us to patch that
@@ -219,6 +224,7 @@ class DeviceController extends Controller {
             'professional_help' => $professional_help,
             'more_time_needed' => $more_time_needed,
             'do_it_yourself' => $do_it_yourself,
+            'reference' => $reference,
             'repaired_by' => $user->id,
         ];
 
@@ -342,6 +348,10 @@ class DeviceController extends Controller {
      *                     property="barrier",
      *                     ref="#/components/schemas/Device/properties/barrier",
      *                ),
+     *                @OA\Property(
+     *                     property="reference",
+     *                     ref="#/components/schemas/Device/properties/reference",
+     *                ),
      *             )
      *         )
      *    ),
@@ -400,7 +410,8 @@ class DeviceController extends Controller {
             $professional_help,
             $more_time_needed,
             $do_it_yourself,
-            $barrier
+            $barrier,
+            $reference
             ) = $this->validateDeviceParams($request,false);
 
         $event = Party::findOrFail($eventid);
@@ -426,6 +437,7 @@ class DeviceController extends Controller {
             'professional_help' => $professional_help,
             'more_time_needed' => $more_time_needed,
             'do_it_yourself' => $do_it_yourself,
+            'reference' => $reference,
             'repaired_by' => $user->id,
         ];
 
@@ -549,6 +561,7 @@ class DeviceController extends Controller {
             'age' => [ 'numeric', 'max:500' ],
             'estimate' => [ 'numeric', 'min:0' ],
             'problem' => [ 'string', 'nullable' ],
+            'reference' => [ 'string', 'nullable', 'max:255' ],
             'notes' => 'string',
             'repair_status' => [ 'string', 'in:Fixed,Repairable,End of life' ],
             'next_steps' => [ 'string', 'in:More time needed,Professional help,Do it yourself', 'nullable' ],
@@ -567,6 +580,7 @@ class DeviceController extends Controller {
         $estimate = $estimate ? $estimate : 0;
         $problem = $request->input('problem');
         $notes = $request->input('notes');
+        $reference = $request->input('reference');
         $repair_status = $request->input('repair_status');
         $barrierInput = $request->input('barrier');
 
@@ -662,7 +676,8 @@ class DeviceController extends Controller {
             $professional_help,
             $more_time_needed,
             $do_it_yourself,
-            $barrier
+            $barrier,
+            $reference
         ];
     }
 

--- a/app/Http/Resources/Device.php
+++ b/app/Http/Resources/Device.php
@@ -175,6 +175,14 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *           ref="#/components/schemas/Image"
  *         )
  *     ),
+ *     @OA\Property(
+ *         property="reference",
+ *         title="reference",
+ *         description="Your reference for this device.",
+ *         format="string",
+ *         maxLength=255,
+ *         example="REP1234"
+ *     ),
  * )
  */
 
@@ -206,6 +214,7 @@ class Device extends JsonResource
             'problem' => $this->problem,
             'short_problem' => $this->getShortProblem(),
             'notes' => $this->notes,
+            'reference' => $this->reference,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->created_at->toIso8601String(),
         ];

--- a/client/app/components/devices/DeviceForm.vue
+++ b/client/app/components/devices/DeviceForm.vue
@@ -121,6 +121,7 @@ const form = reactive({
   estimate: props.device?.estimate ? String(props.device.estimate) : '',
   problem: props.device?.problem || '',
   notes: props.device?.notes || '',
+  reference: props.device?.reference || '',
   repairStatus: props.device?.repair_status || '',
   nextSteps: props.device?.next_steps || '',
   spareParts: props.device?.spare_parts || '',
@@ -347,6 +348,7 @@ function buildPayload() {
     model: form.model,
     problem: form.problem,
     notes: form.notes,
+    reference: form.reference,
     repair_status: form.repairStatus,
     next_steps: showNextSteps.value ? form.nextSteps : '',
     spare_parts: showSpareParts.value ? form.spareParts : '',
@@ -591,6 +593,23 @@ defineExpose({ submit })
             :placeholder="t('devices.model_if_known')"
             :disabled="readonly"
             data-testid="device-form-model"
+          >
+        </BFormGroup>
+
+        <BFormGroup label-for="device-form-reference">
+          <template #label>
+            {{ t('devices.reference') }}:
+            <FieldInfoPopover :content="t('devices.tooltip_reference')" :variant="infoIconVariant" />
+          </template>
+          <input
+            id="device-form-reference"
+            v-model="form.reference"
+            type="text"
+            maxlength="255"
+            autocomplete="off"
+            class="form-control"
+            :disabled="readonly"
+            data-testid="device-form-reference"
           >
         </BFormGroup>
 

--- a/client/app/components/devices/DeviceRow.vue
+++ b/client/app/components/devices/DeviceRow.vue
@@ -83,7 +83,12 @@ async function confirmDelete() {
 
 <template>
   <tr v-if="!editing" :data-testid="`event-device-${device.id}`">
-    <td>{{ device.item_type || '-' }}</td>
+    <td class="device-reference-cell">
+      <span v-if="device.reference" class="device-reference text-muted d-block" :data-testid="`event-device-reference-${device.id}`">
+        {{ device.reference }}
+      </span>
+      {{ device.item_type || '-' }}
+    </td>
     <td>{{ device.category ? t(device.category.name) : '-' }}</td>
     <!-- Gap fix (MEDIUM): legacy hides Brand/Age/Assessment/Status/Spare-parts
          below md (EventDeviceList.vue's `d-none d-md-table-cell` fields). -->
@@ -176,5 +181,13 @@ async function confirmDelete() {
   font-size: small;
   line-height: 2;
   text-transform: uppercase;
+}
+
+.device-reference-cell {
+  line-height: normal;
+}
+
+.device-reference {
+  font-size: 60%;
 }
 </style>

--- a/client/app/components/events/EventDevicesReadOnly.vue
+++ b/client/app/components/events/EventDevicesReadOnly.vue
@@ -114,7 +114,12 @@ function round(n) {
               :key="device.id"
               :data-testid="`event-device-${device.id}`"
             >
-              <td>{{ device.item_type || '-' }}</td>
+              <td class="device-reference-cell">
+                <span v-if="device.reference" class="device-reference text-muted d-block" :data-testid="`event-device-reference-${device.id}`">
+                  {{ device.reference }}
+                </span>
+                {{ device.item_type || '-' }}
+              </td>
               <td>{{ device.category ? t(device.category.name) : '-' }}</td>
               <td v-if="activeTab === 'powered'">{{ device.brand }}</td>
               <td>{{ parseFloat(device.age) ? device.age : '-' }}</td>
@@ -139,3 +144,13 @@ function round(n) {
     </template>
   </div>
 </template>
+
+<style scoped>
+.device-reference-cell {
+  line-height: normal;
+}
+
+.device-reference {
+  font-size: 60%;
+}
+</style>

--- a/client/i18n/locales/en.json
+++ b/client/i18n/locales/en.json
@@ -646,7 +646,9 @@
         "repair_outcome": "Repair outcome?",
         "add_data_group": "Please select a group",
         "add_data_event": "Please select an event",
-        "add_data_action_button": "Go to event"
+        "add_data_action_button": "Go to event",
+        "reference": "Reference",
+        "tooltip_reference": "You can optionally record your own reference ID for this item, to cross-reference it to other software tools you are using."
     },
     "discourse": {
         "number_of_comments": "Number of comments",

--- a/client/i18n/locales/fr-BE.json
+++ b/client/i18n/locales/fr-BE.json
@@ -663,7 +663,9 @@
         "repair_outcome": "Résultat de la réparation?",
         "add_data_group": "Veuillez sélectionner un Repair Café",
         "add_data_event": "Veuillez sélectionner un événement",
-        "add_data_action_button": "Participer à l'événément"
+        "add_data_action_button": "Participer à l'événément",
+        "reference": "Référence",
+        "tooltip_reference": "Vous pouvez éventuellement enregistrer votre propre identifiant de référence pour cet élément, afin de le recouper avec d'autres outils logiciels que vous utilisez."
     },
     "discourse": {
         "number_of_comments": "Nombre de commentaires",

--- a/client/i18n/locales/fr.json
+++ b/client/i18n/locales/fr.json
@@ -412,7 +412,9 @@
         "repair_outcome": "Résultat de la réparation?",
         "add_data_group": "Veuillez sélectionner un Repair Café",
         "add_data_event": "Veuillez sélectionner un événement",
-        "add_data_action_button": "Participer à l'événément"
+        "add_data_action_button": "Participer à l'événément",
+        "reference": "Référence",
+        "tooltip_reference": "Vous pouvez éventuellement enregistrer votre propre identifiant de référence pour cet élément, afin de le recouper avec d'autres outils logiciels que vous utilisez."
     },
     "discourse": {
         "number_of_comments": "Nombre de commentaires",

--- a/client/tests/components/devices/DeviceForm.spec.js
+++ b/client/tests/components/devices/DeviceForm.spec.js
@@ -119,10 +119,10 @@ describe('components/devices/DeviceForm', () => {
   // each carry an info popover; ours had none. Asserting the count rather
   // than mere presence, because four of the five rendering and one silently
   // missing would still look fine on screen.
-  it('shows an info popover on each of the five documented fields', () => {
+  it('shows an info popover on each of the six documented fields', () => {
     const wrapper = mountForm()
 
-    expect(wrapper.findAll('[data-testid="field-info-toggle"]')).toHaveLength(5)
+    expect(wrapper.findAll('[data-testid="field-info-toggle"]')).toHaveLength(6)
   })
 
   // The item-type help text differs by powered-ness: the examples are
@@ -191,6 +191,42 @@ describe('components/devices/DeviceForm', () => {
       // pre-existing validation ('brand' => 'string' etc., no nullable)
       // 422s on null values - the shape the legacy client always sent.
     })
+  })
+
+  // PR #775 (device reference). Groups cross-reference items to their own
+  // repair-tracking software, so the field has to survive a round trip: it is
+  // free text, optional, and capped at 255 to match the column.
+  it('offers an optional reference field with its tooltip', () => {
+    const wrapper = mountForm()
+    const input = wrapper.find('[data-testid="device-form-reference"]')
+
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('maxlength')).toBe('255')
+    expect(wrapper.findAllComponents({ name: 'FieldInfoPopover' }).map(c => c.props('content')))
+      .toContain(en.devices.tooltip_reference)
+  })
+
+  it('sends the reference when one is given', async () => {
+    store.addDevice = vi.fn().mockResolvedValue({ device: { id: 42 } })
+    const wrapper = mountForm()
+
+    await chooseOption(wrapper, 'device-form-category', '10')
+    await wrapper.find('[data-testid="device-form-reference"]').setValue('REP1234')
+    await wrapper.find('[data-testid="device-form"]').trigger('submit')
+    await wrapper.vm.$nextTick()
+
+    expect(store.addDevice).toHaveBeenCalledWith(5, expect.objectContaining({ reference: 'REP1234' }))
+  })
+
+  it('omits the reference when it is left blank', async () => {
+    store.addDevice = vi.fn().mockResolvedValue({ device: { id: 42 } })
+    const wrapper = mountForm()
+
+    await chooseOption(wrapper, 'device-form-category', '10')
+    await wrapper.find('[data-testid="device-form"]').trigger('submit')
+    await wrapper.vm.$nextTick()
+
+    expect(Object.keys(store.addDevice.mock.calls[0][1])).not.toContain('reference')
   })
 
   it('loops addDevice once per unit of quantity', async () => {
@@ -331,6 +367,12 @@ describe('components/devices/DeviceForm', () => {
       expect(wrapper.find('[data-testid="device-form-category"]').attributes('data-value')).toBe('10')
       expect(wrapper.find('[data-testid="device-form-brand"]').element.value).toBe('Acme')
       expect(wrapper.find('[data-testid="device-form-model"]').element.value).toBe('K1')
+    })
+
+    it('prefills the reference from the device prop', () => {
+      const wrapper = mountForm({ device: editDevice({ reference: 'REP1234' }) })
+
+      expect(wrapper.find('[data-testid="device-form-reference"]').element.value).toBe('REP1234')
     })
 
     it('shows DevicePhotos with the device id and existing images', () => {

--- a/client/tests/components/devices/DeviceRow.spec.js
+++ b/client/tests/components/devices/DeviceRow.spec.js
@@ -67,6 +67,20 @@ describe('components/devices/DeviceRow', () => {
     expect(wrapper.find('[data-testid="event-device-status-1"]').text()).toBe('Fixed')
   })
 
+  // PR #775: groups cross-reference items to their own repair-tracking
+  // software, so the reference has to be readable without opening the row.
+  it('shows the reference above the item type when one is set', () => {
+    const wrapper = mountRow({ device: device({ reference: 'REP1234' }) })
+
+    expect(wrapper.find('[data-testid="event-device-reference-1"]').text()).toBe('REP1234')
+  })
+
+  it('shows nothing where the reference would be when it is unset', () => {
+    const wrapper = mountRow()
+
+    expect(wrapper.find('[data-testid="event-device-reference-1"]').exists()).toBe(false)
+  })
+
   it('hides the brand column when unpowered', () => {
     const wrapper = mountRow({ powered: false })
     expect(wrapper.find('[data-testid="event-device-1"]').text()).not.toContain('Acme')

--- a/client/tests/components/events/EventDevicesReadOnly.spec.js
+++ b/client/tests/components/events/EventDevicesReadOnly.spec.js
@@ -57,6 +57,14 @@ describe('components/events/EventDevicesReadOnly', () => {
     expect(wrapper.find('[data-testid="event-device-1"]').exists()).toBe(false)
   })
 
+  // PR #775: the read-only table is the same listing as DeviceRow.vue's, so
+  // the reference has to be visible here too rather than only when editing.
+  it('shows a device reference when one is set', () => {
+    const wrapper = mountComponent({ devices: [device({ id: 1, reference: 'REP1234' })] })
+
+    expect(wrapper.find('[data-testid="event-device-reference-1"]').text()).toBe('REP1234')
+  })
+
   it('shows the empty state when a tab has no devices', () => {
     const wrapper = mountComponent({ devices: [] })
     expect(wrapper.find('[data-testid="event-devices-empty"]').exists()).toBe(true)

--- a/database/migrations/2026_09_08_000000_add_reference_to_devices_table.php
+++ b/database/migrations/2026_09_08_000000_add_reference_to_devices_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddReferenceToDevicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->string('reference')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('reference');
+        });
+    }
+}

--- a/lang/en/devices.php
+++ b/lang/en/devices.php
@@ -75,4 +75,6 @@ return [
   'add_data_group' => 'Please select a group',
   'add_data_event' => 'Please select an event',
   'add_data_action_button' => 'Go to event',
+  'reference' => 'Reference',
+  'tooltip_reference' => 'You can optionally record your own reference ID for this item, to cross-reference it to other software tools you are using.',
 ];

--- a/lang/fr-BE/devices.php
+++ b/lang/fr-BE/devices.php
@@ -74,4 +74,6 @@ return [
   'add_data_group' => 'Veuillez sélectionner un Repair Café',
   'add_data_event' => 'Veuillez sélectionner un événement',
   'add_data_action_button' => 'Participer à l\'événément',
+  'reference' => 'Référence',
+  'tooltip_reference' => 'Vous pouvez éventuellement enregistrer votre propre identifiant de référence pour cet élément, afin de le recouper avec d\'autres outils logiciels que vous utilisez.',
 ];

--- a/lang/fr/devices.php
+++ b/lang/fr/devices.php
@@ -74,4 +74,6 @@ return [
   'add_data_group' => 'Veuillez sélectionner un Repair Café',
   'add_data_event' => 'Veuillez sélectionner un événement',
   'add_data_action_button' => 'Participer à l\'événément',
+  'reference' => 'Référence',
+  'tooltip_reference' => 'Vous pouvez éventuellement enregistrer votre propre identifiant de référence pour cet élément, afin de le recouper avec d\'autres outils logiciels que vous utilisez.',
 ];

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -6,3 +6,16 @@ general_log_file = /var/lib/mysql/general.log
 # Disable ONLY_FULL_GROUP_BY for compatibility with getItemTypes() query
 # This query uses window functions in a way that's incompatible with strict GROUP BY mode
 sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+# The schema has triggers (repair_status_str_up and friends), and with binary
+# logging on MySQL refuses to create them without SUPER: "ERROR 1419 ... you
+# might want to use the less safe log_bin_trust_function_creators variable".
+#
+# docker_run.sh runs migrate:fresh --seed as the container starts, so setting
+# this afterwards - as CI's "Setup application" step does - is too late: the
+# trigger migration has already failed, and because migrate stops there every
+# LATER migration is silently skipped. That leaves a half-migrated database
+# that mostly works, until something actually needs one of the skipped
+# columns, and then it looks like an unrelated 500.
+#
+# Setting it here applies from server start, before anything migrates.
+log_bin_trust_function_creators = 1

--- a/tests/Feature/Devices/APIv2DeviceTest.php
+++ b/tests/Feature/Devices/APIv2DeviceTest.php
@@ -164,6 +164,7 @@ class APIv2DeviceTest extends TestCase
             'category' => 11,
             'problem' => 'Test problem',
             'notes' => 'Test notes',
+            'reference' => 'REP1234',
             'brand' => 'Test brand',
             'model' => 'Test model',
             'age' => 1.5,
@@ -203,6 +204,7 @@ class APIv2DeviceTest extends TestCase
         $this->assertEquals(100.00, $json['data']['estimate']);
         $this->assertEquals('Test problem', $json['data']['problem']);
         $this->assertEquals('Test notes', $json['data']['notes']);
+        $this->assertEquals('REP1234', $json['data']['reference']);
         $this->assertEquals($repair_status_str, $json['data']['repair_status']);
 
         if ($parts_provider_str) {

--- a/tests/Feature/Devices/CategoryTest.php
+++ b/tests/Feature/Devices/CategoryTest.php
@@ -41,6 +41,7 @@ class CategoryTest extends TestCase
             'estimate' => 100.00,
             'item_type' => 'Test item type',
             'repair_status' => 'Fixed',
+            'reference' => 'REP12456',
         ]);
 
         $rsp->assertSuccessful();
@@ -48,6 +49,7 @@ class CategoryTest extends TestCase
         $device = Device::findOrFail($iddevices);
         self::assertEquals($device->category_creation, 11);
         self::assertEquals($device->category, 46);
+        self::assertEquals($device->reference, 'REP12456');
     }
 
     public function testListItems(): void {


### PR DESCRIPTION
Reimplements #775 on the Nuxt client, so the work isn't lost when the SPA lands.

Groups that run their own repair-tracking software need to tie an item on Restarters back to their own record. This adds an optional free-text `reference` (max 255) to a device.

**API** — as in #775: migration, `$fillable`, validation in `validateDeviceParams`, the `Device` resource, the OpenAPI schema, and both the create and update paths.

**Client** — new work, since #775 predates the SPA:
- `DeviceForm.vue` — the field sits with brand/model, because it identifies the item rather than describing its repair. Tooltip from `devices.tooltip_reference`.
- `DeviceRow.vue` — shown small and muted above the item type, matching what #775 did in `EventDeviceSummary.vue`, so it's readable without opening the row and without spending a table column.

**Translations** — `reference`/`tooltip_reference` in en, fr and fr-BE (fr strings taken from #775), with `client/i18n/locales/*.json` regenerated by `translations:export-client`.

**Tests** — written first: 5 client specs (field present with tooltip, sent when filled, omitted when blank, prefilled when editing, displayed in the row) and the #775 backend assertions for the create and update round trip. Client 88/88 pass; the two device feature tests pass with 23 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)