### PR TITLE
fix: let MySQL create the schema's triggers in CI

### DIFF
--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -6,3 +6,16 @@ general_log_file = /var/lib/mysql/general.log
 # Disable ONLY_FULL_GROUP_BY for compatibility with getItemTypes() query
 # This query uses window functions in a way that's incompatible with strict GROUP BY mode
 sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+# The schema has triggers (repair_status_str_up and friends), and with binary
+# logging on MySQL refuses to create them without SUPER: "ERROR 1419 ... you
+# might want to use the less safe log_bin_trust_function_creators variable".
+#
+# docker_run.sh runs migrate:fresh --seed as the container starts, so setting
+# this afterwards - as CI's "Setup application" step does - is too late: the
+# trigger migration has already failed, and because migrate stops there every
+# LATER migration is silently skipped. That leaves a half-migrated database
+# that mostly works, until something actually needs one of the skipped
+# columns, and then it looks like an unrelated 500.
+#
+# Setting it here applies from server start, before anything migrates.
+log_bin_trust_function_creators = 1


### PR DESCRIPTION
## What's wrong

`docker_run.sh` runs `migrate:fresh --seed` as the app container starts. CI sets `log_bin_trust_function_creators = 1` afterwards, in "Setup application" — by which point `recreate_repair_status_triggers` has already failed:

```
SQLSTATE[HY000]: General error: 1419 You do not have the SUPER privilege and binary
logging is enabled (SQL: CREATE TRIGGER `repair_status_str_up` ...)
```

`migrate` stops at the first failure, so **every migration after that one is silently skipped**.

On `develop` today the trigger migration happens to be the last one, so nothing is skipped and the only consequence is that **CI has been running without the repair_status triggers**. It's the next migration added after it that gets silently dropped — which is exactly how this surfaced, on the Nuxt branch, as an unexplained 500 from a column that should have existed.

## The fix

Set it in the mounted `mysql/my.cnf`, so it applies from server start rather than after the app has already migrated. Verified with `mysqld --validate-config`. This also fixes local reseeds, which need the same `SET GLOBAL` by hand today.

## Worth watching on this PR

Creating the triggers restores behaviour CI hasn't had, so if any test has been passing *because* the triggers were missing, it'll fail here. That would be worth knowing either way — a green run means the triggers were simply absent for no benefit.

The now-redundant `SET GLOBAL` in "Setup application" is left alone; it's harmless and still covers anyone running an older database container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)